### PR TITLE
Issue-33_bug fix: Update storage-quota

### DIFF
--- a/app/[locale]/(routes)/components/dasboard/storage-quota.tsx
+++ b/app/[locale]/(routes)/components/dasboard/storage-quota.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Flex, ProgressBar, Text } from "@tremor/react";
 import { Database, Server } from "lucide-react";


### PR DESCRIPTION
In issue 33, there used to be createContext can only be used in client component error. Now it's fixed.