### PR TITLE
feat(crm): show invoices on account detail page

### DIFF
--- a/actions/invoices/get-invoices-by-accountId.ts
+++ b/actions/invoices/get-invoices-by-accountId.ts
@@ -1,0 +1,12 @@
+import { prismadb } from "@/lib/prisma";
+
+export async function getInvoicesByAccountId(accountId: string) {
+  return prismadb.invoices.findMany({
+    where: { accountId },
+    orderBy: { createdAt: "desc" },
+    include: {
+      account: { select: { id: true, name: true } },
+      series: { select: { id: true, name: true } },
+    },
+  });
+}

--- a/app/[locale]/(routes)/crm/accounts/[accountId]/page.tsx
+++ b/app/[locale]/(routes)/crm/accounts/[accountId]/page.tsx
@@ -14,11 +14,14 @@ import { getAccountProducts } from "@/actions/crm/account-products/get-account-p
 import { getProductsFull } from "@/actions/crm/products/get-products";
 import { serializeDecimalsList } from "@/lib/serialize-decimals";
 import { getAccountsTasks } from "@/actions/crm/account/get-tasks";
+import { getInvoicesByAccountId } from "@/actions/invoices/get-invoices-by-accountId";
+import { getTranslations } from "next-intl/server";
 
 import OpportunitiesView from "../../components/OpportunitiesView";
 import LeadsView from "../../components/LeadsView";
 import ContactsView from "../../components/ContactsView";
 import DocumentsView from "../../components/DocumentsView";
+import InvoicesView from "../../components/InvoicesView";
 
 import {
   Documents,
@@ -57,6 +60,30 @@ const AccountDetailPage = async (props: AccountDetailPageProps) => {
   const leads: crm_Leads[] = await getLeadsByAccountId(accountId);
   const documents: Documents[] = await getDocumentsByAccountId(accountId);
   const tasks: crm_Accounts_Tasks[] = await getAccountsTasks(accountId);
+  const invoices = await getInvoicesByAccountId(accountId);
+  const t = await getTranslations("InvoicesPage");
+  const invoiceStatusLabels: Record<string, string> = {
+    DRAFT: t("status.DRAFT"),
+    ISSUED: t("status.ISSUED"),
+    SENT: t("status.SENT"),
+    PARTIALLY_PAID: t("status.PARTIALLY_PAID"),
+    PAID: t("status.PAID"),
+    OVERDUE: t("status.OVERDUE"),
+    CANCELLED: t("status.CANCELLED"),
+    DISPUTED: t("status.DISPUTED"),
+    REFUNDED: t("status.REFUNDED"),
+    WRITTEN_OFF: t("status.WRITTEN_OFF"),
+  };
+  const invoiceTableLabels = {
+    number: t("table.number"),
+    account: t("table.account"),
+    issueDate: t("table.issueDate"),
+    dueDate: t("table.dueDate"),
+    total: t("table.total"),
+    status: t("table.status"),
+    type: t("table.type"),
+    currency: t("table.currency"),
+  };
   const crmData = await getAllCrmData();
   const accountProducts = serializeDecimalsList(
     await getAccountProducts(accountId)
@@ -103,6 +130,12 @@ const AccountDetailPage = async (props: AccountDetailPageProps) => {
               activeProducts={activeProducts}
             />
             <DocumentsView data={documents} accountId={accountId} />
+            <InvoicesView
+              data={JSON.parse(JSON.stringify(invoices))}
+              accountId={accountId}
+              statusLabels={invoiceStatusLabels}
+              tableLabels={invoiceTableLabels}
+            />
           </div>
         </TabsContent>
         <TabsContent value="history">

--- a/app/[locale]/(routes)/crm/components/InvoicesView.tsx
+++ b/app/[locale]/(routes)/crm/components/InvoicesView.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Plus } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { InvoicesTable } from "@/app/[locale]/(routes)/invoices/components/invoices-table";
+
+interface InvoicesViewProps {
+  data: any;
+  accountId?: string;
+  statusLabels?: Record<string, string>;
+  tableLabels?: {
+    number?: string;
+    account?: string;
+    issueDate?: string;
+    dueDate?: string;
+    total?: string;
+    status?: string;
+    type?: string;
+    currency?: string;
+  };
+}
+
+const InvoicesView = ({
+  data,
+  accountId,
+  statusLabels,
+  tableLabels,
+}: InvoicesViewProps) => {
+  const router = useRouter();
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex justify-between">
+          <div>
+            <CardTitle
+              onClick={() => router.push("/invoices")}
+              className="cursor-pointer"
+            >
+              Invoices
+            </CardTitle>
+            <CardDescription></CardDescription>
+          </div>
+          {accountId && (
+            <Link href={`/invoices/new?accountId=${accountId}`}>
+              <Button size="sm">
+                <Plus className="mr-2 h-4 w-4" />
+                New invoice
+              </Button>
+            </Link>
+          )}
+        </div>
+        <Separator />
+      </CardHeader>
+      <CardContent>
+        {!data || data.length === 0 ? (
+          "No assigned invoices found"
+        ) : (
+          <InvoicesTable
+            invoices={data}
+            statusLabels={statusLabels}
+            tableLabels={tableLabels}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default InvoicesView;


### PR DESCRIPTION
## Summary
- Adds an Invoices section on the account detail page, alongside Documents.
- New server action `getInvoicesByAccountId` filters invoices by `accountId`.
- New `InvoicesView` card wraps the existing `InvoicesTable` with localized labels and a "New invoice" shortcut that prefills `accountId`.

## Test plan
- [ ] Open an account with invoices (e.g. `/en/crm/accounts/<id>`) and confirm the Invoices card renders with the correct rows.
- [ ] Open an account with no invoices and confirm the empty state copy.
- [ ] Click "New invoice" and confirm it lands on `/invoices/new?accountId=...`.
- [ ] Verify Czech locale labels render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)