### PR TITLE
feat: Docker self-hosting setup with full automation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+.next
+.git
+.gitignore
+.env
+.env.local
+.env*.local
+*.md
+.vscode
+.idea
+tests
+e2e
+playwright-report
+test-results
+docs
+.playwright

--- a/.env.docker
+++ b/.env.docker
@@ -30,6 +30,22 @@
 # instead of a .env file. Same effect.
 # =============================================================
 
+# =============================================================
+# REQUIRED: Initial admin account
+# =============================================================
+# This email becomes the admin user created by the seed script
+# on first start. The app uses passwordless Email OTP to log in,
+# so you MUST set this to a real email you control AND configure
+# an email provider (RESEND_API_KEY below) so OTP codes can be
+# delivered. Without an email provider, you can still read the
+# OTP from the database directly while testing.
+#
+# Only used on first run (when no users exist in the database).
+# Changing it later has no effect — create new admins from the
+# Admin panel instead.
+# =============================================================
+ADMIN_EMAIL=you@example.com
+
 # --- Database (default: bundled Postgres) ---
 # Override to use an external database:
 # DATABASE_URL=postgresql://user:pass@your-host:5432/nextcrm
@@ -56,7 +72,10 @@
 # --- OpenAI (optional, for AI features) ---
 # OPENAI_API_KEY=sk-...
 
-# --- Email Sending via Resend (optional) ---
+# --- Email Sending via Resend (recommended) ---
+# Required so the admin (ADMIN_EMAIL above) can actually receive
+# the login OTP. Without this, OTP codes go nowhere and you'll
+# need to read them from the database manually.
 # RESEND_API_KEY=re_...
 # RESEND_FROM_EMAIL=noreply@yourdomain.com
 

--- a/.env.docker
+++ b/.env.docker
@@ -1,15 +1,34 @@
-# ===========================================
+# =============================================================
 # NextCRM Docker Environment Configuration
-# ===========================================
-# Copy this file to .env to customize your deployment.
-# docker-compose.yml already sets sensible defaults for all
-# internal services. Only set values here if you need to override.
+# =============================================================
 #
-# Usage:
-#   cp .env.docker .env
-#   # Edit .env with your values
-#   docker-compose up
-# ===========================================
+# HOW TO USE THIS FILE
+# --------------------
+# 1. Copy it:        cp .env.docker .env
+# 2. Edit it:        uncomment lines below and add your values
+# 3. Start the app:  docker compose up -d
+#
+# Docker Compose automatically reads .env from this directory
+# and injects the values into the app container. You do NOT
+# need to edit Dockerfile or docker-compose.yml.
+#
+# WHAT YOU CAN SAFELY IGNORE
+# --------------------------
+# Internal services (Postgres, MinIO, Inngest) already have
+# working defaults baked into docker-compose.yml. You only need
+# to set values below if you want to:
+#   - Enable an optional integration (OpenAI, Google OAuth, etc.)
+#   - Override the bundled database/storage with your own
+#
+# The app runs fine with NO .env file at all. Optional features
+# stay disabled until you provide real keys.
+#
+# SECURITY
+# --------
+# .env is in .gitignore — your secrets stay local.
+# Coolify/Portainer users: set these via the platform UI
+# instead of a .env file. Same effect.
+# =============================================================
 
 # --- Database (default: bundled Postgres) ---
 # Override to use an external database:

--- a/.env.docker
+++ b/.env.docker
@@ -46,8 +46,31 @@
 # =============================================================
 ADMIN_EMAIL=you@example.com
 
+# =============================================================
+# REQUIRED FOR PRODUCTION: Internal service credentials
+# =============================================================
+# The bundled Postgres and MinIO containers default to the
+# placeholder password "changeme". This is fine for local
+# experimentation since the services are NOT exposed to the
+# host network — only the app on port 3000 is reachable from
+# outside the Docker network.
+#
+# But you should still set strong values before running this
+# anywhere accessible (Coolify, VPS, production server). The
+# same env var is used by both the service and the app, so a
+# single override changes both sides.
+# =============================================================
+POSTGRES_USER=nextcrm
+POSTGRES_PASSWORD=changeme
+POSTGRES_DB=nextcrm
+
+MINIO_ROOT_USER=nextcrm
+MINIO_ROOT_PASSWORD=changeme
+
 # --- Database (default: bundled Postgres) ---
-# Override to use an external database:
+# Override only if you want to point at an EXTERNAL database
+# instead of the bundled one. Otherwise, set POSTGRES_USER /
+# POSTGRES_PASSWORD / POSTGRES_DB above and the app picks them up.
 # DATABASE_URL=postgresql://user:pass@your-host:5432/nextcrm
 
 # --- Auth ---
@@ -57,7 +80,8 @@ ADMIN_EMAIL=you@example.com
 # BETTER_AUTH_URL=http://localhost:3000
 
 # --- MinIO Object Storage (default: bundled MinIO) ---
-# Override to use external S3-compatible storage:
+# Override only to use an EXTERNAL S3-compatible store. For the
+# bundled MinIO, set MINIO_ROOT_USER / MINIO_ROOT_PASSWORD above.
 # MINIO_ENDPOINT=https://your-s3-host
 # MINIO_PORT=443
 # MINIO_BUCKET=your-bucket

--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,62 @@
+# ===========================================
+# NextCRM Docker Environment Configuration
+# ===========================================
+# Copy this file to .env to customize your deployment.
+# docker-compose.yml already sets sensible defaults for all
+# internal services. Only set values here if you need to override.
+#
+# Usage:
+#   cp .env.docker .env
+#   # Edit .env with your values
+#   docker-compose up
+# ===========================================
+
+# --- Database (default: bundled Postgres) ---
+# Override to use an external database:
+# DATABASE_URL=postgresql://user:pass@your-host:5432/nextcrm
+
+# --- Auth ---
+# Auto-generated on first start if not set.
+# Set explicitly for stable sessions across container restarts:
+# BETTER_AUTH_SECRET=your-secret-here
+# BETTER_AUTH_URL=http://localhost:3000
+
+# --- MinIO Object Storage (default: bundled MinIO) ---
+# Override to use external S3-compatible storage:
+# MINIO_ENDPOINT=https://your-s3-host
+# MINIO_PORT=443
+# MINIO_BUCKET=your-bucket
+# MINIO_USE_SSL=true
+# MINIO_ACCESS_KEY=your-key
+# MINIO_SECRET_KEY=your-secret
+
+# --- Google OAuth (optional) ---
+# GOOGLE_ID=your-google-client-id
+# GOOGLE_SECRET=your-google-client-secret
+
+# --- OpenAI (optional, for AI features) ---
+# OPENAI_API_KEY=sk-...
+
+# --- Email Sending via Resend (optional) ---
+# RESEND_API_KEY=re_...
+# RESEND_FROM_EMAIL=noreply@yourdomain.com
+
+# --- SMTP / IMAP (optional, for email client) ---
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=your-user
+# SMTP_PASSWORD=your-password
+# IMAP_HOST=imap.example.com
+# IMAP_PORT=993
+# IMAP_USER=your-user
+# IMAP_PASSWORD=your-password
+
+# --- Firecrawl (optional, for contact enrichment) ---
+# FIRECRAWL_API_KEY=fc-...
+
+# --- E2B (optional, for agent enrichment) ---
+# E2B_API_KEY=e2b_...
+
+# --- Rossum (optional, for invoice parsing) ---
+# ROSSUM_USERNAME=your-user
+# ROSSUM_PASSWORD=your-password

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,28 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# Dummy env vars for build-time validation. Next.js collects page data
+# during build, which imports modules that check env vars at load time.
+# Real values are injected at runtime via docker-compose.
+ENV DATABASE_URL="postgresql://placeholder:placeholder@placeholder:5432/placeholder"
+ENV INNGEST_ID="nextcrm-build"
+ENV INNGEST_APP_NAME="NextCRM-Build"
+ENV INNGEST_EVENT_KEY="build-placeholder"
+ENV INNGEST_SIGNING_KEY="build-placeholder"
+ENV BETTER_AUTH_SECRET="build-time-placeholder-secret-replace-at-runtime"
+ENV BETTER_AUTH_URL="http://localhost:3000"
+ENV MINIO_ENDPOINT="http://placeholder:9000"
+ENV MINIO_PORT="9000"
+ENV MINIO_BUCKET="placeholder"
+ENV MINIO_USE_SSL="false"
+ENV MINIO_ACCESS_KEY="placeholder"
+ENV MINIO_SECRET_KEY="placeholder"
+ENV NEXT_PUBLIC_MINIO_ENDPOINT="http://placeholder:9000"
+ENV EMAIL_ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000"
+ENV OPENAI_API_KEY="sk-placeholder-for-build"
+ENV RESEND_API_KEY="re_placeholder_for_build"
+ENV SKIP_ENV_VALIDATION=1
+
 RUN pnpm prisma generate
 RUN pnpm next build
 
@@ -33,6 +55,21 @@ FROM node:22-alpine AS runner
 
 RUN apk add --no-cache curl postgresql-client
 
+# Install Prisma CLI + tsx + dotenv into a SEPARATE /opt/tools directory.
+# This avoids conflicts with Next.js standalone node_modules (which has
+# a pnpm-symlinked structure that npm install chokes on). We'll expose
+# these via PATH and NODE_PATH so prisma.config.ts can resolve `prisma/config`.
+WORKDIR /opt/tools
+RUN printf '{"name":"nextcrm-tools","version":"0.0.0","private":true}\n' > package.json && \
+    npm install --no-audit --no-fund \
+      prisma@7.6.0 \
+      @prisma/client@7.6.0 \
+      @prisma/adapter-pg@7.6.0 \
+      pg@8.18.0 \
+      tsx@4.21.0 \
+      dotenv@17.3.1 \
+      typescript@5.9.3
+
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -42,33 +79,46 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
-# Copy standalone build output
+# Copy standalone build output (includes its own minimal node_modules
+# with @prisma/client the app needs at runtime)
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static
 COPY --from=build /app/public ./public
 
-# Copy Prisma files for runtime migrations and seeding
+# Copy Prisma schema + migrations for runtime migrate deploy
 COPY --from=build /app/prisma ./prisma
-COPY --from=build /app/node_modules/.pnpm/@prisma+client*/node_modules/.prisma ./node_modules/.prisma
-COPY --from=build /app/node_modules/.pnpm/@prisma+engines*/node_modules/@prisma/engines ./node_modules/@prisma/engines
-COPY --from=build /app/node_modules/.pnpm/prisma*/node_modules/prisma ./node_modules/prisma
-COPY --from=build /app/node_modules/.pnpm/@prisma+client*/node_modules/@prisma/client ./node_modules/@prisma/client
 
-# Copy seed dependencies (ts-node, tsx, typescript for seed script)
-COPY --from=build /app/node_modules/.pnpm/ts-node*/node_modules/ts-node ./node_modules/ts-node
-COPY --from=build /app/node_modules/.pnpm/tsx*/node_modules/tsx ./node_modules/tsx
-COPY --from=build /app/node_modules/.pnpm/typescript*/node_modules/typescript ./node_modules/typescript
-COPY --from=build /app/package.json ./package.json
+# Write a Docker-specific prisma.config.ts that does not import dotenv
+# (env vars are injected by docker-compose, not loaded from .env files).
+RUN printf '%s\n' \
+    'import { defineConfig, env } from "prisma/config";' \
+    '' \
+    'export default defineConfig({' \
+    '  datasource: {' \
+    '    url: env("DATABASE_URL"),' \
+    '  },' \
+    '  migrations: {' \
+    '    seed: "tsx prisma/seeds/seed.ts",' \
+    '  },' \
+    '});' \
+    > /app/prisma.config.ts
 
-# Make npx find prisma
-ENV PATH="/app/node_modules/.bin:$PATH"
+# Merge /opt/tools packages into /app/node_modules so ESM import
+# resolution (used by tsx for the seed script) can find them.
+# ESM ignores NODE_PATH, so packages like @prisma/adapter-pg must exist
+# as real directories under /app/node_modules. The `-n` flag prevents
+# overwriting existing symlinks/dirs from the pnpm-structured standalone.
+RUN mkdir -p /app/node_modules/@prisma && \
+    cp -rn /opt/tools/node_modules/@prisma/adapter-pg /app/node_modules/@prisma/ 2>/dev/null || true && \
+    cp -rn /opt/tools/node_modules/pg-cloudflare /app/node_modules/ 2>/dev/null || true
 
 # Copy entrypoint
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x docker-entrypoint.sh
 
-# Set ownership
-RUN chown -R nextjs:nodejs /app
+# Set ownership for /app (standalone output + prisma)
+# and /opt/tools so the non-root nextjs user can use them.
+RUN chown -R nextjs:nodejs /app /opt/tools
 
 USER nextjs
 
@@ -76,5 +126,9 @@ EXPOSE 3000
 
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
+# Make prisma/tsx CLIs discoverable AND make prisma.config.ts able to
+# `import "prisma/config"` via Node's module resolution (NODE_PATH).
+ENV PATH="/opt/tools/node_modules/.bin:$PATH"
+ENV NODE_PATH="/opt/tools/node_modules"
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,80 @@
+# ============================================
+# Stage 1: Install dependencies
+# ============================================
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+
+RUN pnpm install --frozen-lockfile
+
+# ============================================
+# Stage 2: Build the application
+# ============================================
+FROM node:22-alpine AS build
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN pnpm prisma generate
+RUN pnpm next build
+
+# ============================================
+# Stage 3: Production runner
+# ============================================
+FROM node:22-alpine AS runner
+
+RUN apk add --no-cache curl postgresql-client
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy standalone build output
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+
+# Copy Prisma files for runtime migrations and seeding
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/node_modules/.pnpm/@prisma+client*/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/.pnpm/@prisma+engines*/node_modules/@prisma/engines ./node_modules/@prisma/engines
+COPY --from=build /app/node_modules/.pnpm/prisma*/node_modules/prisma ./node_modules/prisma
+COPY --from=build /app/node_modules/.pnpm/@prisma+client*/node_modules/@prisma/client ./node_modules/@prisma/client
+
+# Copy seed dependencies (ts-node, tsx, typescript for seed script)
+COPY --from=build /app/node_modules/.pnpm/ts-node*/node_modules/ts-node ./node_modules/ts-node
+COPY --from=build /app/node_modules/.pnpm/tsx*/node_modules/tsx ./node_modules/tsx
+COPY --from=build /app/node_modules/.pnpm/typescript*/node_modules/typescript ./node_modules/typescript
+COPY --from=build /app/package.json ./package.json
+
+# Make npx find prisma
+ENV PATH="/app/node_modules/.bin:$PATH"
+
+# Copy entrypoint
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+# Set ownership
+RUN chown -R nextjs:nodejs /app
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -308,35 +308,91 @@ Available soon at: http://docs.nextcrm.io
 
 </details>
 
-## Docker installation
+## Docker Installation (Recommended for Self-Hosting)
 
-[Link to Docker HUB](https://hub.docker.com/repository/docker/nextcrmio/nextcrm/general)
+The fastest way to run NextCRM is with Docker Compose. The provided `docker-compose.yml` bundles everything you need: the app, PostgreSQL (with pgvector), MinIO for file storage, and Inngest for background jobs. No manual setup of databases, buckets, or migrations — it all happens automatically on first start.
 
-<details>
-<summary><b>Show instructions</b></summary>
+### Quick Start
 
-1. Make sure you have docker and docker-compose installed
+```sh
+git clone https://github.com/pdovhomilja/nextcrm-app.git
+cd nextcrm-app
+docker compose up -d
+```
 
-2. Prepare .env and .env.local files
+That's it. Open [http://localhost:3000](http://localhost:3000) — the app is ready, the schema is migrated, and a default admin user (`test@nextcrm.app`) has been seeded.
 
-   ```create
-   .env (for Prisma URI string) and .env.local (all others ENVs) file inside docker folder
-   ```
+### What you get
 
-3. build docker image
+| Service | Purpose | Exposed |
+|---|---|---|
+| `app` | NextCRM (Next.js standalone build) | `localhost:3000` |
+| `postgres` | PostgreSQL 17 with pgvector | internal only |
+| `minio` | S3-compatible object storage | internal only |
+| `inngest` | Background job runner | internal only |
 
-   ```sh
-   docker build -t nextcrm .
-   ```
+Only port `3000` is exposed to the host. Everything else stays on the internal Docker network — secure by default. Uncomment the relevant `ports:` blocks in `docker-compose.yml` if you need direct access (e.g. for psql or the MinIO console).
 
-4. Run docker container
+### Configuring environment variables
 
-   ```sh
-   docker run -p 3000:3000 nextcrm
-   ```
+You **never edit `Dockerfile` or `docker-compose.yml`** to add your secrets. Instead, create a `.env` file in the project root — Docker Compose reads it automatically and injects the values into the container.
 
-5. http://localhost:3000
-</details>
+```sh
+cp .env.docker .env
+nano .env       # add your real API keys
+docker compose up -d
+```
+
+The `.env.docker` file lists every supported variable with comments. Internal services (Postgres, MinIO, Inngest) already have working defaults — you only need to add values for **optional external integrations** you want to enable:
+
+```bash
+# Example .env
+OPENAI_API_KEY=sk-your-real-key       # enables AI features
+GOOGLE_ID=...apps.googleusercontent.com  # enables Google OAuth
+GOOGLE_SECRET=GOCSPX-...
+RESEND_API_KEY=re_...                 # enables transactional email
+FIRECRAWL_API_KEY=fc-...              # enables contact enrichment
+```
+
+`.env` is in `.gitignore`, so your secrets never get committed.
+
+### Persistent data
+
+Database and uploaded files persist across restarts via two named volumes:
+
+- `postgres_data` — your database
+- `minio_data` — uploaded files
+
+```sh
+docker compose down        # stops services, keeps data
+docker compose down -v     # stops services AND wipes all data
+```
+
+### Updating to a new release
+
+```sh
+git pull
+docker compose up -d --build
+```
+
+The entrypoint runs `prisma migrate deploy` on every start, so new schema changes are applied automatically. The seed only runs on first install (when no users exist), so your data is safe across upgrades.
+
+### Coolify, Dokku, Portainer, etc.
+
+This setup works out of the box with self-hosting platforms:
+
+- **Coolify** — point it at this repo, choose "Docker Compose" build pack, set your env vars in Coolify's UI
+- **Portainer / Dockge** — paste `docker-compose.yml` into a stack, add env vars in the UI
+
+In all cases, env vars set through the platform UI override the placeholders in `docker-compose.yml` the same way a `.env` file does locally.
+
+### Default login
+
+After first start, the seeded admin account is:
+
+- **Email:** `test@nextcrm.app`
+
+The app uses passwordless Email OTP — log in with that email and grab the OTP from the database (or configure SMTP/Resend to actually send the email).
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -317,10 +317,15 @@ The fastest way to run NextCRM is with Docker Compose. The provided `docker-comp
 ```sh
 git clone https://github.com/pdovhomilja/nextcrm-app.git
 cd nextcrm-app
+cp .env.docker .env
+nano .env                # set ADMIN_EMAIL to a real email you own
 docker compose up -d
 ```
 
-That's it. Open [http://localhost:3000](http://localhost:3000) — the app is ready, the schema is migrated, and a default admin user (`test@nextcrm.app`) has been seeded.
+Open [http://localhost:3000](http://localhost:3000) — the app is ready, the schema is migrated, and the seeded admin user matches the `ADMIN_EMAIL` you set.
+
+> [!IMPORTANT]
+> NextCRM uses **passwordless Email OTP** for login. You MUST set `ADMIN_EMAIL` to an address you control AND provide a `RESEND_API_KEY` (or another email provider) so OTP codes can actually be delivered. Without an email provider, you can still log in by reading the OTP straight from the database — convenient for first-time testing, not for production.
 
 ### What you get
 
@@ -386,13 +391,26 @@ This setup works out of the box with self-hosting platforms:
 
 In all cases, env vars set through the platform UI override the placeholders in `docker-compose.yml` the same way a `.env` file does locally.
 
-### Default login
+### First login
 
-After first start, the seeded admin account is:
+After first start, the seeded admin account uses whatever you set in `ADMIN_EMAIL`. Since login is passwordless Email OTP, there are two paths:
 
-- **Email:** `test@nextcrm.app`
+**With email provider configured (recommended)**
 
-The app uses passwordless Email OTP — log in with that email and grab the OTP from the database (or configure SMTP/Resend to actually send the email).
+Set `RESEND_API_KEY` (or another supported provider) in `.env`, then enter your `ADMIN_EMAIL` on the sign-in page and check your inbox for the OTP.
+
+**Without email provider (first-run testing)**
+
+Read the OTP directly from the database:
+
+```sh
+docker compose exec postgres psql -U nextcrm -d nextcrm \
+  -c 'SELECT identifier, value, "expiresAt" FROM "Verification" ORDER BY "createdAt" DESC LIMIT 1;'
+```
+
+(`identifier` is the email, `value` is the OTP code.)
+
+Use that OTP on the sign-in page. After login, configure an email provider from the Admin panel so future logins work normally.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -344,11 +344,14 @@ You **never edit `Dockerfile` or `docker-compose.yml`** to add your secrets. Ins
 
 ```sh
 cp .env.docker .env
-nano .env       # add your real API keys
+nano .env       # set ADMIN_EMAIL, internal service passwords, and any optional API keys
 docker compose up -d
 ```
 
-The `.env.docker` file lists every supported variable with comments. Internal services (Postgres, MinIO, Inngest) already have working defaults — you only need to add values for **optional external integrations** you want to enable:
+> [!WARNING]
+> The bundled Postgres and MinIO containers ship with a placeholder password (`changeme`) so the stack works on first run. The internal services are not exposed to the host network — only the app on port 3000 is reachable — so this is safe for local experimentation. **For any deployment beyond your laptop**, set strong values for `POSTGRES_PASSWORD` and `MINIO_ROOT_PASSWORD` in your `.env` file before starting the stack.
+
+The `.env.docker` file lists every supported variable with comments. Beyond the internal service passwords, you only need to add values for **optional external integrations** you want to enable:
 
 ```bash
 # Example .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  # --- PostgreSQL Database ---
+  # --- PostgreSQL Database (with pgvector extension for embeddings) ---
   postgres:
-    image: postgres:18-alpine
+    image: pgvector/pgvector:pg17
     restart: unless-stopped
     environment:
       POSTGRES_USER: nextcrm
@@ -50,7 +50,7 @@ services:
     networks:
       - nextcrm
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8288/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8288/health"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -72,6 +72,8 @@ services:
       DB_HOST: postgres
       DB_PORT: "5432"
       DB_USER: nextcrm
+      DB_PASSWORD: nextcrm
+      DB_NAME: nextcrm
 
       # Auth
       BETTER_AUTH_URL: http://localhost:3000
@@ -98,12 +100,17 @@ services:
       NEXT_PUBLIC_APP_NAME: NextCRM
       NEXT_PUBLIC_APP_URL: http://localhost:3000
 
-      # Optional — override via .env file or environment:
-      # OPENAI_API_KEY: ""
-      # GOOGLE_ID: ""
-      # GOOGLE_SECRET: ""
-      # RESEND_API_KEY: ""
-      # FIRECRAWL_API_KEY: ""
+      # Placeholder values for optional external services.
+      # The app initializes these clients at module load time, so empty
+      # values cause crashes. Users override these via .env to enable
+      # the corresponding features. The app runs fine with placeholders;
+      # individual features just won't work until real keys are provided.
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-sk-placeholder-replace-to-enable-ai}
+      RESEND_API_KEY: ${RESEND_API_KEY:-re_placeholder_replace_to_enable_email}
+      GOOGLE_ID: ${GOOGLE_ID:-}
+      GOOGLE_SECRET: ${GOOGLE_SECRET:-}
+      FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY:-}
+      E2B_API_KEY: ${E2B_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,15 @@ services:
       NEXT_PUBLIC_APP_NAME: NextCRM
       NEXT_PUBLIC_APP_URL: http://localhost:3000
 
+      # Initial admin account (created on first run by the seed script).
+      # IMPORTANT: set this to a real email you control. The app uses
+      # passwordless Email OTP, so the placeholder default cannot
+      # receive login codes. Override via .env on first start, then
+      # configure SMTP/Resend (RESEND_API_KEY) so OTP emails actually
+      # send. Without an email provider you can read the OTP from
+      # the database directly.
+      TEST_USER_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
+
       # Placeholder values for optional external services.
       # The app initializes these clients at module load time, so empty
       # values cause crashes. Users override these via .env to enable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,15 @@ services:
     image: pgvector/pgvector:pg17
     restart: unless-stopped
     environment:
-      POSTGRES_USER: nextcrm
-      POSTGRES_PASSWORD: nextcrm
-      POSTGRES_DB: nextcrm
+      POSTGRES_USER: ${POSTGRES_USER:-nextcrm}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      POSTGRES_DB: ${POSTGRES_DB:-nextcrm}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - nextcrm
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U nextcrm"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-nextcrm}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -26,8 +26,8 @@ services:
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin123
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-nextcrm}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-changeme}
     volumes:
       - minio_data:/data
     networks:
@@ -67,26 +67,27 @@ services:
     ports:
       - "3000:3000"
     environment:
-      # Database
-      DATABASE_URL: postgresql://nextcrm:nextcrm@postgres:5432/nextcrm
+      # Database — values come from the same env vars as the postgres
+      # service above so a single override changes both sides.
+      DATABASE_URL: postgresql://${POSTGRES_USER:-nextcrm}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-nextcrm}
       DB_HOST: postgres
       DB_PORT: "5432"
-      DB_USER: nextcrm
-      DB_PASSWORD: nextcrm
-      DB_NAME: nextcrm
+      DB_USER: ${POSTGRES_USER:-nextcrm}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      DB_NAME: ${POSTGRES_DB:-nextcrm}
 
       # Auth
       BETTER_AUTH_URL: http://localhost:3000
       # BETTER_AUTH_SECRET is auto-generated if not set
 
-      # MinIO
+      # MinIO — values come from the same env vars as the minio service.
       NEXT_PUBLIC_MINIO_ENDPOINT: http://minio:9000
       MINIO_ENDPOINT: http://minio:9000
       MINIO_PORT: "9000"
       MINIO_BUCKET: nextcrm
       MINIO_USE_SSL: "false"
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin123
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-nextcrm}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-changeme}
 
       # Inngest
       INNGEST_DEV: "1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,129 @@
+services:
+  # --- PostgreSQL Database ---
+  postgres:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: nextcrm
+      POSTGRES_PASSWORD: nextcrm
+      POSTGRES_DB: nextcrm
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nextcrm"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    # Uncomment to expose Postgres to host:
+    # ports:
+    #   - "5432:5432"
+
+  # --- MinIO Object Storage ---
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    volumes:
+      - minio_data:/data
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    # Uncomment to expose MinIO to host:
+    # ports:
+    #   - "9000:9000"
+    #   - "9001:9001"
+
+  # --- Inngest Dev Server ---
+  inngest:
+    image: inngest/inngest:latest
+    restart: unless-stopped
+    command: inngest dev -u http://app:3000/api/inngest
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8288/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    # Uncomment to expose Inngest dashboard to host:
+    # ports:
+    #   - "8288:8288"
+
+  # --- NextCRM Application ---
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Database
+      DATABASE_URL: postgresql://nextcrm:nextcrm@postgres:5432/nextcrm
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_USER: nextcrm
+
+      # Auth
+      BETTER_AUTH_URL: http://localhost:3000
+      # BETTER_AUTH_SECRET is auto-generated if not set
+
+      # MinIO
+      NEXT_PUBLIC_MINIO_ENDPOINT: http://minio:9000
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_PORT: "9000"
+      MINIO_BUCKET: nextcrm
+      MINIO_USE_SSL: "false"
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin123
+
+      # Inngest
+      INNGEST_DEV: "1"
+      INNGEST_ID: nextcrm
+      INNGEST_APP_NAME: NextCRM
+      INNGEST_EVENT_KEY: local
+      INNGEST_SIGNING_KEY: ""
+      INNGEST_BASE_URL: http://inngest:8288
+
+      # App
+      NEXT_PUBLIC_APP_NAME: NextCRM
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+      # Optional — override via .env file or environment:
+      # OPENAI_API_KEY: ""
+      # GOOGLE_ID: ""
+      # GOOGLE_SECRET: ""
+      # RESEND_API_KEY: ""
+      # FIRECRAWL_API_KEY: ""
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      inngest:
+        condition: service_healthy
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  postgres_data:
+  minio_data:
+
+networks:
+  nextcrm:
+    driver: bridge

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -e
+
+echo "==> NextCRM Docker Entrypoint"
+
+# --- 1. Wait for Postgres ---
+echo "==> Waiting for PostgreSQL..."
+RETRIES=30
+until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -q 2>/dev/null; do
+  RETRIES=$((RETRIES - 1))
+  if [ "$RETRIES" -le 0 ]; then
+    echo "ERROR: PostgreSQL did not become ready in time."
+    exit 1
+  fi
+  echo "    Postgres not ready, retrying in 1s... ($RETRIES attempts left)"
+  sleep 1
+done
+echo "==> PostgreSQL is ready."
+
+# --- 2. Auto-generate secrets if not provided ---
+if [ -z "$BETTER_AUTH_SECRET" ]; then
+  export BETTER_AUTH_SECRET=$(head -c 32 /dev/urandom | base64)
+  echo "==> Generated BETTER_AUTH_SECRET"
+fi
+
+if [ -z "$EMAIL_ENCRYPTION_KEY" ]; then
+  export EMAIL_ENCRYPTION_KEY=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  echo "==> Generated EMAIL_ENCRYPTION_KEY"
+fi
+
+# --- 3. Run Prisma migrations ---
+echo "==> Running database migrations..."
+npx prisma migrate deploy
+echo "==> Migrations complete."
+
+# --- 4. Create MinIO bucket (idempotent) ---
+if [ -n "$MINIO_ENDPOINT" ] && [ -n "$MINIO_ACCESS_KEY" ] && [ -n "$MINIO_SECRET_KEY" ] && [ -n "$MINIO_BUCKET" ]; then
+  echo "==> Ensuring MinIO bucket '$MINIO_BUCKET' exists..."
+  # Strip protocol for host:port extraction
+  MINIO_HOST=$(echo "$MINIO_ENDPOINT" | sed 's|https\?://||')
+
+  # Create bucket via S3 API — returns 200 if created, 409 if exists (both are fine)
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X PUT "http://${MINIO_HOST}/${MINIO_BUCKET}" \
+    -H "Host: ${MINIO_HOST}" \
+    -u "${MINIO_ACCESS_KEY}:${MINIO_SECRET_KEY}" \
+    2>/dev/null || echo "000")
+
+  if [ "$STATUS" = "200" ]; then
+    echo "==> Bucket '$MINIO_BUCKET' created."
+  elif [ "$STATUS" = "409" ]; then
+    echo "==> Bucket '$MINIO_BUCKET' already exists."
+  else
+    echo "WARN: Could not create MinIO bucket (HTTP $STATUS). File storage may not work until bucket is created manually."
+  fi
+fi
+
+# --- 5. Conditional database seed ---
+echo "==> Checking if database needs seeding..."
+USER_COUNT=$(npx prisma db execute --stdin <<'SQL' 2>/dev/null | grep -c "1" || echo "0"
+SELECT 1 FROM "User" LIMIT 1;
+SQL
+)
+
+if [ "$USER_COUNT" = "0" ]; then
+  echo "==> No users found, seeding database..."
+  npx prisma db seed
+  echo "==> Seeding complete."
+else
+  echo "==> Database already has users, skipping seed."
+fi
+
+# --- 6. Start the application ---
+echo "==> Starting NextCRM..."
+exec node server.js

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,7 +30,7 @@ fi
 
 # --- 3. Run Prisma migrations ---
 echo "==> Running database migrations..."
-npx prisma migrate deploy
+prisma migrate deploy
 echo "==> Migrations complete."
 
 # --- 4. Create MinIO bucket (idempotent) ---
@@ -56,18 +56,22 @@ if [ -n "$MINIO_ENDPOINT" ] && [ -n "$MINIO_ACCESS_KEY" ] && [ -n "$MINIO_SECRET
 fi
 
 # --- 5. Conditional database seed ---
+# Use psql to count users directly (reliable) rather than prisma db execute
+# (which emits noisy output hard to parse).
 echo "==> Checking if database needs seeding..."
-USER_COUNT=$(npx prisma db execute --stdin <<'SQL' 2>/dev/null | grep -c "1" || echo "0"
-SELECT 1 FROM "User" LIMIT 1;
-SQL
-)
+USER_COUNT=$(PGPASSWORD="${DB_PASSWORD:-nextcrm}" psql \
+  -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "${DB_NAME:-nextcrm}" \
+  -tAc 'SELECT COUNT(*) FROM "Users";' 2>/dev/null || echo "0")
 
-if [ "$USER_COUNT" = "0" ]; then
+# Strip whitespace
+USER_COUNT=$(echo "$USER_COUNT" | tr -d '[:space:]')
+
+if [ "$USER_COUNT" = "0" ] || [ -z "$USER_COUNT" ]; then
   echo "==> No users found, seeding database..."
-  npx prisma db seed
+  prisma db seed
   echo "==> Seeding complete."
 else
-  echo "==> Database already has users, skipping seed."
+  echo "==> Database already has $USER_COUNT user(s), skipping seed."
 fi
 
 # --- 6. Start the application ---

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,8 +59,8 @@ fi
 # Use psql to count users directly (reliable) rather than prisma db execute
 # (which emits noisy output hard to parse).
 echo "==> Checking if database needs seeding..."
-USER_COUNT=$(PGPASSWORD="${DB_PASSWORD:-nextcrm}" psql \
-  -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "${DB_NAME:-nextcrm}" \
+USER_COUNT=$(PGPASSWORD="$DB_PASSWORD" psql \
+  -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
   -tAc 'SELECT COUNT(*) FROM "Users";' 2>/dev/null || echo "0")
 
 # Strip whitespace

--- a/docs/superpowers/plans/2026-04-08-docker-implementation.md
+++ b/docs/superpowers/plans/2026-04-08-docker-implementation.md
@@ -1,0 +1,700 @@
+# Docker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable users to run `docker-compose up` and get a fully working NextCRM instance with app, Postgres, Inngest, and MinIO.
+
+**Architecture:** Multi-stage Dockerfile with standalone Next.js output. Single docker-compose.yml orchestrates 4 services on an internal network. Entrypoint script handles migrations, seeding, and MinIO bucket creation automatically.
+
+**Tech Stack:** Docker, Docker Compose, Node 22 Alpine, Postgres 18, MinIO, Inngest Dev Server
+
+**Spec:** `docs/superpowers/specs/2026-04-08-docker-implementation-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `Dockerfile` | Multi-stage build: deps → build → runner |
+| `docker-compose.yml` | Service orchestration (app, postgres, inngest, minio) |
+| `docker-entrypoint.sh` | Startup: wait for DB, migrate, seed, create bucket, start app |
+| `.dockerignore` | Exclude unnecessary files from build context |
+| `.env.docker` | Documented example of all configurable env vars |
+| `next.config.js` | Modified: add `output: "standalone"`, add `minio` hostname |
+
+---
+
+### Task 1: Add `.dockerignore`
+
+**Files:**
+- Create: `.dockerignore`
+
+- [ ] **Step 1: Create `.dockerignore`**
+
+```
+node_modules
+.next
+.git
+.gitignore
+.env
+.env.local
+.env*.local
+*.md
+.vscode
+.idea
+tests
+e2e
+playwright-report
+test-results
+docs
+.playwright
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .dockerignore
+git commit -m "chore: add .dockerignore for Docker build context"
+```
+
+---
+
+### Task 2: Modify `next.config.js` for standalone output
+
+**Files:**
+- Modify: `next.config.js`
+
+- [ ] **Step 1: Read current `next.config.js`**
+
+Read the file to confirm current state before editing.
+
+- [ ] **Step 2: Add `output: "standalone"` and `minio` hostname**
+
+Edit `next.config.js` — add `output: "standalone"` to the `nextConfig` object and add `minio` to the `remotePatterns` array:
+
+```javascript
+const withNextIntl = require("next-intl/plugin")(
+  "./i18n/request.ts"
+);
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  serverExternalPackages: ["pdf-parse", "pdfjs-dist"],
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "localhost" },
+      { protocol: "https", hostname: "res.cloudinary.com" },
+      { protocol: "https", hostname: "lh3.googleusercontent.com" },
+      { protocol: "https", hostname: "minio-cwg0o4ss0scoccgwso8sk004.coolify.cz" },
+      { protocol: "http", hostname: "minio" },
+    ],
+  },
+  async redirects() {
+    return [
+      {
+        source: "/:locale/crm/targets/:path*",
+        destination: "/:locale/campaigns/targets/:path*",
+        permanent: true,
+      },
+      {
+        source: "/:locale/crm/target-lists/:path*",
+        destination: "/:locale/campaigns/target-lists/:path*",
+        permanent: true,
+      },
+    ];
+  },
+};
+
+module.exports = withNextIntl(nextConfig);
+```
+
+The two changes are:
+1. `output: "standalone"` — produces self-contained build
+2. `{ protocol: "http", hostname: "minio" }` — allows Next.js Image to load from internal MinIO service
+
+- [ ] **Step 3: Verify the app still builds locally**
+
+```bash
+pnpm build
+```
+
+Expected: Build succeeds. The `.next/standalone/` directory should now exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add next.config.js
+git commit -m "feat: enable Next.js standalone output for Docker"
+```
+
+---
+
+### Task 3: Create `docker-entrypoint.sh`
+
+**Files:**
+- Create: `docker-entrypoint.sh`
+
+- [ ] **Step 1: Create the entrypoint script**
+
+```bash
+#!/bin/sh
+set -e
+
+echo "==> NextCRM Docker Entrypoint"
+
+# --- 1. Wait for Postgres ---
+echo "==> Waiting for PostgreSQL..."
+RETRIES=30
+until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -q 2>/dev/null; do
+  RETRIES=$((RETRIES - 1))
+  if [ "$RETRIES" -le 0 ]; then
+    echo "ERROR: PostgreSQL did not become ready in time."
+    exit 1
+  fi
+  echo "    Postgres not ready, retrying in 1s... ($RETRIES attempts left)"
+  sleep 1
+done
+echo "==> PostgreSQL is ready."
+
+# --- 2. Auto-generate secrets if not provided ---
+if [ -z "$BETTER_AUTH_SECRET" ]; then
+  export BETTER_AUTH_SECRET=$(head -c 32 /dev/urandom | base64)
+  echo "==> Generated BETTER_AUTH_SECRET"
+fi
+
+if [ -z "$EMAIL_ENCRYPTION_KEY" ]; then
+  export EMAIL_ENCRYPTION_KEY=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  echo "==> Generated EMAIL_ENCRYPTION_KEY"
+fi
+
+# --- 3. Run Prisma migrations ---
+echo "==> Running database migrations..."
+npx prisma migrate deploy
+echo "==> Migrations complete."
+
+# --- 4. Create MinIO bucket (idempotent) ---
+if [ -n "$MINIO_ENDPOINT" ] && [ -n "$MINIO_ACCESS_KEY" ] && [ -n "$MINIO_SECRET_KEY" ] && [ -n "$MINIO_BUCKET" ]; then
+  echo "==> Ensuring MinIO bucket '$MINIO_BUCKET' exists..."
+  # Strip protocol for host:port extraction
+  MINIO_HOST=$(echo "$MINIO_ENDPOINT" | sed 's|https\?://||')
+
+  # Create bucket via S3 API — returns 200 if created, 409 if exists (both are fine)
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X PUT "http://${MINIO_HOST}/${MINIO_BUCKET}" \
+    -H "Host: ${MINIO_HOST}" \
+    -u "${MINIO_ACCESS_KEY}:${MINIO_SECRET_KEY}" \
+    2>/dev/null || echo "000")
+
+  if [ "$STATUS" = "200" ]; then
+    echo "==> Bucket '$MINIO_BUCKET' created."
+  elif [ "$STATUS" = "409" ]; then
+    echo "==> Bucket '$MINIO_BUCKET' already exists."
+  else
+    echo "WARN: Could not create MinIO bucket (HTTP $STATUS). File storage may not work until bucket is created manually."
+  fi
+fi
+
+# --- 5. Conditional database seed ---
+echo "==> Checking if database needs seeding..."
+USER_COUNT=$(npx prisma db execute --stdin <<'SQL' 2>/dev/null | grep -c "1" || echo "0"
+SELECT 1 FROM "User" LIMIT 1;
+SQL
+)
+
+if [ "$USER_COUNT" = "0" ]; then
+  echo "==> No users found, seeding database..."
+  npx prisma db seed
+  echo "==> Seeding complete."
+else
+  echo "==> Database already has users, skipping seed."
+fi
+
+# --- 6. Start the application ---
+echo "==> Starting NextCRM..."
+exec node server.js
+```
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x docker-entrypoint.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-entrypoint.sh
+git commit -m "feat: add Docker entrypoint script for auto-initialization"
+```
+
+---
+
+### Task 4: Create `Dockerfile`
+
+**Files:**
+- Create: `Dockerfile`
+
+- [ ] **Step 1: Create the multi-stage Dockerfile**
+
+```dockerfile
+# ============================================
+# Stage 1: Install dependencies
+# ============================================
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+
+RUN pnpm install --frozen-lockfile
+
+# ============================================
+# Stage 2: Build the application
+# ============================================
+FROM node:22-alpine AS build
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN pnpm prisma generate
+RUN pnpm next build
+
+# ============================================
+# Stage 3: Production runner
+# ============================================
+FROM node:22-alpine AS runner
+
+RUN apk add --no-cache curl postgresql-client
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy standalone build output
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+
+# Copy Prisma files for runtime migrations and seeding
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/node_modules/.pnpm/@prisma+client*/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/.pnpm/@prisma+engines*/node_modules/@prisma/engines ./node_modules/@prisma/engines
+COPY --from=build /app/node_modules/.pnpm/prisma*/node_modules/prisma ./node_modules/prisma
+COPY --from=build /app/node_modules/.pnpm/@prisma+client*/node_modules/@prisma/client ./node_modules/@prisma/client
+
+# Copy seed dependencies (ts-node, tsx, typescript for seed script)
+COPY --from=build /app/node_modules/.pnpm/ts-node*/node_modules/ts-node ./node_modules/ts-node
+COPY --from=build /app/node_modules/.pnpm/tsx*/node_modules/tsx ./node_modules/tsx
+COPY --from=build /app/node_modules/.pnpm/typescript*/node_modules/typescript ./node_modules/typescript
+COPY --from=build /app/package.json ./package.json
+
+# Make npx find prisma
+ENV PATH="/app/node_modules/.bin:$PATH"
+
+# Copy entrypoint
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+# Set ownership
+RUN chown -R nextjs:nodejs /app
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+```
+
+**Notes on the runner stage:**
+- `postgresql-client` provides `pg_isready` for the entrypoint health check
+- `curl` is needed for MinIO bucket creation
+- Prisma client, engines, and CLI are copied individually to avoid pulling the entire `node_modules`
+- Seed dependencies (ts-node, tsx, typescript) are needed for `prisma db seed` which runs `ts-node ./prisma/seeds/seed.ts`
+- The `PATH` addition ensures `npx prisma` resolves correctly
+
+- [ ] **Step 2: Verify the Dockerfile builds**
+
+```bash
+docker build -t nextcrm:test .
+```
+
+Expected: Build completes successfully. If Prisma COPY paths don't resolve, inspect the build stage to find exact paths:
+
+```bash
+docker build --target build -t nextcrm:build-debug .
+docker run --rm nextcrm:build-debug ls -la node_modules/.pnpm/ | grep prisma
+```
+
+Adjust the COPY paths in the Dockerfile if the pnpm store paths differ.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat: add multi-stage Dockerfile for NextCRM"
+```
+
+---
+
+### Task 5: Create `docker-compose.yml`
+
+**Files:**
+- Create: `docker-compose.yml`
+
+- [ ] **Step 1: Create the compose file**
+
+```yaml
+services:
+  # --- PostgreSQL Database ---
+  postgres:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: nextcrm
+      POSTGRES_PASSWORD: nextcrm
+      POSTGRES_DB: nextcrm
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nextcrm"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    # Uncomment to expose Postgres to host:
+    # ports:
+    #   - "5432:5432"
+
+  # --- MinIO Object Storage ---
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    volumes:
+      - minio_data:/data
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    # Uncomment to expose MinIO to host:
+    # ports:
+    #   - "9000:9000"
+    #   - "9001:9001"
+
+  # --- Inngest Dev Server ---
+  inngest:
+    image: inngest/inngest:latest
+    restart: unless-stopped
+    command: inngest dev -u http://app:3000/api/inngest
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8288/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    # Uncomment to expose Inngest dashboard to host:
+    # ports:
+    #   - "8288:8288"
+
+  # --- NextCRM Application ---
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Database
+      DATABASE_URL: postgresql://nextcrm:nextcrm@postgres:5432/nextcrm
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_USER: nextcrm
+
+      # Auth
+      BETTER_AUTH_URL: http://localhost:3000
+      # BETTER_AUTH_SECRET is auto-generated if not set
+
+      # MinIO
+      NEXT_PUBLIC_MINIO_ENDPOINT: http://minio:9000
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_PORT: "9000"
+      MINIO_BUCKET: nextcrm
+      MINIO_USE_SSL: "false"
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin123
+
+      # Inngest
+      INNGEST_DEV: "1"
+      INNGEST_ID: nextcrm
+      INNGEST_APP_NAME: NextCRM
+      INNGEST_EVENT_KEY: local
+      INNGEST_SIGNING_KEY: ""
+      INNGEST_BASE_URL: http://inngest:8288
+
+      # App
+      NEXT_PUBLIC_APP_NAME: NextCRM
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+      # Optional — override via .env file or environment:
+      # OPENAI_API_KEY: ""
+      # GOOGLE_ID: ""
+      # GOOGLE_SECRET: ""
+      # RESEND_API_KEY: ""
+      # FIRECRAWL_API_KEY: ""
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      inngest:
+        condition: service_healthy
+    networks:
+      - nextcrm
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  postgres_data:
+  minio_data:
+
+networks:
+  nextcrm:
+    driver: bridge
+```
+
+**Key decisions:**
+- `DB_HOST`, `DB_PORT`, `DB_USER` are separate env vars used by the entrypoint for `pg_isready` (which doesn't parse connection strings)
+- Inngest `command` points back to the app's Inngest route for function discovery
+- `inngest` healthcheck uses `wget` instead of `curl` because the Inngest image is based on a minimal distro that includes wget
+- `start_period: 30s` on the app gives time for migrations and seeding before health checks start failing
+- All optional API keys are commented out — users add them via `.env` file
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat: add docker-compose.yml with all services"
+```
+
+---
+
+### Task 6: Create `.env.docker` example file
+
+**Files:**
+- Create: `.env.docker`
+
+- [ ] **Step 1: Create the example env file**
+
+```bash
+# ===========================================
+# NextCRM Docker Environment Configuration
+# ===========================================
+# Copy this file to .env to customize your deployment.
+# docker-compose.yml already sets sensible defaults for all
+# internal services. Only set values here if you need to override.
+#
+# Usage:
+#   cp .env.docker .env
+#   # Edit .env with your values
+#   docker-compose up
+# ===========================================
+
+# --- Database (default: bundled Postgres) ---
+# Override to use an external database:
+# DATABASE_URL=postgresql://user:pass@your-host:5432/nextcrm
+
+# --- Auth ---
+# Auto-generated on first start if not set.
+# Set explicitly for stable sessions across container restarts:
+# BETTER_AUTH_SECRET=your-secret-here
+# BETTER_AUTH_URL=http://localhost:3000
+
+# --- MinIO Object Storage (default: bundled MinIO) ---
+# Override to use external S3-compatible storage:
+# MINIO_ENDPOINT=https://your-s3-host
+# MINIO_PORT=443
+# MINIO_BUCKET=your-bucket
+# MINIO_USE_SSL=true
+# MINIO_ACCESS_KEY=your-key
+# MINIO_SECRET_KEY=your-secret
+
+# --- Google OAuth (optional) ---
+# GOOGLE_ID=your-google-client-id
+# GOOGLE_SECRET=your-google-client-secret
+
+# --- OpenAI (optional, for AI features) ---
+# OPENAI_API_KEY=sk-...
+
+# --- Email Sending via Resend (optional) ---
+# RESEND_API_KEY=re_...
+# RESEND_FROM_EMAIL=noreply@yourdomain.com
+
+# --- SMTP / IMAP (optional, for email client) ---
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=your-user
+# SMTP_PASSWORD=your-password
+# IMAP_HOST=imap.example.com
+# IMAP_PORT=993
+# IMAP_USER=your-user
+# IMAP_PASSWORD=your-password
+
+# --- Firecrawl (optional, for contact enrichment) ---
+# FIRECRAWL_API_KEY=fc-...
+
+# --- E2B (optional, for agent enrichment) ---
+# E2B_API_KEY=e2b_...
+
+# --- Rossum (optional, for invoice parsing) ---
+# ROSSUM_USERNAME=your-user
+# ROSSUM_PASSWORD=your-password
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.docker
+git commit -m "docs: add .env.docker example for Docker deployments"
+```
+
+---
+
+### Task 7: End-to-end verification
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Build and start all services**
+
+```bash
+docker-compose up --build -d
+```
+
+Expected: All 4 services start. Watch logs:
+
+```bash
+docker-compose logs -f app
+```
+
+Expected output sequence:
+1. `==> Waiting for PostgreSQL...`
+2. `==> PostgreSQL is ready.`
+3. `==> Generated BETTER_AUTH_SECRET`
+4. `==> Running database migrations...`
+5. `==> Migrations complete.`
+6. `==> Ensuring MinIO bucket 'nextcrm' exists...`
+7. `==> Bucket 'nextcrm' created.`
+8. `==> No users found, seeding database...`
+9. `==> Seeding complete.`
+10. `==> Starting NextCRM...`
+
+- [ ] **Step 2: Verify health checks**
+
+```bash
+docker-compose ps
+```
+
+Expected: All services show `(healthy)` status.
+
+- [ ] **Step 3: Verify the app is accessible**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
+```
+
+Expected: `200`
+
+- [ ] **Step 4: Verify restart idempotency**
+
+```bash
+docker-compose restart app
+docker-compose logs -f app
+```
+
+Expected: Entrypoint runs again but:
+- Migrations report "no pending migrations"
+- Bucket creation reports "already exists"
+- Seed is skipped ("Database already has users")
+- App starts normally
+
+- [ ] **Step 5: Fix any issues found during verification**
+
+If any step fails, debug and fix. Common issues:
+- Prisma COPY paths in Dockerfile need adjustment — use `docker build --target build` to inspect
+- MinIO bucket creation auth may need adjustment — test curl command manually
+- Seed detection query may need adjustment based on actual Prisma output
+
+- [ ] **Step 6: Clean up test build**
+
+```bash
+docker-compose down -v
+```
+
+- [ ] **Step 7: Final commit (if any fixes were made)**
+
+```bash
+git add -A
+git commit -m "fix: Docker setup adjustments from e2e verification"
+```
+
+---
+
+### Task 8: Verify `docker-compose up` from clean state
+
+**Files:** None (final validation)
+
+- [ ] **Step 1: Full clean start**
+
+```bash
+docker-compose down -v
+docker rmi nextcrm-app-app 2>/dev/null || true
+docker-compose up --build -d
+```
+
+- [ ] **Step 2: Wait for healthy state and verify**
+
+```bash
+# Wait for app to be healthy (up to 60s)
+timeout 60 sh -c 'until docker-compose ps app | grep -q healthy; do sleep 2; done'
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
+```
+
+Expected: `200`
+
+- [ ] **Step 3: Clean up**
+
+```bash
+docker-compose down -v
+```
+
+- [ ] **Step 4: Commit any final adjustments**
+
+If any fixes were needed, commit them.

--- a/docs/superpowers/specs/2026-04-08-docker-implementation-design.md
+++ b/docs/superpowers/specs/2026-04-08-docker-implementation-design.md
@@ -1,0 +1,199 @@
+# Docker Implementation Design
+
+**Date:** 2026-04-08
+**Status:** Approved
+
+## Goal
+
+Enable users to clone the NextCRM repo and run `docker-compose up` to get a fully working instance — app, database, background jobs, and file storage — with zero manual configuration. Optimized for self-hosting platforms like Coolify.
+
+## User Experience
+
+```bash
+git clone https://github.com/pdovhomilja/nextcrm-app
+cd nextcrm-app
+docker-compose up
+# → app ready at http://localhost:3000
+```
+
+## Architecture
+
+### Services
+
+| Service | Image | Internal Port | Exposed Port | Purpose |
+|---------|-------|--------------|--------------|---------|
+| app | Built from `./Dockerfile` | 3000 | 3000 | NextCRM application |
+| postgres | `postgres:18-alpine` | 5432 | none | Database |
+| inngest | `inngest/inngest:latest` | 8288 | none | Background jobs |
+| minio | `minio/minio:latest` | 9000, 9001 | none | Object storage (S3-compatible) |
+
+### Networking
+
+- Single Docker network: `nextcrm`
+- Only port 3000 exposed to host
+- All inter-service communication over internal DNS (e.g., `postgres:5432`, `minio:9000`, `inngest:8288`)
+- Users who need direct DB/MinIO access can uncomment port mappings in docker-compose.yml
+
+### Volumes
+
+- `postgres_data` — persistent database storage
+- `minio_data` — persistent file storage
+
+## Dockerfile (Multi-stage)
+
+### Stage 1: `deps`
+
+- Base: `node:22-alpine`
+- Install `pnpm` globally
+- Copy `package.json` + `pnpm-lock.yaml`
+- Run `pnpm install --frozen-lockfile`
+- This layer is cached — only rebuilds when dependencies change
+
+### Stage 2: `build`
+
+- Copy source code from context
+- Copy `node_modules` from `deps` stage
+- Run `pnpm prisma generate`
+- Run `pnpm next build`
+- Next.js produces standalone output in `.next/standalone/`
+
+### Stage 3: `runner`
+
+- Base: `node:22-alpine`
+- Create non-root user `nextjs` (uid 1001)
+- Copy from build stage:
+  - `.next/standalone/` — the self-contained server
+  - `.next/static/` → `.next/standalone/.next/static/`
+  - `public/` → `.next/standalone/public/`
+  - `prisma/` — schema + migrations for runtime migrate/seed
+  - Prisma engine binaries
+- Copy `docker-entrypoint.sh`
+- Run as `nextjs` user
+- Entrypoint: `docker-entrypoint.sh`
+
+**Expected image size:** ~200-300MB
+
+## Entrypoint Script (`docker-entrypoint.sh`)
+
+Sequential startup flow:
+
+1. **Wait for Postgres** — loop with `pg_isready` until database accepts connections. Max 30 second timeout, then fail with clear error message.
+2. **Run migrations** — `npx prisma migrate deploy` to apply all pending migrations.
+3. **Create MinIO bucket** — ensure the `nextcrm` bucket exists using the MinIO S3 API via `curl` (PUT request to create bucket). No additional tools needed. Idempotent — skips if bucket already present (ignores 409 BucketAlreadyOwnedByYou).
+4. **Conditional seed** — query database for existing users. If none found, run `npx prisma db seed` to create default admin account. Prevents re-seeding on container restarts.
+5. **Start app** — `exec node server.js` (exec replaces shell so signals propagate correctly for graceful shutdown).
+
+## docker-compose.yml
+
+### Default Credentials (Internal Only)
+
+| Service | Credentials |
+|---------|------------|
+| Postgres | user: `nextcrm`, password: `nextcrm`, database: `nextcrm` |
+| MinIO | access key: `minioadmin`, secret key: `minioadmin123`, bucket: `nextcrm` |
+
+### Environment Wiring
+
+The app service receives pre-configured environment variables:
+
+```yaml
+DATABASE_URL: postgresql://nextcrm:nextcrm@postgres:5432/nextcrm
+MINIO_ENDPOINT: http://minio:9000
+NEXT_PUBLIC_MINIO_ENDPOINT: http://minio:9000
+MINIO_PORT: "9000"
+MINIO_BUCKET: nextcrm
+MINIO_USE_SSL: "false"
+MINIO_ACCESS_KEY: minioadmin
+MINIO_SECRET_KEY: minioadmin123
+INNGEST_BASE_URL: http://inngest:8288
+INNGEST_EVENT_KEY: local
+BETTER_AUTH_URL: http://localhost:3000
+```
+
+`BETTER_AUTH_SECRET` and `EMAIL_ENCRYPTION_KEY` are auto-generated in the entrypoint if not provided via environment.
+
+### Health Checks
+
+| Service | Check | Interval | Retries |
+|---------|-------|----------|---------|
+| postgres | `pg_isready -U nextcrm` | 5s | 5 |
+| minio | `curl -f http://localhost:9000/minio/health/live` | 5s | 5 |
+| inngest | `curl -f http://localhost:8288/health` | 5s | 5 |
+| app | `curl -f http://localhost:3000` | 10s | 5 |
+
+### Dependency Ordering
+
+```
+app → depends_on → postgres (healthy), minio (healthy), inngest (healthy)
+```
+
+### Restart Policy
+
+All services: `restart: unless-stopped`
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | Multi-stage build for NextCRM |
+| `docker-compose.yml` | Full-stack service orchestration |
+| `docker-entrypoint.sh` | Startup script (migrations, seed, bucket creation) |
+| `.dockerignore` | Exclude node_modules, .next, .git, .env* from build context |
+| `.env.docker` | Example env file documenting all configurable variables |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `next.config.js` | Add `output: "standalone"`, add `minio` to image `remotePatterns` |
+
+## .env.docker Structure
+
+Variables grouped by category:
+
+### Required (have defaults in docker-compose.yml)
+
+- `DATABASE_URL` — Postgres connection string
+- `MINIO_*` — MinIO connection details
+- `INNGEST_*` — Inngest connection details
+- `BETTER_AUTH_SECRET` — auto-generated if not set
+- `BETTER_AUTH_URL` — defaults to http://localhost:3000
+- `EMAIL_ENCRYPTION_KEY` — auto-generated if not set
+
+### Optional (external services, disabled by default)
+
+- `OPENAI_API_KEY` — for AI features
+- `GOOGLE_ID` / `GOOGLE_SECRET` — for Google OAuth login
+- `RESEND_API_KEY` — for email sending
+- `FIRECRAWL_API_KEY` — for contact enrichment
+- `ROSSUM_USERNAME` / `ROSSUM_PASSWORD` — for invoice parsing
+- `SMTP_*` / `IMAP_*` — for email client functionality
+- `E2B_API_KEY` — for E2B enrichment
+
+## .dockerignore
+
+```
+node_modules
+.next
+.git
+.env
+.env.local
+.env*.local
+*.md
+.vscode
+.idea
+tests
+e2e
+playwright-report
+test-results
+docs
+```
+
+## Security Notes
+
+- Only port 3000 exposed to host — database, MinIO, and Inngest are not accessible from outside Docker network
+- App runs as non-root user in container
+- Default internal credentials are for local/self-hosted use only — users deploying publicly should override via environment variables
+- `.env` files excluded from Docker build context via `.dockerignore`

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const withNextIntl = require("next-intl/plugin")(
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   serverExternalPackages: ["pdf-parse", "pdfjs-dist"],
   images: {
     remotePatterns: [
@@ -11,6 +12,7 @@ const nextConfig = {
       { protocol: "https", hostname: "res.cloudinary.com" },
       { protocol: "https", hostname: "lh3.googleusercontent.com" },
       { protocol: "https", hostname: "minio-cwg0o4ss0scoccgwso8sk004.coolify.cz" },
+      { protocol: "http", hostname: "minio" },
     ],
   },
   async redirects() {


### PR DESCRIPTION
## Summary

Adds first-class Docker support so anyone can self-host NextCRM with a single `docker compose up`. Bundles the app, PostgreSQL (with pgvector), MinIO, and Inngest into one stack with automatic migrations, bucket creation, and seeding.

## What's included

- **`Dockerfile`** — multi-stage build (deps → build → runner) with Next.js standalone output. Final image runs as non-root, ~200-300MB.
- **`docker-compose.yml`** — 4 services on internal network, only port 3000 exposed. Health checks + dependency ordering + restart policies.
- **`docker-entrypoint.sh`** — waits for Postgres, runs migrations, ensures MinIO bucket, conditionally seeds the DB (idempotent on restart), then starts the app.
- **`.dockerignore`** — keeps the build context small.
- **`.env.docker`** — documented example file with `ADMIN_EMAIL` as the prominent first setting.
- **`next.config.js`** — `output: "standalone"` + `minio` hostname for image serving.
- **`README.md`** — full Docker installation guide replacing the stale section.

## User experience

```sh
git clone https://github.com/pdovhomilja/nextcrm-app.git
cd nextcrm-app
cp .env.docker .env
nano .env                # set ADMIN_EMAIL
docker compose up -d
# → http://localhost:3000
```

Works out of the box with **Coolify**, Portainer, Dockge, and similar self-hosting platforms — env vars set via the platform UI override the placeholders the same way `.env` does locally.

## Verified end-to-end

Built and tested locally on Docker 29.3.0 / Compose v5.1.0:

- All 4 services start and report `(healthy)`
- 26 Prisma migrations apply automatically
- MinIO bucket `nextcrm` created via S3 API
- Seed runs on first start, skipped on restart (detects existing users)
- App responds with HTTP 307 → 200 at `/en/sign-in`
- Volume persistence verified across `down`/`up` cycles
- Clean-state startup verified (`down -v` then `up -d`)

## Notable design decisions

- **`pgvector/pgvector:pg17`** instead of vanilla Postgres — required by the embeddings migration
- **Prisma + tsx installed in `/opt/tools`** separately from Next.js standalone `node_modules` to avoid pnpm symlink layout conflicts
- **`@prisma/adapter-pg` merged into `/app/node_modules`** so ESM import resolution finds it (NODE_PATH only works for CJS)
- **Build-time placeholder env vars** for modules that initialize clients at import time (OpenAI, Inngest, MinIO) — overridden at runtime by docker-compose
- **`ADMIN_EMAIL` env var** wires through to the existing `TEST_USER_EMAIL` seed variable so users get a real admin account they can actually log in to via Email OTP

## Test plan

- [ ] `git pull && docker compose up -d` on a clean machine
- [ ] Verify all 4 containers reach healthy state
- [ ] Confirm `http://localhost:3000` redirects to `/en/sign-in`
- [ ] Set `ADMIN_EMAIL` + `RESEND_API_KEY` in `.env`, verify OTP delivery
- [ ] Without email provider: read OTP from `Verification` table per README instructions
- [ ] `docker compose down && docker compose up -d` — verify seed is skipped
- [ ] `docker compose down -v && docker compose up -d` — verify clean-state seed runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)