### PR TITLE
fix: remove db push from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && pnpm prisma db push && next build",
+    "build":  "prisma generate && next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "migrate:mongo-to-postgres": "pnpm exec tsx scripts/migrate-mongo-to-postgres.ts",


### PR DESCRIPTION
## What changed
- Removed `pnpm prisma db push` from build script (caused database connection errors)
- Build now only runs `prisma generate` and `next build`
- DigitalOcean environment variables added to .env.local with placeholder values

## How I tested
- ✅ `pnpm build` - successful (see screenshot)
- ✅ All routes compiled properly
- ✅ TypeScript checks passed

## Remaining issues
- DigitalOcean variables need real values in production