### PR TITLE
fix(prisma): add missing crm_Target_Contact migration

### DIFF
--- a/prisma/migrations/20260418000000_add_crm_target_contact/migration.sql
+++ b/prisma/migrations/20260418000000_add_crm_target_contact/migration.sql
@@ -1,0 +1,60 @@
+-- CreateTable: crm_Target_Contact
+-- Introduces multi-contact enrichment records attached to crm_Targets.
+-- Idempotent: safe to re-run on databases that already have the table
+-- (e.g. environments synced via `prisma db push`).
+
+CREATE TABLE IF NOT EXISTS "crm_Target_Contact" (
+    "id"           UUID         NOT NULL DEFAULT gen_random_uuid(),
+    "targetId"     UUID         NOT NULL,
+    "contactId"    UUID,
+    "name"         TEXT,
+    "email"        TEXT,
+    "title"        TEXT,
+    "phone"        TEXT,
+    "linkedinUrl"  TEXT,
+    "source"       TEXT         NOT NULL DEFAULT 'manual',
+    "enrichStatus" "crm_Enrichment_Status" NOT NULL DEFAULT 'PENDING',
+    "enrichedAt"   TIMESTAMP(3),
+    "createdAt"    TIMESTAMP(3) NOT NULL DEFAULT now(),
+    "updatedAt"    TIMESTAMP(3) NOT NULL DEFAULT now(),
+
+    CONSTRAINT "crm_Target_Contact_pkey" PRIMARY KEY ("id")
+);
+
+-- Unique constraints
+CREATE UNIQUE INDEX IF NOT EXISTS "crm_Target_Contact_targetId_email_key"
+    ON "crm_Target_Contact" ("targetId", "email");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "crm_Target_Contact_targetId_linkedinUrl_key"
+    ON "crm_Target_Contact" ("targetId", "linkedinUrl");
+
+-- Lookup indexes
+CREATE INDEX IF NOT EXISTS "crm_Target_Contact_targetId_idx"
+    ON "crm_Target_Contact" ("targetId");
+
+CREATE INDEX IF NOT EXISTS "crm_Target_Contact_enrichStatus_idx"
+    ON "crm_Target_Contact" ("enrichStatus");
+
+-- Foreign keys (guarded so re-runs don't fail)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'crm_Target_Contact_targetId_fkey'
+    ) THEN
+        ALTER TABLE "crm_Target_Contact"
+            ADD CONSTRAINT "crm_Target_Contact_targetId_fkey"
+            FOREIGN KEY ("targetId") REFERENCES "crm_Targets"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'crm_Target_Contact_contactId_fkey'
+    ) THEN
+        ALTER TABLE "crm_Target_Contact"
+            ADD CONSTRAINT "crm_Target_Contact_contactId_fkey"
+            FOREIGN KEY ("contactId") REFERENCES "crm_Contacts"("id")
+            ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

Follow-up to #178. The `crm_Target_Contact` model was added to `schema.prisma` in commit `e9f42be` (2026-03-26) without a corresponding migration file. Deployed environments (xmation, demo, production) fail with Prisma P2021 `TableDoesNotExist` on the target detail page because `prisma migrate deploy` has nothing to apply for this model.

This PR adds the missing migration `20260418000000_add_crm_target_contact` so `migrate deploy` creates the table.

## Details

- Idempotent migration: `CREATE TABLE IF NOT EXISTS`, guarded FK additions — safe on DBs that already have the table via `prisma db push`.
- Matches existing repo conventions (see `20260328000000_add_crm_activities`).
- Uses `gen_random_uuid()` for PK default, `DEFAULT now()` on both `createdAt` and `updatedAt`.
- Unique constraints: `(targetId, email)`, `(targetId, linkedinUrl)`.
- FKs: `targetId → crm_Targets ON DELETE CASCADE`, `contactId → crm_Contacts ON DELETE SET NULL`.

## Affected URLs (before fix)

- https://xmation.nextcrm.app/en/campaigns/targets/*
- https://demo.nextcrm.io/en/campaigns/targets/*

## Test plan

- [ ] Verify `prisma migrate deploy` completes cleanly on remote dev environment.
- [ ] Load a target detail page on dev environment — no P2021 error.
- [ ] Verify `target_contacts` include in `actions/crm/get-target.ts` returns (possibly empty) array.
- [ ] Apply to xmation after merge; reload affected URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)