### PR TITLE
fix(security): close enrichment BOLA/IDOR (Phase B1)

### DIFF
--- a/app/api/crm/contacts/enrich-bulk/__tests__/route.test.ts
+++ b/app/api/crm/contacts/enrich-bulk/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Contacts: { findMany: jest.fn() },
+  },
+}));
+jest.mock("@/lib/api-keys", () => ({
+  getApiKey: jest.fn().mockResolvedValue("sk-test"),
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({ ids: ["1"] }) },
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const mockedGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockedUser = prismadb.users.findUnique as jest.MockedFunction<
+  typeof prismadb.users.findUnique
+>;
+const mockedFindMany = prismadb.crm_Contacts.findMany as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findMany
+>;
+const mockedSend = inngest.send as jest.MockedFunction<typeof inngest.send>;
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/crm/contacts/enrich-bulk", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/contacts/enrich-bulk", () => {
+  it("401 unauth", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const res = await POST(makeReq({ contactIds: ["a"], fields: [{ name: "website" }] }));
+    expect(res.status).toBe(401);
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it("403 when any contact id is unauthorized (fail-closed)", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u" } } as any);
+    mockedUser.mockResolvedValue({ id: "u", role: "user" } as any);
+    mockedFindMany.mockResolvedValue([{ id: "a" }] as any);
+    const res = await POST(
+      makeReq({ contactIds: ["a", "b"], fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it("succeeds + sends Inngest event when all ids authorized", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "m" } } as any);
+    mockedUser.mockResolvedValue({ id: "m", role: "manager" } as any);
+    mockedFindMany.mockResolvedValue([{ id: "a" }, { id: "b" }] as any);
+    const res = await POST(
+      makeReq({ contactIds: ["a", "b"], fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "enrich/contacts.bulk",
+        data: expect.objectContaining({
+          contactIds: ["a", "b"],
+          triggeredBy: "m",
+        }),
+      }),
+    );
+  });
+});

--- a/app/api/crm/contacts/enrich-bulk/route.ts
+++ b/app/api/crm/contacts/enrich-bulk/route.ts
@@ -1,12 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
 import { inngest } from "@/inngest/client";
 import { getApiKey } from "@/lib/api-keys";
+import {
+  requireAuthenticated,
+  filterAuthorizedContactIds,
+  unauthorizedResponse,
+  forbiddenResponse,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
   }
 
   const { contactIds, fields } = await request.json();
@@ -21,15 +30,20 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "fields must be a non-empty array" }, { status: 400 });
   }
 
-  const firecrawlApiKey = await getApiKey("FIRECRAWL", session.user.id);
-  const openaiApiKey = await getApiKey("OPENAI", session.user.id);
+  const firecrawlApiKey = await getApiKey("FIRECRAWL", user.id);
+  const openaiApiKey = await getApiKey("OPENAI", user.id);
   if (!firecrawlApiKey || !openaiApiKey) {
     return NextResponse.json({ error: "NO_API_KEY" }, { status: 402 });
   }
 
+  const authorized = await filterAuthorizedContactIds(user, contactIds);
+  if (authorized.length !== contactIds.length) {
+    return forbiddenResponse();
+  }
+
   await inngest.send({
     name: "enrich/contacts.bulk",
-    data: { contactIds, fields, triggeredBy: session.user.id },
+    data: { contactIds, fields, triggeredBy: user.id },
   });
 
   return NextResponse.json({ success: true, count: contactIds.length });

--- a/app/api/crm/contacts/enrich/__tests__/route.test.ts
+++ b/app/api/crm/contacts/enrich/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Contacts: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    crm_Contact_Enrichment: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+jest.mock("@/lib/api-keys", () => ({
+  getApiKey: jest.fn().mockResolvedValue("sk-test"),
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { POST, DELETE } from "../route";
+
+const mockedGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockedFindUser = prismadb.users.findUnique as jest.MockedFunction<
+  typeof prismadb.users.findUnique
+>;
+const mockedFindContactScope = prismadb.crm_Contacts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findFirst
+>;
+const mockedFindContact = prismadb.crm_Contacts.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findUnique
+>;
+const mockedFindEnrichment = prismadb.crm_Contact_Enrichment.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Contact_Enrichment.findUnique
+>;
+const mockedCreateEnrichment = prismadb.crm_Contact_Enrichment.create as jest.MockedFunction<
+  typeof prismadb.crm_Contact_Enrichment.create
+>;
+
+function makePostReq(body: unknown) {
+  return new NextRequest("http://localhost/api/crm/contacts/enrich", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/contacts/enrich", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const res = await POST(
+      makePostReq({ contactId: "c1", fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(401);
+    expect(mockedFindContact).not.toHaveBeenCalled();
+    expect(mockedCreateEnrichment).not.toHaveBeenCalled();
+  });
+
+  it("returns 403/404 when user does not own the contact (no DB write)", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "victim" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "victim", role: "user" } as any);
+    mockedFindContactScope.mockResolvedValue(null); // assertCanWriteContact throws
+    const res = await POST(
+      makePostReq({ contactId: "c1", fields: [{ name: "website" }] }),
+    );
+    expect([403, 404]).toContain(res.status);
+    expect(mockedFindContact).not.toHaveBeenCalled();
+    expect(mockedCreateEnrichment).not.toHaveBeenCalled();
+  });
+
+  it("manager can enrich any contact", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "m1" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "m1", role: "manager" } as any);
+    mockedFindContactScope.mockResolvedValue({ id: "c1" } as any);
+    mockedFindContact.mockResolvedValue({ id: "c1", email: "x@y.com" } as any);
+    mockedCreateEnrichment.mockResolvedValue({ id: "e1" } as any);
+
+    const res = await POST(
+      makePostReq({ contactId: "c1", fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedCreateEnrichment).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DELETE /api/crm/contacts/enrich", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const req = new NextRequest(
+      "http://localhost/api/crm/contacts/enrich?sessionId=missing",
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when sessionId not in activeSessions", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "u", role: "user" } as any);
+    const req = new NextRequest(
+      "http://localhost/api/crm/contacts/enrich?sessionId=ghost",
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req);
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/crm/contacts/enrich/route.ts
+++ b/app/api/crm/contacts/enrich/route.ts
@@ -1,11 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { AgentEnrichmentStrategy } from "@/lib/enrichment/strategies/agent-enrichment-strategy";
 import type { EnrichmentField } from "@/lib/enrichment/types";
 import type { StoredEnrichmentResult } from "@/lib/enrichment/types/stored-result";
 import { validateEnrichRequest } from "./validate";
 import { getApiKey } from "@/lib/api-keys";
+import {
+  requireAuthenticated,
+  assertCanWriteContact,
+  assertCanCancelContactEnrichment,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const runtime = "nodejs";
 
@@ -14,15 +22,12 @@ export const runtime = "nodejs";
 const activeSessions = new Map<string, { controller: AbortController; enrichmentId: string }>();
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const firecrawlApiKey = await getApiKey("FIRECRAWL", session.user.id);
-  const openaiApiKey = await getApiKey("OPENAI", session.user.id);
-  if (!firecrawlApiKey || !openaiApiKey) {
-    return NextResponse.json({ error: "NO_API_KEY" }, { status: 402 });
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
   }
 
   const body = await request.json();
@@ -31,6 +36,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: validationError }, { status: 400 });
   }
   const { contactId, fields } = body as { contactId: string; fields: EnrichmentField[] };
+
+  try {
+    await assertCanWriteContact(user, contactId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+
+  const firecrawlApiKey = await getApiKey("FIRECRAWL", user.id);
+  const openaiApiKey = await getApiKey("OPENAI", user.id);
+  if (!firecrawlApiKey || !openaiApiKey) {
+    return NextResponse.json({ error: "NO_API_KEY" }, { status: 402 });
+  }
 
   const contact = await prismadb.crm_Contacts.findUnique({
     where: { id: contactId },
@@ -52,7 +70,7 @@ export async function POST(request: NextRequest) {
       contactId,
       status: "RUNNING",
       fields: fields.map((f) => f.name),
-      triggeredBy: session.user.id,
+      triggeredBy: user.id,
     },
   });
 
@@ -124,6 +142,14 @@ export async function POST(request: NextRequest) {
 // ---- CANCEL ENDPOINT (DELETE /api/crm/contacts/enrich?sessionId=...) ----
 // Called by the drawer's Cancel button. Also triggered server-side via request.signal abort on disconnect.
 export async function DELETE(request: NextRequest) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
   const sessionId = new URL(request.url).searchParams.get("sessionId");
   if (!sessionId) {
     return NextResponse.json({ error: "sessionId required" }, { status: 400 });
@@ -131,7 +157,14 @@ export async function DELETE(request: NextRequest) {
 
   const entry = activeSessions.get(sessionId);
   if (!entry) {
-    return NextResponse.json({ error: "Session not found or already complete" }, { status: 404 });
+    return notFoundOrForbiddenResponse();
+  }
+
+  try {
+    await assertCanCancelContactEnrichment(user, entry.enrichmentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
   }
 
   entry.controller.abort();

--- a/app/api/crm/targets/[id]/contacts/[contactId]/enrich/__tests__/route.test.ts
+++ b/app/api/crm/targets/[id]/contacts/[contactId]/enrich/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+    crm_Target_Contact: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({}) },
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const ft = prismadb.crm_Targets.findFirst as jest.MockedFunction<typeof prismadb.crm_Targets.findFirst>;
+const ftc = (prismadb as any).crm_Target_Contact.findFirst as jest.MockedFunction<any>;
+const send = inngest.send as jest.MockedFunction<typeof inngest.send>;
+
+function makeReq() {
+  return new NextRequest(
+    "http://localhost/api/crm/targets/t1/contacts/c1/enrich",
+    { method: "POST" },
+  );
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/targets/[id]/contacts/[contactId]/enrich", () => {
+  it("401 when unauthenticated", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ id: "t1", contactId: "c1" }),
+    });
+    expect(res.status).toBe(401);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("404 when target not in scope", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    ft.mockResolvedValue(null);
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ id: "t1", contactId: "c1" }),
+    });
+    expect(res.status).toBe(404);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("404 when target-contact linkage check fails", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    ft.mockResolvedValue({ id: "t1" } as any);
+    ftc.mockResolvedValue(null);
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ id: "t1", contactId: "c1" }),
+    });
+    expect(res.status).toBe(404);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("200 when owner with valid linkage queues Inngest", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    ft.mockResolvedValue({ id: "t1" } as any);
+    ftc.mockResolvedValue({ id: "c1" } as any);
+    const res = await POST(makeReq(), {
+      params: Promise.resolve({ id: "t1", contactId: "c1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(ftc).toHaveBeenCalledWith({
+      where: { id: "c1", targetId: "t1" },
+      select: { id: true },
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "enrich/target.contact.run",
+        data: expect.objectContaining({ contactId: "c1", triggeredBy: "u" }),
+      }),
+    );
+  });
+});

--- a/app/api/crm/targets/[id]/contacts/[contactId]/enrich/route.ts
+++ b/app/api/crm/targets/[id]/contacts/[contactId]/enrich/route.ts
@@ -1,19 +1,45 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
 import { inngest } from "@/inngest/client";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(
   _request: NextRequest,
-  { params }: { params: Promise<{ id: string; contactId: string }> }
+  { params }: { params: Promise<{ id: string; contactId: string }> },
 ) {
-  const session = await getSession();
-  if (!session) return new NextResponse("Unauthorized", { status: 401 });
+  const { id: targetId, contactId } = await params;
 
-  const { contactId } = await params;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+
+  const link = await prismadb.crm_Target_Contact.findFirst({
+    where: { id: contactId, targetId },
+    select: { id: true },
+  });
+  if (!link) return notFoundOrForbiddenResponse();
 
   await inngest.send({
     name: "enrich/target.contact.run",
-    data: { contactId, triggeredBy: session.user.id },
+    data: { contactId, triggeredBy: user.id },
   });
 
   return NextResponse.json({ queued: true });

--- a/app/api/crm/targets/[id]/contacts/__tests__/route.test.ts
+++ b/app/api/crm/targets/[id]/contacts/__tests__/route.test.ts
@@ -1,0 +1,83 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+    crm_Target_Contact: { create: jest.fn() },
+  },
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { POST } from "../route";
+
+const mockedGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockedFindUniqueUser = prismadb.users.findUnique as jest.MockedFunction<
+  typeof prismadb.users.findUnique
+>;
+const mockedFindFirstTarget = prismadb.crm_Targets.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Targets.findFirst
+>;
+const mockedCreateTC = prismadb.crm_Target_Contact.create as jest.MockedFunction<
+  typeof prismadb.crm_Target_Contact.create
+>;
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/crm/targets/t1/contacts", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/targets/[id]/contacts", () => {
+  it("401 when unauthenticated and does not call create", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const res = await POST(makeReq({ name: "x" }), {
+      params: Promise.resolve({ id: "t1" }),
+    });
+    expect(res.status).toBe(401);
+    expect(mockedCreateTC).not.toHaveBeenCalled();
+  });
+
+  it("404 when user not in target scope and does not call create", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u1" } } as any);
+    mockedFindUniqueUser.mockResolvedValue({ id: "u1", role: "user" } as any);
+    mockedFindFirstTarget.mockResolvedValue(null as any);
+
+    const res = await POST(makeReq({ name: "x" }), {
+      params: Promise.resolve({ id: "t1" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockedCreateTC).not.toHaveBeenCalled();
+  });
+
+  it("200 when user owns the target", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u1" } } as any);
+    mockedFindUniqueUser.mockResolvedValue({ id: "u1", role: "user" } as any);
+    mockedFindFirstTarget.mockResolvedValue({ id: "t1" } as any);
+    mockedCreateTC.mockResolvedValue({ id: "tc1" } as any);
+
+    const res = await POST(makeReq({ name: "Alice" }), {
+      params: Promise.resolve({ id: "t1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockedCreateTC).toHaveBeenCalledTimes(1);
+  });
+
+  it("200 when manager on any target", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "m1" } } as any);
+    mockedFindUniqueUser.mockResolvedValue({ id: "m1", role: "manager" } as any);
+    mockedFindFirstTarget.mockResolvedValue({ id: "t1" } as any);
+    mockedCreateTC.mockResolvedValue({ id: "tc1" } as any);
+
+    const res = await POST(makeReq({ email: "a@b.c" }), {
+      params: Promise.resolve({ id: "t1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockedCreateTC).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/crm/targets/[id]/contacts/route.ts
+++ b/app/api/crm/targets/[id]/contacts/route.ts
@@ -1,15 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getSession();
-  if (!session) return new NextResponse("Unauthorized", { status: 401 });
-
   const { id: targetId } = await params;
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+
   const { name, email, phone, linkedinUrl } = await request.json() as {
     name?: string; email?: string; phone?: string; linkedinUrl?: string;
   };

--- a/app/api/crm/targets/[id]/enrich/__tests__/route.test.ts
+++ b/app/api/crm/targets/[id]/enrich/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({}) },
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const ft = prismadb.crm_Targets.findFirst as jest.MockedFunction<typeof prismadb.crm_Targets.findFirst>;
+const send = inngest.send as jest.MockedFunction<typeof inngest.send>;
+
+function makeReq(body: unknown = {}) {
+  return new NextRequest("http://localhost/api/crm/targets/t1/enrich", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/targets/[id]/enrich", () => {
+  it("401 unauth", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await POST(makeReq(), { params: Promise.resolve({ id: "t1" }) });
+    expect(res.status).toBe(401);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("404 when user does not own target", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    ft.mockResolvedValue(null);
+    const res = await POST(makeReq(), { params: Promise.resolve({ id: "t1" }) });
+    expect(res.status).toBe(404);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("user owning target queues Inngest", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    ft.mockResolvedValue({ id: "t1" } as any);
+    const res = await POST(makeReq(), { params: Promise.resolve({ id: "t1" }) });
+    expect(res.status).toBe(200);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "enrich/target.run",
+        data: expect.objectContaining({ targetId: "t1", triggeredBy: "u" }),
+      }),
+    );
+  });
+});

--- a/app/api/crm/targets/[id]/enrich/route.ts
+++ b/app/api/crm/targets/[id]/enrich/route.ts
@@ -1,21 +1,36 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { inngest } from "@/inngest/client";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const session = await getSession();
-  if (!session) return new NextResponse("Unauthorized", { status: 401 });
-
-  const { id: targetId } = await params;
-  const body = await request.json().catch(() => ({})) as { force?: boolean };
-
+  const { id } = await params;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+  const body = await request.json().catch(() => ({}));
   await inngest.send({
     name: "enrich/target.run",
-    data: { targetId, triggeredBy: session.user.id, force: body.force ?? false },
+    data: { targetId: id, triggeredBy: user.id, force: body.force ?? false },
   });
-
   return NextResponse.json({ queued: true });
 }

--- a/app/api/crm/targets/enrich-bulk/__tests__/route.test.ts
+++ b/app/api/crm/targets/enrich-bulk/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: { findMany: jest.fn() },
+  },
+}));
+jest.mock("@/lib/api-keys", () => ({
+  getApiKey: jest.fn().mockResolvedValue("sk-test"),
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({ ids: ["1"] }) },
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const mockedGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockedUser = prismadb.users.findUnique as jest.MockedFunction<
+  typeof prismadb.users.findUnique
+>;
+const mockedFindMany = prismadb.crm_Targets.findMany as jest.MockedFunction<
+  typeof prismadb.crm_Targets.findMany
+>;
+const mockedSend = inngest.send as jest.MockedFunction<typeof inngest.send>;
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/crm/targets/enrich-bulk", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/targets/enrich-bulk", () => {
+  it("401 unauth", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const res = await POST(makeReq({ targetIds: ["a"], fields: [{ name: "company_website" }] }));
+    expect(res.status).toBe(401);
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it("403 when any target id is unauthorized (fail-closed)", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u" } } as any);
+    mockedUser.mockResolvedValue({ id: "u", role: "user" } as any);
+    mockedFindMany.mockResolvedValue([{ id: "a" }] as any);
+    const res = await POST(
+      makeReq({ targetIds: ["a", "b"], fields: [{ name: "company_website" }] }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it("succeeds + sends Inngest event when all ids authorized", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "m" } } as any);
+    mockedUser.mockResolvedValue({ id: "m", role: "manager" } as any);
+    mockedFindMany.mockResolvedValue([{ id: "a" }, { id: "b" }] as any);
+    const res = await POST(
+      makeReq({ targetIds: ["a", "b"], fields: [{ name: "company_website" }] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "enrich/targets.bulk",
+        data: expect.objectContaining({
+          targetIds: ["a", "b"],
+          triggeredBy: "m",
+        }),
+      }),
+    );
+  });
+});

--- a/app/api/crm/targets/enrich-bulk/route.ts
+++ b/app/api/crm/targets/enrich-bulk/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
 import { inngest } from "@/inngest/client";
 import { getApiKey } from "@/lib/api-keys";
 import { FIELD_MAP } from "@/lib/enrichment/presets/target-fields";
 import type { EnrichmentField } from "@/lib/enrichment/types";
+import {
+  requireAuthenticated,
+  filterAuthorizedTargetIds,
+  unauthorizedResponse,
+  forbiddenResponse,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
   }
 
   const { targetIds, fields } = await request.json();
@@ -33,15 +42,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const firecrawlApiKey = await getApiKey("FIRECRAWL", session.user.id);
-  const openaiApiKey = await getApiKey("OPENAI", session.user.id);
+  const firecrawlApiKey = await getApiKey("FIRECRAWL", user.id);
+  const openaiApiKey = await getApiKey("OPENAI", user.id);
   if (!firecrawlApiKey || !openaiApiKey) {
     return NextResponse.json({ error: "NO_API_KEY" }, { status: 402 });
   }
 
+  const authorized = await filterAuthorizedTargetIds(user, targetIds);
+  if (authorized.length !== targetIds.length) {
+    return forbiddenResponse();
+  }
+
   await inngest.send({
     name: "enrich/targets.bulk",
-    data: { targetIds, fields, triggeredBy: session.user.id },
+    data: { targetIds, fields, triggeredBy: user.id },
   });
 
   return NextResponse.json({ success: true, count: targetIds.length });

--- a/app/api/crm/targets/enrich/__tests__/route.test.ts
+++ b/app/api/crm/targets/enrich/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    crm_Target_Enrichment: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+jest.mock("@/lib/api-keys", () => ({
+  getApiKey: jest.fn().mockResolvedValue("sk-test"),
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { POST, DELETE } from "../route";
+
+const mockedGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockedFindUser = prismadb.users.findUnique as jest.MockedFunction<
+  typeof prismadb.users.findUnique
+>;
+const mockedFindTargetScope = prismadb.crm_Targets.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Targets.findFirst
+>;
+const mockedFindTarget = prismadb.crm_Targets.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Targets.findUnique
+>;
+const mockedFindEnrichment = prismadb.crm_Target_Enrichment.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Target_Enrichment.findUnique
+>;
+const mockedCreateEnrichment = prismadb.crm_Target_Enrichment.create as jest.MockedFunction<
+  typeof prismadb.crm_Target_Enrichment.create
+>;
+
+function makePostReq(body: unknown) {
+  return new NextRequest("http://localhost/api/crm/targets/enrich", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/targets/enrich", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const res = await POST(
+      makePostReq({ targetId: "t1", fields: [{ name: "position" }] }),
+    );
+    expect(res.status).toBe(401);
+    expect(mockedFindTarget).not.toHaveBeenCalled();
+    expect(mockedCreateEnrichment).not.toHaveBeenCalled();
+  });
+
+  it("returns 403/404 when user does not own the target (no DB write)", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "victim" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "victim", role: "user" } as any);
+    mockedFindTargetScope.mockResolvedValue(null); // assertCanWriteTarget throws
+    const res = await POST(
+      makePostReq({ targetId: "t1", fields: [{ name: "position" }] }),
+    );
+    expect([403, 404]).toContain(res.status);
+    expect(mockedFindTarget).not.toHaveBeenCalled();
+    expect(mockedCreateEnrichment).not.toHaveBeenCalled();
+  });
+
+  it("manager can enrich any target", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "m1" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "m1", role: "manager" } as any);
+    mockedFindTargetScope.mockResolvedValue({ id: "t1" } as any);
+    mockedFindTarget.mockResolvedValue({
+      id: "t1",
+      email: "x@y.com",
+      company: "Acme",
+      company_website: "https://acme.com",
+    } as any);
+    mockedCreateEnrichment.mockResolvedValue({ id: "e1" } as any);
+
+    const res = await POST(
+      makePostReq({ targetId: "t1", fields: [{ name: "position" }] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedCreateEnrichment).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DELETE /api/crm/targets/enrich", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const req = new NextRequest(
+      "http://localhost/api/crm/targets/enrich?sessionId=missing",
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when sessionId not in activeSessions", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "u", role: "user" } as any);
+    const req = new NextRequest(
+      "http://localhost/api/crm/targets/enrich?sessionId=ghost",
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req);
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/crm/targets/enrich/route.ts
+++ b/app/api/crm/targets/enrich/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { AgentEnrichmentStrategy } from "@/lib/enrichment/strategies/agent-enrichment-strategy";
 import type { EnrichmentField } from "@/lib/enrichment/types";
@@ -7,21 +6,27 @@ import type { StoredEnrichmentResult } from "@/lib/enrichment/types/stored-resul
 import { validateEnrichRequest } from "./validate";
 import { getApiKey } from "@/lib/api-keys";
 import { FIELD_MAP } from "@/lib/enrichment/presets/target-fields";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  assertCanCancelTargetEnrichment,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const runtime = "nodejs";
 
 const activeSessions = new Map<string, { controller: AbortController; enrichmentId: string }>();
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const firecrawlApiKey = await getApiKey("FIRECRAWL", session.user.id);
-  const openaiApiKey = await getApiKey("OPENAI", session.user.id);
-  if (!firecrawlApiKey || !openaiApiKey) {
-    return NextResponse.json({ error: "NO_API_KEY" }, { status: 402 });
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
   }
 
   const body = await request.json();
@@ -38,6 +43,19 @@ export async function POST(request: NextRequest) {
       { error: `Unknown fields: ${invalidFields.map((f) => f.name).join(", ")}` },
       { status: 400 }
     );
+  }
+
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+
+  const firecrawlApiKey = await getApiKey("FIRECRAWL", user.id);
+  const openaiApiKey = await getApiKey("OPENAI", user.id);
+  if (!firecrawlApiKey || !openaiApiKey) {
+    return NextResponse.json({ error: "NO_API_KEY" }, { status: 402 });
   }
 
   const target = await prismadb.crm_Targets.findUnique({
@@ -63,7 +81,7 @@ export async function POST(request: NextRequest) {
       targetId,
       status: "RUNNING",
       fields: fields.map((f) => f.name),
-      triggeredBy: session.user.id,
+      triggeredBy: user.id,
     },
   });
 
@@ -137,6 +155,14 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
   const sessionId = new URL(request.url).searchParams.get("sessionId");
   if (!sessionId) {
     return NextResponse.json({ error: "sessionId required" }, { status: 400 });
@@ -145,6 +171,13 @@ export async function DELETE(request: NextRequest) {
   const entry = activeSessions.get(sessionId);
   if (!entry) {
     return NextResponse.json({ error: "Session not found or already complete" }, { status: 404 });
+  }
+
+  try {
+    await assertCanCancelTargetEnrichment(user, entry.enrichmentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
   }
 
   entry.controller.abort();

--- a/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b1.md
+++ b/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b1.md
@@ -1,0 +1,1425 @@
+# Permission-Driven Authorization — Phase B1 (Enrichment Routes) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining BOLA/IDOR findings on every enrichment-related API route (CRM contacts + targets, bulk variants, target sub-routes, campaign re-exports). After B1 lands, no authenticated user can read, enrich, or cancel an enrichment for a record they don't own — and the spec's "verify scope before queueing Inngest events" rule is enforced at the route boundary.
+
+**Architecture:** Extend `lib/authz/scopes/crm.ts` with read-side and bulk-filter helpers + enrichment cancel helpers. Apply them as the first authorization step in every enrichment route. For cancels, use **approach (b)**: look up the in-flight `enrichmentId` from the existing in-memory `activeSessions` map, load the enrichment row, and check `triggeredBy === user.id` (manager/admin pass through). Bulk routes fail-closed: if any requested ID isn't authorized, return 403 — do not silently filter.
+
+**Out of scope:** Inngest worker re-validation (workers will keep trusting `triggeredBy` from event payload — Phase B addresses route boundary; worker hardening is a separate follow-up). Read-side scoping for non-enrichment routes (Phase D). Invoice PDF (B2). Reports export (B3).
+
+**Tech Stack:** Next.js 16, Prisma 7, Better Auth 1.5, Jest 30 + ts-jest. Same as Phase A.
+
+**Spec source:** `docs/specs/2026-05-01-permission-driven-migration-design.md` §7.4–7.5, §12 Phase 2.
+**Audit source:** `docs/2026-05-01-bola-idor-security-audit.md` "Target Enrichment Surfaces", "Bulk Contact Enrichment for Arbitrary IDs", "Contact Enrichment for Arbitrary Contact", "Unauthenticated Contact Enrichment Cancel".
+
+---
+
+## File Structure
+
+**New files:**
+- `lib/authz/__tests__/scopes-crm-read.test.ts` — tests for new read/write/filter assertions
+- `lib/authz/__tests__/scopes-crm-enrichment.test.ts` — tests for cancel-permission helpers
+- `app/api/crm/contacts/enrich/__tests__/route.test.ts`
+- `app/api/crm/contacts/enrich-bulk/__tests__/route.test.ts`
+- `app/api/crm/targets/enrich/__tests__/route.test.ts`
+- `app/api/crm/targets/enrich-bulk/__tests__/route.test.ts`
+- `app/api/crm/targets/[id]/enrich/__tests__/route.test.ts`
+- `app/api/crm/targets/[id]/contacts/__tests__/route.test.ts`
+- `app/api/crm/targets/[id]/contacts/[contactId]/enrich/__tests__/route.test.ts`
+
+**Modified files:**
+- `lib/authz/scopes/crm.ts` — add `assertCanReadContact`, `assertCanWriteContact`, `assertCanReadTarget`, `assertCanWriteTarget`, `filterAuthorizedContactIds`, `filterAuthorizedTargetIds`, `assertCanCancelContactEnrichment`, `assertCanCancelTargetEnrichment`
+- `lib/authz/index.ts` — barrel re-exports
+- `app/api/crm/contacts/enrich/route.ts` — POST + DELETE
+- `app/api/crm/contacts/enrich-bulk/route.ts` — POST
+- `app/api/crm/targets/enrich/route.ts` — POST + DELETE
+- `app/api/crm/targets/enrich-bulk/route.ts` — POST
+- `app/api/crm/targets/[id]/enrich/route.ts` — POST
+- `app/api/crm/targets/[id]/contacts/route.ts` — POST
+- `app/api/crm/targets/[id]/contacts/[contactId]/enrich/route.ts` — POST
+
+Campaign re-exports (`app/api/campaigns/targets/[id]/enrich`, `enrich`, `enrich-bulk`) require no source change — fixed by source.
+
+---
+
+## Task 1: Read/write assertion helpers (contact + target)
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts`
+- Create: `lib/authz/__tests__/scopes-crm-read.test.ts`
+
+Add four assertion helpers. They throw `AuthorizationError` if the user can't access the row, or `Error("not found")` if the row doesn't exist. Manager/admin always pass.
+
+- [ ] **Step 1: Write the failing test**
+
+`lib/authz/__tests__/scopes-crm-read.test.ts`:
+```ts
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contacts: { findFirst: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  assertCanReadContact,
+  assertCanWriteContact,
+  assertCanReadTarget,
+  assertCanWriteTarget,
+} from "../scopes/crm";
+
+const findContact = prismadb.crm_Contacts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findFirst
+>;
+const findTarget = prismadb.crm_Targets.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Targets.findFirst
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanReadContact", () => {
+  it("admin: bare where, resolves on hit", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await expect(
+      assertCanReadContact({ id: "u", role: "admin" }, "c1"),
+    ).resolves.toBeUndefined();
+    expect(findContact).toHaveBeenCalledWith({
+      where: { id: "c1" },
+      select: { id: true },
+    });
+  });
+
+  it("manager: bare where, resolves on hit", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await assertCanReadContact({ id: "u", role: "manager" }, "c1");
+    expect(findContact).toHaveBeenCalledWith({
+      where: { id: "c1" },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped where with ownership OR clauses", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await assertCanReadContact({ id: "u3", role: "user" }, "c1");
+    const arg = findContact.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({
+      id: "c1",
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { created_by: "u3" },
+        { createdBy: "u3" },
+      ]),
+    });
+  });
+
+  it("throws AuthorizationError when no row", async () => {
+    findContact.mockResolvedValue(null);
+    await expect(
+      assertCanReadContact({ id: "u3", role: "user" }, "c1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteContact", () => {
+  it("user: same scope as read for now (Phase D may diverge)", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await assertCanWriteContact({ id: "u3", role: "user" }, "c1");
+    const arg = findContact.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({
+      id: "c1",
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { created_by: "u3" },
+        { createdBy: "u3" },
+      ]),
+    });
+  });
+
+  it("throws AuthorizationError when no row", async () => {
+    findContact.mockResolvedValue(null);
+    await expect(
+      assertCanWriteContact({ id: "u3", role: "user" }, "c1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanReadTarget", () => {
+  it("admin: bare where", async () => {
+    findTarget.mockResolvedValue({ id: "t1" } as any);
+    await assertCanReadTarget({ id: "u", role: "admin" }, "t1");
+    expect(findTarget).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped to created_by", async () => {
+    findTarget.mockResolvedValue({ id: "t1" } as any);
+    await assertCanReadTarget({ id: "u3", role: "user" }, "t1");
+    expect(findTarget).toHaveBeenCalledWith({
+      where: { id: "t1", created_by: "u3" },
+      select: { id: true },
+    });
+  });
+
+  it("throws AuthorizationError on miss", async () => {
+    findTarget.mockResolvedValue(null);
+    await expect(
+      assertCanReadTarget({ id: "u3", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteTarget", () => {
+  it("user: scoped to created_by", async () => {
+    findTarget.mockResolvedValue({ id: "t1" } as any);
+    await assertCanWriteTarget({ id: "u3", role: "user" }, "t1");
+    expect(findTarget).toHaveBeenCalledWith({
+      where: { id: "t1", created_by: "u3" },
+      select: { id: true },
+    });
+  });
+
+  it("throws on miss", async () => {
+    findTarget.mockResolvedValue(null);
+    await expect(
+      assertCanWriteTarget({ id: "u3", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+pnpm jest lib/authz/__tests__/scopes-crm-read.test.ts
+```
+Expected: FAIL — helpers don't exist yet.
+
+- [ ] **Step 3: Extend `lib/authz/scopes/crm.ts`**
+
+Append to the file (before any existing exports if exports are at the bottom — otherwise just append at the end):
+
+```ts
+import { AuthorizationError } from "../errors";
+
+// Read scope mirrors write scope in Phase B1.
+// Phase D may add separate read-only ownership rules (e.g., watchers).
+async function findContactInScope(user: AuthzUser, contactId: string) {
+  if (user.role === "admin" || user.role === "manager") {
+    return prismadb.crm_Contacts.findFirst({
+      where: { id: contactId },
+      select: { id: true },
+    });
+  }
+  return prismadb.crm_Contacts.findFirst({
+    where: {
+      id: contactId,
+      OR: [
+        { assigned_to: user.id },
+        { created_by: user.id },
+        { createdBy: user.id },
+      ],
+    },
+    select: { id: true },
+  });
+}
+
+async function findTargetInScope(user: AuthzUser, targetId: string) {
+  if (user.role === "admin" || user.role === "manager") {
+    return prismadb.crm_Targets.findFirst({
+      where: { id: targetId },
+      select: { id: true },
+    });
+  }
+  return prismadb.crm_Targets.findFirst({
+    where: { id: targetId, created_by: user.id },
+    select: { id: true },
+  });
+}
+
+export async function assertCanReadContact(
+  user: AuthzUser,
+  contactId: string,
+): Promise<void> {
+  const row = await findContactInScope(user, contactId);
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteContact(
+  user: AuthzUser,
+  contactId: string,
+): Promise<void> {
+  const row = await findContactInScope(user, contactId);
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanReadTarget(
+  user: AuthzUser,
+  targetId: string,
+): Promise<void> {
+  const row = await findTargetInScope(user, targetId);
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteTarget(
+  user: AuthzUser,
+  targetId: string,
+): Promise<void> {
+  const row = await findTargetInScope(user, targetId);
+  if (!row) throw new AuthorizationError();
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+pnpm jest lib/authz/__tests__/scopes-crm-read.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Re-export from barrel**
+
+Add to `lib/authz/index.ts`:
+```ts
+export {
+  assertCanReadContact,
+  assertCanWriteContact,
+  assertCanReadTarget,
+  assertCanWriteTarget,
+} from "./scopes/crm";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/authz/scopes/crm.ts lib/authz/__tests__/scopes-crm-read.test.ts lib/authz/index.ts
+git commit -m "feat(authz): add read/write assertion helpers for contacts and targets"
+```
+
+---
+
+## Task 2: Bulk filter helpers
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts`
+- Modify: `lib/authz/__tests__/scopes-crm-read.test.ts` (or new file — implementer's choice)
+
+`filterAuthorizedContactIds(user, ids)` and `filterAuthorizedTargetIds(user, ids)` return the **subset** of input ids that the user is authorized to read/enrich. Routes will compare `result.length === input.length` and reject the whole request if any id is unauthorized (fail-closed per spec §7.5).
+
+- [ ] **Step 1: Write the failing test (append to scopes-crm-read.test.ts)**
+
+```ts
+describe("filterAuthorizedContactIds", () => {
+  it("admin: returns all input ids that exist (queries with bare where)", async () => {
+    (prismadb.crm_Contacts.findMany as jest.Mock) =
+      jest.fn().mockResolvedValue([{ id: "a" }, { id: "b" }]);
+    const out = await filterAuthorizedContactIds(
+      { id: "u", role: "admin" },
+      ["a", "b", "c"],
+    );
+    expect(out).toEqual(["a", "b"]);
+    expect(prismadb.crm_Contacts.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["a", "b", "c"] } },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped where with OR clauses", async () => {
+    (prismadb.crm_Contacts.findMany as jest.Mock) =
+      jest.fn().mockResolvedValue([{ id: "a" }]);
+    await filterAuthorizedContactIds(
+      { id: "u3", role: "user" },
+      ["a", "b"],
+    );
+    const arg = (prismadb.crm_Contacts.findMany as jest.Mock).mock.calls[0][0];
+    expect(arg.where).toMatchObject({
+      id: { in: ["a", "b"] },
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { created_by: "u3" },
+        { createdBy: "u3" },
+      ]),
+    });
+  });
+
+  it("returns empty array when input is empty (no DB call)", async () => {
+    const fn = jest.fn();
+    (prismadb.crm_Contacts.findMany as jest.Mock) = fn;
+    const out = await filterAuthorizedContactIds(
+      { id: "u", role: "user" },
+      [],
+    );
+    expect(out).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe("filterAuthorizedTargetIds", () => {
+  it("user: scoped to created_by", async () => {
+    (prismadb.crm_Targets.findMany as jest.Mock) =
+      jest.fn().mockResolvedValue([{ id: "t1" }]);
+    await filterAuthorizedTargetIds({ id: "u3", role: "user" }, ["t1", "t2"]);
+    expect(prismadb.crm_Targets.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1", "t2"] }, created_by: "u3" },
+      select: { id: true },
+    });
+  });
+});
+```
+
+Also add to the imports at the top of the test file:
+```ts
+import {
+  // existing imports...
+  filterAuthorizedContactIds,
+  filterAuthorizedTargetIds,
+} from "../scopes/crm";
+```
+
+And to the prisma mock at the top:
+```ts
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contacts: { findFirst: jest.fn(), findMany: jest.fn() },
+    crm_Targets: { findFirst: jest.fn(), findMany: jest.fn() },
+  },
+}));
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+pnpm jest lib/authz/__tests__/scopes-crm-read.test.ts
+```
+Expected: FAIL — helpers don't exist.
+
+- [ ] **Step 3: Implement in `lib/authz/scopes/crm.ts`**
+
+Append:
+```ts
+export async function filterAuthorizedContactIds(
+  user: AuthzUser,
+  contactIds: string[],
+): Promise<string[]> {
+  if (contactIds.length === 0) return [];
+  const baseWhere =
+    user.role === "admin" || user.role === "manager"
+      ? { id: { in: contactIds } }
+      : {
+          id: { in: contactIds },
+          OR: [
+            { assigned_to: user.id },
+            { created_by: user.id },
+            { createdBy: user.id },
+          ],
+        };
+  const rows = await prismadb.crm_Contacts.findMany({
+    where: baseWhere,
+    select: { id: true },
+  });
+  return rows.map((r) => r.id);
+}
+
+export async function filterAuthorizedTargetIds(
+  user: AuthzUser,
+  targetIds: string[],
+): Promise<string[]> {
+  if (targetIds.length === 0) return [];
+  const baseWhere =
+    user.role === "admin" || user.role === "manager"
+      ? { id: { in: targetIds } }
+      : { id: { in: targetIds }, created_by: user.id };
+  const rows = await prismadb.crm_Targets.findMany({
+    where: baseWhere,
+    select: { id: true },
+  });
+  return rows.map((r) => r.id);
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+pnpm jest lib/authz/__tests__/scopes-crm-read.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add to barrel**
+
+Append to `lib/authz/index.ts`:
+```ts
+export {
+  filterAuthorizedContactIds,
+  filterAuthorizedTargetIds,
+} from "./scopes/crm";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/authz/scopes/crm.ts lib/authz/__tests__/scopes-crm-read.test.ts lib/authz/index.ts
+git commit -m "feat(authz): add bulk-id authorization filters for contacts and targets"
+```
+
+---
+
+## Task 3: Enrichment cancel helpers
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts`
+- Create: `lib/authz/__tests__/scopes-crm-enrichment.test.ts`
+
+`assertCanCancelContactEnrichment(user, enrichmentId)` and `assertCanCancelTargetEnrichment(user, enrichmentId)` load the enrichment row, check it exists, and check `triggeredBy === user.id` OR user is manager/admin. Throw `AuthorizationError` otherwise.
+
+- [ ] **Step 1: Write the failing test**
+
+`lib/authz/__tests__/scopes-crm-enrichment.test.ts`:
+```ts
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contact_Enrichment: { findUnique: jest.fn() },
+    crm_Target_Enrichment: { findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  assertCanCancelContactEnrichment,
+  assertCanCancelTargetEnrichment,
+} from "../scopes/crm";
+
+const findContactE = prismadb.crm_Contact_Enrichment.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Contact_Enrichment.findUnique
+>;
+const findTargetE = prismadb.crm_Target_Enrichment.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Target_Enrichment.findUnique
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanCancelContactEnrichment", () => {
+  it("throws when enrichment not found", async () => {
+    findContactE.mockResolvedValue(null);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "u", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("user: passes when triggeredBy matches", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: "u1" } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("user: throws when triggeredBy is someone else", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: "other" } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("manager: passes regardless of triggeredBy", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: "other" } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "m1", role: "manager" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("admin: passes regardless of triggeredBy", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: null } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "a1", role: "admin" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertCanCancelTargetEnrichment", () => {
+  it("user: passes when triggeredBy matches", async () => {
+    findTargetE.mockResolvedValue({ id: "e1", triggeredBy: "u1" } as any);
+    await expect(
+      assertCanCancelTargetEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("user: throws when triggeredBy is someone else", async () => {
+    findTargetE.mockResolvedValue({ id: "e1", triggeredBy: "other" } as any);
+    await expect(
+      assertCanCancelTargetEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws when not found", async () => {
+    findTargetE.mockResolvedValue(null);
+    await expect(
+      assertCanCancelTargetEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+pnpm jest lib/authz/__tests__/scopes-crm-enrichment.test.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement in `lib/authz/scopes/crm.ts`**
+
+Append:
+```ts
+export async function assertCanCancelContactEnrichment(
+  user: AuthzUser,
+  enrichmentId: string,
+): Promise<void> {
+  const row = await prismadb.crm_Contact_Enrichment.findUnique({
+    where: { id: enrichmentId },
+    select: { id: true, triggeredBy: true },
+  });
+  if (!row) throw new AuthorizationError();
+  if (user.role === "admin" || user.role === "manager") return;
+  if (row.triggeredBy !== user.id) throw new AuthorizationError();
+}
+
+export async function assertCanCancelTargetEnrichment(
+  user: AuthzUser,
+  enrichmentId: string,
+): Promise<void> {
+  const row = await prismadb.crm_Target_Enrichment.findUnique({
+    where: { id: enrichmentId },
+    select: { id: true, triggeredBy: true },
+  });
+  if (!row) throw new AuthorizationError();
+  if (user.role === "admin" || user.role === "manager") return;
+  if (row.triggeredBy !== user.id) throw new AuthorizationError();
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+pnpm jest lib/authz/__tests__/scopes-crm-enrichment.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add to barrel**
+
+Append to `lib/authz/index.ts`:
+```ts
+export {
+  assertCanCancelContactEnrichment,
+  assertCanCancelTargetEnrichment,
+} from "./scopes/crm";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/authz/scopes/crm.ts lib/authz/__tests__/scopes-crm-enrichment.test.ts lib/authz/index.ts
+git commit -m "feat(authz): add enrichment cancel permission helpers"
+```
+
+---
+
+## Task 4: Patch contact stream enrichment route (POST + DELETE)
+
+**Files:**
+- Modify: `app/api/crm/contacts/enrich/route.ts`
+- Create: `app/api/crm/contacts/enrich/__tests__/route.test.ts`
+
+The current POST creates a `crm_Contact_Enrichment` row for any session user against any contact id. Add `assertCanWriteContact` BEFORE both the contact lookup and the enrichment-row create. The current DELETE has no auth at all — add `requireAuthenticated` + `assertCanCancelContactEnrichment` against the enrichmentId from `activeSessions`.
+
+The route exports `runtime = "nodejs"` and a streaming POST. Keep all existing streaming behavior unchanged — only add authorization gates before any side-effect.
+
+- [ ] **Step 1: Write the failing tests**
+
+`app/api/crm/contacts/enrich/__tests__/route.test.ts`:
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Contacts: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    crm_Contact_Enrichment: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+jest.mock("@/lib/api-keys", () => ({
+  getApiKey: jest.fn().mockResolvedValue("sk-test"),
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { POST, DELETE } from "../route";
+
+const mockedGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockedFindUser = prismadb.users.findUnique as jest.MockedFunction<
+  typeof prismadb.users.findUnique
+>;
+const mockedFindContactScope = prismadb.crm_Contacts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findFirst
+>;
+const mockedFindContact = prismadb.crm_Contacts.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findUnique
+>;
+const mockedFindEnrichment = prismadb.crm_Contact_Enrichment.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Contact_Enrichment.findUnique
+>;
+const mockedCreateEnrichment = prismadb.crm_Contact_Enrichment.create as jest.MockedFunction<
+  typeof prismadb.crm_Contact_Enrichment.create
+>;
+
+function makePostReq(body: unknown) {
+  return new NextRequest("http://localhost/api/crm/contacts/enrich", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/contacts/enrich", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const res = await POST(
+      makePostReq({ contactId: "c1", fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(401);
+    expect(mockedFindContact).not.toHaveBeenCalled();
+    expect(mockedCreateEnrichment).not.toHaveBeenCalled();
+  });
+
+  it("returns 403/404 when user does not own the contact (no DB write)", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "victim" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "victim", role: "user" } as any);
+    mockedFindContactScope.mockResolvedValue(null); // assertCanWriteContact throws
+    const res = await POST(
+      makePostReq({ contactId: "c1", fields: [{ name: "website" }] }),
+    );
+    expect([403, 404]).toContain(res.status);
+    expect(mockedFindContact).not.toHaveBeenCalled();
+    expect(mockedCreateEnrichment).not.toHaveBeenCalled();
+  });
+
+  it("manager can enrich any contact", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "m1" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "m1", role: "manager" } as any);
+    mockedFindContactScope.mockResolvedValue({ id: "c1" } as any);
+    mockedFindContact.mockResolvedValue({ id: "c1", email: "x@y.com" } as any);
+    mockedCreateEnrichment.mockResolvedValue({ id: "e1" } as any);
+
+    const res = await POST(
+      makePostReq({ contactId: "c1", fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedCreateEnrichment).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DELETE /api/crm/contacts/enrich", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const req = new NextRequest(
+      "http://localhost/api/crm/contacts/enrich?sessionId=missing",
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when sessionId not in activeSessions", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u" } } as any);
+    mockedFindUser.mockResolvedValue({ id: "u", role: "user" } as any);
+    const req = new NextRequest(
+      "http://localhost/api/crm/contacts/enrich?sessionId=ghost",
+      { method: "DELETE" },
+    );
+    const res = await DELETE(req);
+    expect(res.status).toBe(404);
+  });
+
+  // Note: positive-path cancel tests would require seeding activeSessions
+  // (module-internal). For coverage, the unit tests here verify the auth
+  // gates; an integration test in __tests__/enrichment/ would cover the
+  // full flow. That's out of B1 scope.
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+pnpm jest 'app/api/crm/contacts/enrich/__tests__/route.test.ts'
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Patch the route**
+
+`app/api/crm/contacts/enrich/route.ts` — replace the auth section of POST and add a real DELETE guard. Pseudocode for the changes (apply to actual file structure):
+
+POST:
+1. After `getSession()` 401 check, call `requireAuthenticated()` from `@/lib/authz`.
+2. Replace direct `getSession()` with the result of `requireAuthenticated()` for `triggeredBy`. (Or call both — `requireAuthenticated` already calls `getSession`.)
+3. **Before** the `prismadb.crm_Contacts.findUnique` lookup that reads `email`, call `assertCanWriteContact(user, contactId)`. If it throws `AuthorizationError`, return `notFoundOrForbiddenResponse()`.
+4. Pass `user.id` as `triggeredBy` (not `session.user.id`).
+
+DELETE:
+1. Call `requireAuthenticated()`. On `AuthenticationError`, return `unauthorizedResponse()`.
+2. Look up `sessionId` from query, then look up `activeSessions.get(sessionId)`. If not found, return 404 (`notFoundOrForbiddenResponse`).
+3. Call `assertCanCancelContactEnrichment(user, entry.enrichmentId)`. On `AuthorizationError`, return `notFoundOrForbiddenResponse()`.
+4. Then proceed with the existing update-and-abort logic.
+
+Concrete handler header (replace the current POST opener):
+```ts
+import {
+  requireAuthenticated,
+  assertCanWriteContact,
+  assertCanCancelContactEnrichment,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+export async function POST(request: NextRequest) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
+  const body = await request.json();
+  const { contactId, fields } = body;
+  if (!validateEnrichRequest({ contactId, fields })) {
+    return NextResponse.json({ error: "contactId and fields required" }, { status: 400 });
+  }
+
+  try {
+    await assertCanWriteContact(user, contactId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+
+  // existing API key checks below (unchanged) — but pass user.id instead of session.user.id
+  const firecrawl = await getApiKey("FIRECRAWL", user.id);
+  // ...
+  const contact = await prismadb.crm_Contacts.findUnique({
+    where: { id: contactId },
+    select: { id: true, email: true },
+  });
+  if (!contact || !contact.email) {
+    return NextResponse.json({ error: "Contact not found or has no email" }, { status: 404 });
+  }
+  const enrichment = await prismadb.crm_Contact_Enrichment.create({
+    data: {
+      contactId,
+      status: "RUNNING",
+      fields: fields.map((f) => f.name),
+      triggeredBy: user.id,
+    },
+  });
+  // ... rest of streaming setup unchanged
+}
+```
+
+DELETE:
+```ts
+export async function DELETE(request: NextRequest) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
+  const { searchParams } = new URL(request.url);
+  const sessionId = searchParams.get("sessionId");
+  if (!sessionId) {
+    return NextResponse.json({ error: "sessionId required" }, { status: 400 });
+  }
+  const entry = activeSessions.get(sessionId);
+  if (!entry) return notFoundOrForbiddenResponse();
+
+  try {
+    await assertCanCancelContactEnrichment(user, entry.enrichmentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+
+  entry.controller.abort();
+  await prismadb.crm_Contact_Enrichment.update({
+    where: { id: entry.enrichmentId },
+    data: { status: "FAILED", error: "Cancelled by user" },
+  });
+  activeSessions.delete(sessionId);
+  return NextResponse.json({ success: true });
+}
+```
+
+Preserve every other line of the streaming POST (SSE setup, AbortController, Inngest invoke, etc.). Only the auth opening and DELETE handler change.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm jest 'app/api/crm/contacts/enrich/__tests__/route.test.ts'
+```
+Expected: PASS, 5 cases.
+
+Then re-run the existing test:
+```bash
+pnpm jest __tests__/enrichment/enrich-route.test.ts 2>&1 | tail -10
+```
+Expected: same baseline as before this PR (the existing test may have been passing or broken pre-existing — note the delta).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/crm/contacts/enrich/route.ts app/api/crm/contacts/enrich/__tests__/route.test.ts
+git commit -m "fix(api): require contact write scope on enrich POST/DELETE"
+```
+
+---
+
+## Task 5: Patch contact bulk enrichment route
+
+**Files:**
+- Modify: `app/api/crm/contacts/enrich-bulk/route.ts`
+- Create: `app/api/crm/contacts/enrich-bulk/__tests__/route.test.ts`
+
+Current behavior: any authenticated user can queue Inngest events for arbitrary contact IDs. Fix: filter the input ids through `filterAuthorizedContactIds`. If the filtered set is smaller than input, return 403 (some IDs unauthorized) — fail-closed per spec.
+
+- [ ] **Step 1: Write failing test**
+
+`app/api/crm/contacts/enrich-bulk/__tests__/route.test.ts`:
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Contacts: { findMany: jest.fn() },
+  },
+}));
+jest.mock("@/lib/api-keys", () => ({
+  getApiKey: jest.fn().mockResolvedValue("sk-test"),
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({ ids: ["1"] }) },
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const mockedGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockedUser = prismadb.users.findUnique as jest.MockedFunction<
+  typeof prismadb.users.findUnique
+>;
+const mockedFindMany = prismadb.crm_Contacts.findMany as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findMany
+>;
+const mockedSend = inngest.send as jest.MockedFunction<typeof inngest.send>;
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/crm/contacts/enrich-bulk", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/contacts/enrich-bulk", () => {
+  it("401 unauth", async () => {
+    mockedGetSession.mockResolvedValue(null as any);
+    const res = await POST(makeReq({ contactIds: ["a"], fields: [{ name: "website" }] }));
+    expect(res.status).toBe(401);
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it("403 when any contact id is unauthorized (fail-closed)", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "u" } } as any);
+    mockedUser.mockResolvedValue({ id: "u", role: "user" } as any);
+    mockedFindMany.mockResolvedValue([{ id: "a" }] as any); // only "a" authorized; "b" not
+    const res = await POST(
+      makeReq({ contactIds: ["a", "b"], fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it("succeeds + sends Inngest event when all ids authorized", async () => {
+    mockedGetSession.mockResolvedValue({ user: { id: "m" } } as any);
+    mockedUser.mockResolvedValue({ id: "m", role: "manager" } as any);
+    mockedFindMany.mockResolvedValue([{ id: "a" }, { id: "b" }] as any);
+    const res = await POST(
+      makeReq({ contactIds: ["a", "b"], fields: [{ name: "website" }] }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockedSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "enrich/contacts.bulk",
+        data: expect.objectContaining({
+          contactIds: ["a", "b"],
+          triggeredBy: "m",
+        }),
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+pnpm jest 'app/api/crm/contacts/enrich-bulk/__tests__/route.test.ts'
+```
+
+- [ ] **Step 3: Patch the route**
+
+`app/api/crm/contacts/enrich-bulk/route.ts` — replace the `getSession()` block with `requireAuthenticated`, then between the input validation and the Inngest send, call `filterAuthorizedContactIds`:
+
+```ts
+import {
+  requireAuthenticated,
+  filterAuthorizedContactIds,
+  unauthorizedResponse,
+  forbiddenResponse,
+  AuthenticationError,
+} from "@/lib/authz";
+
+export async function POST(request: NextRequest) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
+  // existing input validation: contactIds array len 1-100, fields non-empty,
+  // FIELD_MAP allowlist check — keep as-is
+  // existing API key checks — keep, pass user.id
+
+  const authorized = await filterAuthorizedContactIds(user, contactIds);
+  if (authorized.length !== contactIds.length) {
+    return forbiddenResponse();
+  }
+
+  await inngest.send({
+    name: "enrich/contacts.bulk",
+    data: { contactIds, fields, triggeredBy: user.id },
+  });
+  return NextResponse.json({ success: true, count: contactIds.length });
+}
+```
+
+- [ ] **Step 4: Run test → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/crm/contacts/enrich-bulk/route.ts app/api/crm/contacts/enrich-bulk/__tests__/route.test.ts
+git commit -m "fix(api): filter contact bulk enrichment ids by user scope"
+```
+
+---
+
+## Task 6: Patch target stream enrichment route (POST + DELETE)
+
+**Files:**
+- Modify: `app/api/crm/targets/enrich/route.ts`
+- Create: `app/api/crm/targets/enrich/__tests__/route.test.ts`
+
+Same pattern as Task 4, but for targets — use `assertCanWriteTarget` and `assertCanCancelTargetEnrichment`. The campaign re-export at `app/api/campaigns/targets/enrich/route.ts` is auto-fixed.
+
+- [ ] **Step 1: Write the failing test** — clone Task 4 test, swap `crm_Contacts` → `crm_Targets`, `crm_Contact_Enrichment` → `crm_Target_Enrichment`, `contactId` → `targetId`, `assertCanWriteContact` → `assertCanWriteTarget` flow. The mocked target findUnique selects `id, email, company, company_website` (current route behavior).
+
+- [ ] **Step 2: Run failing test**
+
+- [ ] **Step 3: Patch the route** — same replacements as Task 4. POST: `requireAuthenticated` → `assertCanWriteTarget(user, targetId)` → existing target lookup + enrichment create with `triggeredBy: user.id`. DELETE: `requireAuthenticated` → look up `entry.enrichmentId` from `activeSessions` → `assertCanCancelTargetEnrichment(user, entry.enrichmentId)` → existing update.
+
+- [ ] **Step 4: Run test → PASS**
+
+- [ ] **Step 5: Verify campaign re-export unchanged**
+
+```bash
+cat 'app/api/campaigns/targets/enrich/route.ts'
+```
+Expected: still `export { POST, DELETE } from "@/app/api/crm/targets/enrich/route";`. No edit needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/crm/targets/enrich/route.ts app/api/crm/targets/enrich/__tests__/route.test.ts
+git commit -m "fix(api): require target write scope on enrich POST/DELETE (auto-fixes campaign re-export)"
+```
+
+---
+
+## Task 7: Patch target bulk enrichment route
+
+**Files:**
+- Modify: `app/api/crm/targets/enrich-bulk/route.ts`
+- Create: `app/api/crm/targets/enrich-bulk/__tests__/route.test.ts`
+
+Same pattern as Task 5 but for targets. Use `filterAuthorizedTargetIds`. Campaign re-export `app/api/campaigns/targets/enrich-bulk/route.ts` auto-fixed.
+
+- [ ] **Step 1: Write failing test** — clone Task 5 test, swap models/fields/event name (`enrich/targets.bulk`).
+
+- [ ] **Step 2: Run failing test**
+
+- [ ] **Step 3: Patch the route** — `requireAuthenticated` → input validation → `filterAuthorizedTargetIds` → length check → Inngest send.
+
+- [ ] **Step 4: Run test → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/crm/targets/enrich-bulk/route.ts app/api/crm/targets/enrich-bulk/__tests__/route.test.ts
+git commit -m "fix(api): filter target bulk enrichment ids by user scope"
+```
+
+---
+
+## Task 8: Patch `targets/[id]/enrich` route
+
+**Files:**
+- Modify: `app/api/crm/targets/[id]/enrich/route.ts`
+- Create: `app/api/crm/targets/[id]/enrich/__tests__/route.test.ts`
+
+Current: takes `id` from path, calls `inngest.send({ name: "enrich/target.run", data: { targetId: id, triggeredBy: session.user.id, force }})` after only session check. Add `assertCanWriteTarget` before the send.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({}) },
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const ft = prismadb.crm_Targets.findFirst as jest.MockedFunction<typeof prismadb.crm_Targets.findFirst>;
+const send = inngest.send as jest.MockedFunction<typeof inngest.send>;
+
+function makeReq(body: unknown = {}) {
+  return new NextRequest("http://localhost/api/crm/targets/t1/enrich", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/crm/targets/[id]/enrich", () => {
+  it("401 unauth", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await POST(makeReq(), { params: Promise.resolve({ id: "t1" }) });
+    expect(res.status).toBe(401);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("404 when user does not own target", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    ft.mockResolvedValue(null);
+    const res = await POST(makeReq(), { params: Promise.resolve({ id: "t1" }) });
+    expect(res.status).toBe(404);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("user owning target queues Inngest", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    ft.mockResolvedValue({ id: "t1" } as any);
+    const res = await POST(makeReq(), { params: Promise.resolve({ id: "t1" }) });
+    expect(res.status).toBe(200);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "enrich/target.run",
+        data: expect.objectContaining({ targetId: "t1", triggeredBy: "u" }),
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Patch route**
+
+```ts
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+import { inngest } from "@/inngest/client";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+  const body = await request.json().catch(() => ({}));
+  await inngest.send({
+    name: "enrich/target.run",
+    data: { targetId: id, triggeredBy: user.id, force: body.force ?? false },
+  });
+  return NextResponse.json({ queued: true });
+}
+```
+
+Verify the campaign re-export is `export { POST } from "@/app/api/crm/targets/[id]/enrich/route";` — auto-fixed.
+
+- [ ] **Step 4: Test → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add 'app/api/crm/targets/[id]/enrich/route.ts' 'app/api/crm/targets/[id]/enrich/__tests__/route.test.ts'
+git commit -m "fix(api): require target write scope on per-target enrich (auto-fixes campaign re-export)"
+```
+
+---
+
+## Task 9: Patch `targets/[id]/contacts` POST
+
+**Files:**
+- Modify: `app/api/crm/targets/[id]/contacts/route.ts`
+- Create: `app/api/crm/targets/[id]/contacts/__tests__/route.test.ts`
+
+Current: creates a `crm_Target_Contact` for any user against any `targetId`. Fix: assert write scope on the parent target before creating the sub-record.
+
+- [ ] **Step 1: Test** — same pattern. Mock `crm_Target_Contact.create`. Cases: 401, 404 when target not in scope, 200 owner, 200 manager. The 404 case must assert `crm_Target_Contact.create` was NOT called.
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Patch**
+
+```ts
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: targetId } = await params;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+  // existing body validation + crm_Target_Contact.create unchanged
+}
+```
+
+- [ ] **Step 4: Test PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add 'app/api/crm/targets/[id]/contacts/route.ts' 'app/api/crm/targets/[id]/contacts/__tests__/route.test.ts'
+git commit -m "fix(api): require parent target write scope on target-contact create"
+```
+
+---
+
+## Task 10: Patch `targets/[id]/contacts/[contactId]/enrich` POST
+
+**Files:**
+- Modify: `app/api/crm/targets/[id]/contacts/[contactId]/enrich/route.ts`
+- Create: `app/api/crm/targets/[id]/contacts/[contactId]/enrich/__tests__/route.test.ts`
+
+Current: trusts both `id` (target) and `contactId` (target-contact). Currently the route doesn't even use `id` — it only sends `{ contactId }` to Inngest. Fix: (a) verify the user can write the parent target, (b) verify the target-contact actually belongs to that target (linkage check, not just existence).
+
+- [ ] **Step 1: Test cases**: 401, 404 when target not in scope, 404 when contact exists but its `targetId` ≠ path `id` (linkage check), 200 owner.
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Patch**
+
+```ts
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; contactId: string }> },
+) {
+  const { id: targetId, contactId } = await params;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return notFoundOrForbiddenResponse();
+    throw e;
+  }
+  // Linkage check: ensure target-contact actually belongs to this target.
+  const tc = await prismadb.crm_Target_Contact.findFirst({
+    where: { id: contactId, targetId },
+    select: { id: true },
+  });
+  if (!tc) return notFoundOrForbiddenResponse();
+
+  await inngest.send({
+    name: "enrich/target.contact.run",
+    data: { contactId, triggeredBy: user.id },
+  });
+  return NextResponse.json({ queued: true });
+}
+```
+
+- [ ] **Step 4: Test PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add 'app/api/crm/targets/[id]/contacts/[contactId]/enrich/route.ts' 'app/api/crm/targets/[id]/contacts/[contactId]/enrich/__tests__/route.test.ts'
+git commit -m "fix(api): require target write scope and contact linkage on per-target-contact enrich"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+pnpm jest 2>&1 | tail -8
+```
+Expected: same baseline failure count as before B1, plus the new authz/route tests all passing. Note delta vs. baseline.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm tsc --noEmit 2>&1 | grep -vE "(invite-user|currencies|auth-permissions|auth\.ts:71)" | head -30
+```
+Expected: no NEW errors introduced by B1. Pre-existing errors filtered.
+
+- [ ] **Step 3: Lint**
+
+```bash
+pnpm lint 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Manual security check (run on a deployed dev environment)**
+
+For each route, repeat the cross-user attack:
+1. As `bob` (role=user), `POST /api/crm/contacts/enrich` with `alice`'s contactId → expect 404, no `crm_Contact_Enrichment` row created (verify in DB).
+2. As `bob`, `DELETE /api/crm/contacts/enrich?sessionId=<alice-active-session>` → expect 404, alice's enrichment unchanged.
+3. As `bob`, `POST /api/crm/contacts/enrich-bulk` with `[alice-contact-id, bob-contact-id]` → expect 403, no Inngest event emitted.
+4. Same three for targets.
+5. As `bob`, `POST /api/crm/targets/<alice-target>/contacts` → expect 404.
+6. As `bob`, `POST /api/crm/targets/<alice-target>/contacts/<some>/enrich` → expect 404.
+7. As `bob`, hit campaign re-exports with alice's targetId → expect 404 (re-export inherits the fix).
+
+- [ ] **Step 5: Push and PR**
+
+```bash
+git push -u origin feat/authz-phase-b1
+gh pr create --base dev --head feat/authz-phase-b1 --title "fix(security): close enrichment BOLA/IDOR (Phase B1)" --body "..."
+```
+
+PR body should reference: spec §7.4–7.5, audit findings on enrichment, this plan path, manual test results.
+
+---
+
+## Acceptance Criteria
+
+- Every enrichment route (POST, DELETE, bulk, sub-paths) returns 401 to unauthenticated callers and 404/403 to authenticated callers who don't own the resource.
+- No `crm_Contact_Enrichment` or `crm_Target_Enrichment` row is created when authorization fails.
+- No Inngest event is emitted when authorization fails (bulk routes fail-closed if any id is unauthorized).
+- DELETE cancel requires both a valid session and ownership of the in-flight enrichment.
+- Campaign re-exports (`/api/campaigns/targets/[id]/enrich`, `/enrich`, `/enrich-bulk`) inherit fixes via `export { ... } from`.
+- Phase A authz module is extended with read/write/cancel/filter helpers, all unit-tested.
+- Cross-user regression tests (≥3 cases per route) pass in CI/test runs.
+
+## Out of B1 scope
+
+- **Inngest worker re-validation.** Background workers still trust `triggeredBy` and the IDs in event payload. A motivated attacker who somehow forges an Inngest event would bypass these route fixes. Hardening workers is a follow-up.
+- **Redis-backed session store.** `activeSessions` is module-local; multi-replica deployments still have stale-session edge cases. Out of scope.
+- **Linked-account scope for contacts.** Phase D adds the rule "user can write a contact whose linked account they have access to." For B1 we keep the same scope shape Phase A used (assigned/created_by/createdBy only).
+- **B2 (invoice PDF + duplicate-invoice IDOR).**
+- **B3 (reports export scoping).**

--- a/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b2.md
+++ b/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b2.md
@@ -1,0 +1,869 @@
+# Permission-Driven Authorization — Phase B2 (Invoices) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Close the remaining invoice-related authorization gaps the audit found: PDF download IDOR, unauthenticated `duplicateInvoice`, missing account-write check on `createInvoice` and `updateInvoice`, plus role-aware refactor of `lib/invoices/permissions.ts` (currently boolean `isAdmin`-only) so manager and admin both pass invoice gates.
+
+**Architecture:**
+1. Refactor `lib/invoices/permissions.ts`: `UserCtx` becomes `{ id: string, role: AppRole }`. Add `canReadInvoice` (creator OR manager OR admin). All helpers use `isManagerOrAdmin || createdBy === user.id`.
+2. Add `assertCanWriteAccount(user, accountId)` to `lib/authz/scopes/crm.ts` — used to validate that a user can bill against the referenced CRM account on `createInvoice`/`updateInvoice`. User scope = `assigned_to=user.id OR createdBy=user.id OR watcher`. Manager/admin = bare lookup.
+3. Patch the PDF route, `duplicateInvoice`, and the unguarded action call sites. `delete-payment.ts` switches from `user.is_admin` to `requireRole(["admin"])`.
+
+**Out of scope:** Read-side scoping for invoice list/detail (user-scoped invoice list is Phase D / E). PDF generation pipeline. Currency/tax-rate config (admin-only already covered by Phase A).
+
+**Spec source:** §6.11, §7.6, §8.13, §12 Phase 2.
+**Audit source:** "Invoice PDF IDOR", "Duplicate Invoice IDOR", "Cross-object Invoice Account Binding".
+
+---
+
+## File Structure
+
+**New files:**
+- `app/api/invoices/[invoiceId]/pdf/__tests__/route.test.ts`
+- `actions/invoices/__tests__/duplicate-invoice.test.ts`
+- `actions/invoices/__tests__/create-invoice-account-scope.test.ts`
+- `lib/authz/__tests__/scopes-crm-account.test.ts`
+
+**Modified files:**
+- `lib/invoices/permissions.ts` — UserCtx role-aware, add `canReadInvoice`
+- `__tests__/lib/invoices/permissions.test.ts` — update fixtures from `isAdmin:bool` → `role:AppRole`
+- `lib/authz/scopes/crm.ts` — add `assertCanWriteAccount`
+- `lib/authz/index.ts` — re-export
+- `app/api/invoices/[invoiceId]/pdf/route.ts` — read scope check
+- `actions/invoices/create-invoice.ts` — `assertCanWriteAccount`
+- `actions/invoices/update-invoice.ts` — `assertCanWriteAccount` on accountId reassignment + role-aware permissions call
+- `actions/invoices/duplicate-invoice.ts` — `assertCanReadInvoice` on source + `assertCanWriteAccount` on copy
+- `actions/invoices/cancel-invoice.ts`, `issue-invoice.ts`, `add-payment.ts`, `send-invoice-email.ts`, `regenerate-pdf.ts` — adapt to role-aware UserCtx
+- `actions/invoices/delete-payment.ts` — `requireRole(["admin"])` instead of `user.is_admin`
+
+---
+
+## Task 1: Account write-scope helper
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts`
+- Create: `lib/authz/__tests__/scopes-crm-account.test.ts`
+- Modify: `lib/authz/index.ts`
+
+`assertCanWriteAccount(user, accountId)` throws `AuthorizationError` if the user cannot operate on the account. User scope: `assigned_to = user.id OR createdBy = user.id OR exists in AccountWatchers`. Manager/admin: bare lookup.
+
+- [ ] **Step 1: Write failing test**
+
+`lib/authz/__tests__/scopes-crm-account.test.ts`:
+```ts
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Accounts: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { assertCanWriteAccount } from "../scopes/crm";
+
+const find = prismadb.crm_Accounts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Accounts.findFirst
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanWriteAccount", () => {
+  it("admin: bare where", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanWriteAccount({ id: "u", role: "admin" }, "a1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "a1" },
+      select: { id: true },
+    });
+  });
+
+  it("manager: bare where", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanWriteAccount({ id: "u", role: "manager" }, "a1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "a1" },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped with assigned/creator/watcher OR clauses", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanWriteAccount({ id: "u3", role: "user" }, "a1");
+    const arg = find.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({
+      id: "a1",
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { createdBy: "u3" },
+        { watchers: { some: { user_id: "u3" } } },
+      ]),
+    });
+  });
+
+  it("throws AuthorizationError when not in scope", async () => {
+    find.mockResolvedValue(null);
+    await expect(
+      assertCanWriteAccount({ id: "u3", role: "user" }, "a1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+```
+
+- [ ] **Step 2: Failing test**
+
+```bash
+pnpm jest lib/authz/__tests__/scopes-crm-account.test.ts
+```
+
+- [ ] **Step 3: Implement in `lib/authz/scopes/crm.ts`**
+
+Append:
+```ts
+export async function assertCanWriteAccount(
+  user: AuthzUser,
+  accountId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: accountId }
+      : {
+          id: accountId,
+          OR: [
+            { assigned_to: user.id },
+            { createdBy: user.id },
+            { watchers: { some: { user_id: user.id } } },
+          ],
+        };
+  const row = await prismadb.crm_Accounts.findFirst({
+    where,
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+```
+
+- [ ] **Step 4: Add to barrel**
+
+```ts
+export { assertCanWriteAccount } from "./scopes/crm";
+```
+
+- [ ] **Step 5: Test → PASS, commit**
+
+```bash
+git add lib/authz/scopes/crm.ts lib/authz/__tests__/scopes-crm-account.test.ts lib/authz/index.ts
+git commit -m "feat(authz): add account write-scope assertion helper"
+```
+
+---
+
+## Task 2: Role-aware invoice permissions
+
+**Files:**
+- Modify: `lib/invoices/permissions.ts`
+- Modify: `__tests__/lib/invoices/permissions.test.ts`
+
+Replace `UserCtx { id, isAdmin }` with `UserCtx { id, role: AppRole }`. Add `canReadInvoice`. Manager and admin pass every gate that previously required admin.
+
+- [ ] **Step 1: Update the permissions module**
+
+Replace `lib/invoices/permissions.ts` content with:
+```ts
+import type { AppRole } from "@/lib/authz";
+
+export type InvoiceStatus =
+  | "DRAFT" | "ISSUED" | "SENT" | "PARTIALLY_PAID" | "PAID"
+  | "OVERDUE" | "CANCELLED" | "DISPUTED" | "REFUNDED" | "WRITTEN_OFF";
+
+export interface UserCtx { id: string; role: AppRole; }
+export interface InvoiceCtx { status: InvoiceStatus; createdBy: string; }
+
+export function isInvoiceImmutable(status: InvoiceStatus): boolean {
+  return status !== "DRAFT";
+}
+
+function isManagerOrAdmin(user: UserCtx): boolean {
+  return user.role === "manager" || user.role === "admin";
+}
+
+function isOwnerOrPrivileged(invoice: InvoiceCtx, user: UserCtx): boolean {
+  return isManagerOrAdmin(user) || invoice.createdBy === user.id;
+}
+
+export function canReadInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
+  return isOwnerOrPrivileged(invoice, user);
+}
+
+export function canEditInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
+  if (isInvoiceImmutable(invoice.status)) return false;
+  return isOwnerOrPrivileged(invoice, user);
+}
+
+export function canIssueInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
+  if (invoice.status !== "DRAFT") return false;
+  return isOwnerOrPrivileged(invoice, user);
+}
+
+export function canCancelInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
+  if (invoice.status !== "DRAFT") return false;
+  return isOwnerOrPrivileged(invoice, user);
+}
+
+const PAYMENT_ALLOWED: ReadonlySet<InvoiceStatus> = new Set<InvoiceStatus>([
+  "ISSUED", "SENT", "PARTIALLY_PAID", "OVERDUE",
+]);
+
+export function canAddPayment(invoice: InvoiceCtx, user: UserCtx): boolean {
+  if (!PAYMENT_ALLOWED.has(invoice.status)) return false;
+  return isOwnerOrPrivileged(invoice, user);
+}
+```
+
+- [ ] **Step 2: Update existing tests**
+
+Edit `__tests__/lib/invoices/permissions.test.ts`. Change every test fixture from `{ id, isAdmin: false/true }` to `{ id, role: "user"/"admin" }`. Add coverage for `manager`:
+
+```ts
+const u  = { id: "u1", role: "user" as const };
+const mg = { id: "m",  role: "manager" as const };
+const ad = { id: "a",  role: "admin" as const };
+
+// ... existing tests ...
+
+describe("canReadInvoice", () => {
+  it("creator can read", () => expect(canReadInvoice({ status: "DRAFT", createdBy: "u1" }, u)).toBe(true));
+  it("non-creator user cannot read", () => expect(canReadInvoice({ status: "DRAFT", createdBy: "u2" }, u)).toBe(false));
+  it("manager can read any", () => expect(canReadInvoice({ status: "DRAFT", createdBy: "u2" }, mg)).toBe(true));
+  it("admin can read any", () => expect(canReadInvoice({ status: "PAID", createdBy: "u2" }, ad)).toBe(true));
+});
+
+// add a manager case to canEditInvoice / canIssueInvoice / canAddPayment / canCancelInvoice
+it("manager can edit any DRAFT", () => expect(canEditInvoice({ status: "DRAFT", createdBy: "u2" }, mg)).toBe(true));
+```
+
+- [ ] **Step 3: Run tests → PASS**
+
+```bash
+pnpm jest __tests__/lib/invoices/permissions.test.ts
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/invoices/permissions.ts __tests__/lib/invoices/permissions.test.ts
+git commit -m "refactor(invoices): role-aware permissions (user/manager/admin); add canReadInvoice"
+```
+
+---
+
+## Task 3: Update invoice action call sites
+
+**Files:**
+- Modify: `actions/invoices/update-invoice.ts`
+- Modify: `actions/invoices/cancel-invoice.ts`
+- Modify: `actions/invoices/issue-invoice.ts`
+- Modify: `actions/invoices/add-payment.ts`
+- Modify: `actions/invoices/send-invoice-email.ts`
+- Modify: `actions/invoices/regenerate-pdf.ts`
+
+Each action constructs a `UserCtx` from `getUser()` and passes it to `lib/invoices/permissions.ts`. After Task 2 the shape changed — switch every call site from `{ id: user.id, isAdmin: user.is_admin }` to `{ id: user.id, role: mapLegacyRole(user.role) }` (use the existing `mapLegacyRole` for safety, since `getUser()` returns the raw DB string).
+
+- [ ] **Step 1: Apply rewrites**
+
+In each file listed above, change:
+```ts
+{ id: user.id, isAdmin: user.is_admin }
+```
+to:
+```ts
+{ id: user.id, role: mapLegacyRole(user.role) }
+```
+
+Add the import in each file:
+```ts
+import { mapLegacyRole } from "@/lib/authz";
+```
+
+For the inline manual checks in `send-invoice-email.ts` and `regenerate-pdf.ts` — these currently do `if (invoice.createdBy !== user.id && !user.is_admin)`. Replace with `canReadInvoice` (since both effectively need read-or-edit access on a non-draft invoice):
+
+In `send-invoice-email.ts`, replace the manual check with:
+```ts
+import { canReadInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
+import { mapLegacyRole } from "@/lib/authz";
+
+if (
+  !canReadInvoice(
+    { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
+    { id: user.id, role: mapLegacyRole(user.role) },
+  )
+) {
+  throw new Error("Forbidden");
+}
+```
+
+Same shape in `regenerate-pdf.ts`.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+pnpm tsc --noEmit 2>&1 | grep -E "actions/invoices" | head
+```
+Expected: no errors in `actions/invoices/*`.
+
+- [ ] **Step 3: Run existing invoice tests**
+
+```bash
+pnpm jest invoices 2>&1 | tail -10
+```
+Expected: same baseline (or better — pre-existing `lifecycle.test.ts` failures may now pass if they were caused by the boolean shape).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add actions/invoices/
+git commit -m "refactor(invoices): pass role-aware UserCtx to permission helpers"
+```
+
+---
+
+## Task 4: Patch invoice PDF route
+
+**Files:**
+- Modify: `app/api/invoices/[invoiceId]/pdf/route.ts`
+- Create: `app/api/invoices/[invoiceId]/pdf/__tests__/route.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    invoices: { findUnique: jest.fn() },
+  },
+}));
+jest.mock("@/lib/invoices/storage", () => ({
+  getInvoicePdfPresignedUrl: jest.fn().mockResolvedValue("https://s3.example/x"),
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { GET } from "../route";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fi = prismadb.invoices.findUnique as jest.MockedFunction<typeof prismadb.invoices.findUnique>;
+
+function req() {
+  return new NextRequest("http://localhost/api/invoices/i1/pdf");
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/invoices/[invoiceId]/pdf", () => {
+  it("401 unauth", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when user does not own the invoice", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ createdBy: "other", status: "ISSUED", pdfStorageKey: "k" } as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("404 when invoice not found", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue(null);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("creator gets redirect to presigned URL", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ createdBy: "u", status: "ISSUED", pdfStorageKey: "k" } as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect([302, 307]).toContain(res.status);
+  });
+
+  it("manager gets redirect for any invoice", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    fi.mockResolvedValue({ createdBy: "other", status: "ISSUED", pdfStorageKey: "k" } as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect([302, 307]).toContain(res.status);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+- [ ] **Step 3: Patch route**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAuthenticated,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { canReadInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
+import { getInvoicePdfPresignedUrl } from "@/lib/invoices/storage";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ invoiceId: string }> }
+) {
+  const { invoiceId } = await params;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
+  const invoice = await prismadb.invoices.findUnique({
+    where: { id: invoiceId },
+    select: { createdBy: true, status: true, pdfStorageKey: true },
+  });
+  if (!invoice) return notFoundOrForbiddenResponse();
+
+  if (
+    !canReadInvoice(
+      { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
+      { id: user.id, role: user.role },
+    )
+  ) {
+    return notFoundOrForbiddenResponse();
+  }
+
+  if (!invoice.pdfStorageKey) {
+    return NextResponse.json(
+      { error: "PDF not yet generated. Issue the invoice first." },
+      { status: 404 },
+    );
+  }
+
+  const url = await getInvoicePdfPresignedUrl(invoice.pdfStorageKey);
+  return NextResponse.redirect(url);
+}
+```
+
+- [ ] **Step 4: Test → PASS, commit**
+
+```bash
+git add 'app/api/invoices/[invoiceId]/pdf/route.ts' 'app/api/invoices/[invoiceId]/pdf/__tests__/route.test.ts'
+git commit -m "fix(api): require invoice read scope on PDF route"
+```
+
+---
+
+## Task 5: Patch `duplicateInvoice`
+
+**Files:**
+- Modify: `actions/invoices/duplicate-invoice.ts`
+- Create: `actions/invoices/__tests__/duplicate-invoice.test.ts`
+
+`duplicateInvoice` currently has zero auth check. Add: `requireAuthenticated` + `canReadInvoice` on source + `assertCanWriteAccount` on the target accountId (since the duplicate copies `accountId` from source — user must still be authorized on it).
+
+- [ ] **Step 1: Failing test**
+
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    invoices: { findUniqueOrThrow: jest.fn(), create: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { duplicateInvoice } from "../duplicate-invoice";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fi = prismadb.invoices.findUniqueOrThrow as jest.MockedFunction<typeof prismadb.invoices.findUniqueOrThrow>;
+const fa = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const ci = prismadb.invoices.create as jest.MockedFunction<typeof prismadb.invoices.create>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("duplicateInvoice", () => {
+  it("throws when unauthenticated", async () => {
+    gs.mockResolvedValue(null as any);
+    await expect(duplicateInvoice("i1")).rejects.toThrow();
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("throws when user cannot read source invoice", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ id: "src", createdBy: "other", status: "ISSUED", accountId: "a1", lineItems: [] } as any);
+    await expect(duplicateInvoice("i1")).rejects.toThrow(/forbidden/i);
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("throws when user cannot write the copied accountId", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ id: "src", createdBy: "u", status: "ISSUED", accountId: "a1", lineItems: [] } as any);
+    fa.mockResolvedValue(null);
+    await expect(duplicateInvoice("i1")).rejects.toThrow(/forbidden/i);
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("succeeds when both checks pass", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ id: "src", createdBy: "u", status: "ISSUED", accountId: "a1", lineItems: [], type: "INVOICE", currency: "USD", subtotal: "0", discountTotal: "0", vatTotal: "0", grandTotal: "0" } as any);
+    fa.mockResolvedValue({ id: "a1" } as any);
+    ci.mockResolvedValue({ id: "new" } as any);
+    await duplicateInvoice("i1");
+    expect(ci).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Patch action**
+
+`actions/invoices/duplicate-invoice.ts`:
+```ts
+"use server";
+import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+import { canReadInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
+import { serializeDecimals } from "@/lib/serialize-decimals";
+
+export async function duplicateInvoice(invoiceId: string) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
+
+  const source = await prismadb.invoices.findUniqueOrThrow({
+    where: { id: invoiceId },
+    include: { lineItems: { orderBy: { position: "asc" } } },
+  });
+
+  if (
+    !canReadInvoice(
+      { status: source.status as InvoiceStatus, createdBy: source.createdBy },
+      { id: user.id, role: user.role },
+    )
+  ) {
+    throw new Error("Forbidden");
+  }
+
+  try {
+    await assertCanWriteAccount(user, source.accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+
+  const invoice = await prismadb.invoices.create({
+    // ... same body as before, but createdBy = user.id
+    data: {
+      type: source.type,
+      status: "DRAFT",
+      createdBy: user.id,
+      accountId: source.accountId,
+      // ... rest unchanged from current implementation
+      seriesId: source.seriesId,
+      currency: source.currency,
+      dueDate: source.dueDate,
+      publicNotes: source.publicNotes,
+      internalNotes: source.internalNotes,
+      bankName: source.bankName,
+      bankAccount: source.bankAccount,
+      iban: source.iban,
+      swift: source.swift,
+      variableSymbol: source.variableSymbol,
+      originalInvoiceId: source.id,
+      subtotal: source.subtotal,
+      discountTotal: source.discountTotal,
+      vatTotal: source.vatTotal,
+      grandTotal: source.grandTotal,
+      balanceDue: source.grandTotal,
+      lineItems: {
+        create: source.lineItems.map((li) => ({
+          position: li.position,
+          productId: li.productId,
+          description: li.description,
+          quantity: li.quantity,
+          unitPrice: li.unitPrice,
+          discountPercent: li.discountPercent,
+          taxRateId: li.taxRateId,
+          lineSubtotal: li.lineSubtotal,
+          lineVat: li.lineVat,
+          lineTotal: li.lineTotal,
+        })),
+      },
+      activity: {
+        create: { actorId: user.id, action: "DUPLICATED", meta: { sourceInvoiceId: invoiceId } },
+      },
+    },
+  });
+
+  return serializeDecimals(invoice);
+}
+```
+
+- [ ] **Step 4: Test → PASS, commit**
+
+```bash
+git add actions/invoices/duplicate-invoice.ts actions/invoices/__tests__/duplicate-invoice.test.ts
+git commit -m "fix(invoices): require read scope on source and write scope on accountId for duplicateInvoice"
+```
+
+---
+
+## Task 6: Account-scope check on `createInvoice` and `updateInvoice`
+
+**Files:**
+- Modify: `actions/invoices/create-invoice.ts`
+- Modify: `actions/invoices/update-invoice.ts`
+- Create: `actions/invoices/__tests__/create-invoice-account-scope.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+`actions/invoices/__tests__/create-invoice-account-scope.test.ts`:
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    invoice_TaxRates: { findMany: jest.fn().mockResolvedValue([]) },
+    invoices: { create: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { createInvoice } from "../create-invoice";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fa = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const ci = prismadb.invoices.create as jest.MockedFunction<typeof prismadb.invoices.create>;
+
+const validInput = {
+  type: "INVOICE",
+  accountId: "a1",
+  currency: "USD",
+  lineItems: [{ description: "x", quantity: 1, unitPrice: 100, discountPercent: 0 }],
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("createInvoice account-scope", () => {
+  it("throws when user has no access to accountId", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue(null);
+    await expect(createInvoice(validInput)).rejects.toThrow(/forbidden/i);
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("succeeds for user owning the account", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue({ id: "a1" } as any);
+    ci.mockResolvedValue({ id: "new" } as any);
+    await createInvoice(validInput);
+    expect(ci).toHaveBeenCalledTimes(1);
+  });
+
+  it("manager can create against any account", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    fa.mockResolvedValue({ id: "a1" } as any);
+    ci.mockResolvedValue({ id: "new" } as any);
+    await createInvoice(validInput);
+    expect(ci).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Patch `create-invoice.ts`**
+
+Replace the start of `createInvoice` body. After zod parse, before any DB write:
+```ts
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+export async function createInvoice(raw: unknown) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
+  const input = createInvoiceSchema.parse(raw);
+
+  try {
+    await assertCanWriteAccount(user, input.accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+
+  // ... rest of existing body, replace `user.id` references already done; ok
+}
+```
+
+Remove the `getUser()` import — replaced by `requireAuthenticated`. Keep the `createdBy: user.id` line (now using AuthzUser's id).
+
+- [ ] **Step 4: Patch `update-invoice.ts`**
+
+In `update-invoice.ts`, after the existing `canEditInvoice` check, if `input.accountId` is present and differs from `existing.accountId` (we're reassigning), call `assertCanWriteAccount(user, input.accountId)`. Add the import. Wrap with the same `AuthorizationError → throw new Error("Forbidden")` shape.
+
+```ts
+// after canEditInvoice check:
+if ("accountId" in input && input.accountId) {
+  try {
+    await assertCanWriteAccount(
+      { id: user.id, role: mapLegacyRole(user.role) },
+      input.accountId,
+    );
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+}
+```
+
+(`update-invoice.ts` still uses `getUser()` for the full Users row — that's fine; just convert to AuthzUser shape for the helper.)
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm jest actions/invoices/__tests__/create-invoice-account-scope.test.ts
+pnpm jest invoices 2>&1 | tail -10
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add actions/invoices/create-invoice.ts actions/invoices/update-invoice.ts actions/invoices/__tests__/create-invoice-account-scope.test.ts
+git commit -m "fix(invoices): require account write scope on create and on accountId reassignment"
+```
+
+---
+
+## Task 7: Switch `delete-payment` to canonical role
+
+**Files:**
+- Modify: `actions/invoices/delete-payment.ts`
+
+Currently: `if (!user.is_admin) throw new Error(...)`. Switch to `requireRole(["admin"])` from `@/lib/authz`.
+
+- [ ] **Step 1: Apply rewrite**
+
+```ts
+"use server";
+import { prismadb } from "@/lib/prisma";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+import { Decimal } from "decimal.js";
+
+export async function deletePayment(paymentId: string) {
+  let user;
+  try {
+    user = await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    if (e instanceof AuthorizationError) throw new Error("Only admins can delete payments");
+    throw e;
+  }
+  // ... rest of existing transaction logic unchanged, using user.id
+}
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+pnpm tsc --noEmit 2>&1 | grep delete-payment | head
+git add actions/invoices/delete-payment.ts
+git commit -m "refactor(invoices): require admin role on delete-payment via canonical helper"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Full suite**
+
+```bash
+pnpm jest 2>&1 | tail -8
+```
+Expected: B2 tests pass; existing invoice/lifecycle tests pass (or unchanged if pre-existing failure).
+
+- [ ] **Step 2: Manual checklist on dev**
+
+1. As `bob` (user, not invoice creator), `GET /api/invoices/<alice-invoice>/pdf` → 404
+2. As `bob`, call `duplicateInvoice("<alice-invoice-id>")` via server action → throws Forbidden, no new invoice row
+3. As `bob`, call `createInvoice({ accountId: "<alice-account>", ... })` → throws Forbidden
+4. As `bob`, call `updateInvoice("<bob-invoice>", { accountId: "<alice-account>" })` → throws Forbidden
+5. As `manager`, all four → succeed
+6. As any non-admin, `deletePayment(...)` → throws "Only admins can delete payments"
+
+- [ ] **Step 3: Push and PR**
+
+```bash
+git push -u origin feat/authz-phase-b2
+gh pr create --base dev --head feat/authz-phase-b2 --title "fix(security): close invoice IDOR (Phase B2)" --body "..."
+```
+
+PR body references: spec §6.11/§7.6/§8.13, audit "Invoice PDF IDOR" / "Duplicate Invoice IDOR" / "Cross-object Invoice Account Binding", manual test results.
+
+---
+
+## Acceptance Criteria
+
+- `lib/invoices/permissions.ts` is role-aware; manager and admin pass every gate.
+- PDF route returns 404 to authenticated non-readers; pre-existing 404-when-PDF-not-generated behavior preserved.
+- `duplicateInvoice` rejects requests where the user can't read the source OR can't write the copied accountId.
+- `createInvoice` and `updateInvoice` reject when `accountId` is outside the user's account scope.
+- `deletePayment` uses canonical `requireRole(["admin"])`.
+- All invoice action call sites pass `{ id, role }` (no remaining `isAdmin` boolean usage in invoice flow).
+- New tests cover the cross-user attack for PDF, duplicate, create-with-foreign-account.
+
+## Out of B2 scope
+
+- Read-side scoping for invoice list/detail (Phase D/E).
+- Background workers (none for invoices).
+- Removing `Users.is_admin` column (Phase F).

--- a/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b3.md
+++ b/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b3.md
@@ -1,0 +1,734 @@
+# Permission-Driven Authorization — Phase B3 (Reports) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Stop unscoped global-data leaks across the reports surface — export route, six per-category report functions, dashboard counts, unified-search cross-entity facet, report config/schedule visibility, and the Inngest scheduled-report sender. After B3, a `user` sees only data they own; `manager` sees business-wide non-admin data; `admin` sees everything.
+
+**Architecture:** Add a single `lib/authz/scopes/report-scope.ts` module that returns a `ReportScope` object — a bag of per-entity Prisma `where` fragments parameterized by user role and id. Every report category function accepts an optional `scope` argument; if omitted, manager-level scope (no filter) is used (back-compat for tests). The export route + Inngest scheduled sender pass the appropriate scope per caller. Config and schedule list/CRUD are filtered by `createdBy === user.id OR isShared` for users (configs only — schedules stay private), bare for manager/admin. The `users` report category is **manager+** only — users get 403.
+
+**Out of scope:** Soft caching of scope helpers, fancy ABAC. The 6 report categories get the same shape applied — no new feature work, only filters and gates.
+
+**Spec source:** §6.13, §7.6, §8.15, §8.16, §12 Phase 5.
+**Audit source:** "Global Report Export", "Global Document Listing", "Global CRM Read Actions" (similar shape).
+
+---
+
+## File Structure
+
+**New files:**
+- `lib/authz/scopes/report-scope.ts` — `ReportScope` interface + `getReportScope(user)`
+- `lib/authz/__tests__/report-scope.test.ts`
+- `app/api/reports/export/__tests__/route.test.ts`
+- `actions/reports/__tests__/users-report-gating.test.ts`
+- `actions/reports/__tests__/config-scope.test.ts`
+- `actions/reports/__tests__/schedule-scope.test.ts`
+- `actions/dashboard/__tests__/get-tasks-count.test.ts`
+- `inngest/functions/reports/__tests__/send-scheduled-scope.test.ts`
+
+**Modified files:**
+- `lib/authz/index.ts`
+- `actions/reports/sales.ts` — accept optional `scope`; apply `where` for opportunity/account scoping
+- `actions/reports/leads.ts` — accept optional `scope`
+- `actions/reports/accounts.ts` — accept optional `scope`
+- `actions/reports/activity.ts` — accept optional `scope`
+- `actions/reports/campaigns.ts` — accept optional `scope`
+- `actions/reports/users.ts` — manager+ only (entire file gated)
+- `actions/reports/dashboard.ts` — `getDashboardKPIs(filters, displayCurrency, scope?)`
+- `actions/reports/types.ts` — export `ReportScope` type alias for consumers
+- `app/api/reports/export/route.ts` — `requireAuthenticated`, build scope, gate `users` category, pass scope to category dispatch
+- `actions/reports/config.ts` — `loadConfigs` filters by user; `saveConfig`, `deleteConfig`, `toggleShare`, `duplicateConfig` enforce ownership-or-admin
+- `actions/reports/schedule.ts` — same shape
+- `actions/dashboard/get-tasks-count.ts` — scope by user (with role override)
+- `actions/fulltext/unified-search.ts` — apply scope filters per entity
+- `inngest/functions/reports/send-scheduled.ts` — scope per schedule's `createdBy` user
+
+---
+
+## Task 1: `ReportScope` interface and builder
+
+**Files:**
+- Create: `lib/authz/scopes/report-scope.ts`
+- Create: `lib/authz/__tests__/report-scope.test.ts`
+- Modify: `lib/authz/index.ts`
+
+`ReportScope` is a bag of partial `where` filters per entity. For manager/admin every field is `{}`. For user, each field constrains to the rows that user owns/created/is-assigned-to. Report-category functions merge their own date filter with `scope.<entity>` via spread.
+
+- [ ] **Step 1: Failing test**
+
+`lib/authz/__tests__/report-scope.test.ts`:
+```ts
+import { getReportScope } from "../scopes/report-scope";
+
+describe("getReportScope", () => {
+  it("admin: all fragments empty (no filter)", () => {
+    const s = getReportScope({ id: "a", role: "admin" });
+    expect(s.opportunity).toEqual({});
+    expect(s.lead).toEqual({});
+    expect(s.account).toEqual({});
+    expect(s.contact).toEqual({});
+    expect(s.task).toEqual({});
+    expect(s.campaign).toEqual({});
+    expect(s.allowUserDirectory).toBe(true);
+  });
+
+  it("manager: same as admin for non-admin entities", () => {
+    const s = getReportScope({ id: "m", role: "manager" });
+    expect(s.opportunity).toEqual({});
+    expect(s.lead).toEqual({});
+    expect(s.allowUserDirectory).toBe(true);
+  });
+
+  it("user: each entity filters to user-owned rows", () => {
+    const s = getReportScope({ id: "u1", role: "user" });
+    expect(s.opportunity).toMatchObject({
+      OR: expect.arrayContaining([
+        { assigned_to: "u1" },
+        { created_by: "u1" },
+      ]),
+    });
+    expect(s.lead).toMatchObject({
+      OR: expect.arrayContaining([{ assigned_to: "u1" }, { createdBy: "u1" }]),
+    });
+    expect(s.account).toMatchObject({
+      OR: expect.arrayContaining([
+        { assigned_to: "u1" },
+        { createdBy: "u1" },
+        { watchers: { some: { user_id: "u1" } } },
+      ]),
+    });
+    expect(s.contact).toMatchObject({
+      OR: expect.arrayContaining([
+        { assigned_to: "u1" },
+        { created_by: "u1" },
+        { createdBy: "u1" },
+      ]),
+    });
+    expect(s.task).toMatchObject({ user: "u1" });
+    expect(s.campaign).toMatchObject({ created_by: "u1" });
+    expect(s.allowUserDirectory).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Implement**
+
+`lib/authz/scopes/report-scope.ts`:
+```ts
+import type { AuthzUser } from "../session";
+
+export interface ReportScope {
+  opportunity: Record<string, unknown>;
+  lead: Record<string, unknown>;
+  account: Record<string, unknown>;
+  contact: Record<string, unknown>;
+  task: Record<string, unknown>;
+  campaign: Record<string, unknown>;
+  allowUserDirectory: boolean;
+}
+
+const EMPTY: ReportScope = {
+  opportunity: {},
+  lead: {},
+  account: {},
+  contact: {},
+  task: {},
+  campaign: {},
+  allowUserDirectory: true,
+};
+
+export function getReportScope(user: AuthzUser): ReportScope {
+  if (user.role === "admin" || user.role === "manager") return EMPTY;
+  return {
+    opportunity: {
+      OR: [{ assigned_to: user.id }, { created_by: user.id }],
+    },
+    lead: { OR: [{ assigned_to: user.id }, { createdBy: user.id }] },
+    account: {
+      OR: [
+        { assigned_to: user.id },
+        { createdBy: user.id },
+        { watchers: { some: { user_id: user.id } } },
+      ],
+    },
+    contact: {
+      OR: [
+        { assigned_to: user.id },
+        { created_by: user.id },
+        { createdBy: user.id },
+      ],
+    },
+    task: { user: user.id },
+    campaign: { created_by: user.id },
+    allowUserDirectory: false,
+  };
+}
+```
+
+- [ ] **Step 4: Add to barrel**
+
+```ts
+export type { ReportScope } from "./scopes/report-scope";
+export { getReportScope } from "./scopes/report-scope";
+```
+
+- [ ] **Step 5: Test → PASS, commit**
+
+```bash
+git add lib/authz/scopes/report-scope.ts lib/authz/__tests__/report-scope.test.ts lib/authz/index.ts
+git commit -m "feat(authz): add ReportScope builder for per-role report data filtering"
+```
+
+---
+
+## Task 2: Apply scope to report category functions
+
+**Files:**
+- Modify: `actions/reports/sales.ts`, `leads.ts`, `accounts.ts`, `activity.ts`, `campaigns.ts`, `dashboard.ts`
+- Modify: `actions/reports/types.ts`
+
+Add an optional `scope: ReportScope` parameter to every exported category function. Default: `getReportScope({id:"",role:"manager"})` (a manager-equivalent empty scope) so existing direct callers keep working without updates.
+
+Inside each function, merge the entity scope into every `prismadb.crm_X.findMany / count` call. Pattern:
+
+```ts
+const data = await prismadb.crm_Opportunities.findMany({
+  where: {
+    ...dateRangeWhere(filters),
+    status: "CLOSED",
+    deletedAt: null,
+    ...scope.opportunity,
+  },
+  // ...
+});
+```
+
+- [ ] **Step 1: Read each file and identify every Prisma read**
+
+```bash
+grep -n "prismadb\." actions/reports/sales.ts actions/reports/leads.ts actions/reports/accounts.ts actions/reports/activity.ts actions/reports/campaigns.ts actions/reports/dashboard.ts | head -80
+```
+
+Map each query to the right `scope.<entity>` field:
+- `crm_Opportunities` → `scope.opportunity`
+- `crm_Leads` → `scope.lead`
+- `crm_Accounts` → `scope.account`
+- `crm_Contacts` → `scope.contact`
+- `tasks` → `scope.task`
+- `crm_campaigns` → `scope.campaign`
+- `crm_Activities` (if present) → choose closest entity (likely user-owned via `created_by`)
+
+- [ ] **Step 2: Update each file**
+
+For each exported function, change signature to accept `scope?: ReportScope`. Default to manager-empty:
+
+```ts
+import type { ReportScope } from "@/lib/authz";
+import { getReportScope } from "@/lib/authz";
+
+const DEFAULT_SCOPE: ReportScope = getReportScope({ id: "", role: "manager" });
+
+export async function getRevenue(
+  filters: ReportFilters,
+  displayCurrency: string,
+  scope: ReportScope = DEFAULT_SCOPE,
+): Promise<number> {
+  const opps = await prismadb.crm_Opportunities.findMany({
+    where: {
+      ...dateRangeWhere(filters),
+      status: "CLOSED",
+      ...scope.opportunity,
+    },
+    select: { budget: true, currency: true },
+  });
+  // ...
+}
+```
+
+Apply the same pattern to every exported function in `sales.ts`, `leads.ts`, `accounts.ts`, `activity.ts`, `campaigns.ts`, `dashboard.ts`.
+
+- [ ] **Step 3: Add a test that the scope is applied**
+
+Pick `sales.ts` as the canary — the implementer adds one new test verifying `getRevenue` passes `scope.opportunity` into the `where` clause:
+
+```ts
+// in __tests__/reports/sales.test.ts (append):
+import { getReportScope } from "@/lib/authz";
+
+it("applies user scope to opportunities query", async () => {
+  (prismadb.crm_Opportunities.findMany as jest.Mock).mockResolvedValue([]);
+  const scope = getReportScope({ id: "u3", role: "user" });
+  await getRevenue({ dateFrom: new Date(), dateTo: new Date() }, "USD", scope);
+  const arg = (prismadb.crm_Opportunities.findMany as jest.Mock).mock.calls.at(-1)![0];
+  expect(arg.where.OR).toEqual(
+    expect.arrayContaining([{ assigned_to: "u3" }, { created_by: "u3" }]),
+  );
+});
+```
+
+(One canary test per file is enough — the pattern is uniform.)
+
+- [ ] **Step 4: Run all report tests**
+
+```bash
+pnpm jest reports 2>&1 | tail -15
+```
+Expected: same baseline. Existing tests still pass because default scope is a no-op.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add actions/reports/ __tests__/reports/
+git commit -m "feat(reports): per-category functions accept ReportScope to filter data by role"
+```
+
+---
+
+## Task 3: Gate `users` report (manager+ only)
+
+**Files:**
+- Modify: `actions/reports/users.ts`
+- Create: `actions/reports/__tests__/users-report-gating.test.ts`
+
+`users.ts` exports `getActiveUsersByYear`, `getActiveUsersLifetime`, `getUserGrowth`, `getUsersByRole`. These queries reveal counts/IDs across the entire user directory — must be **manager+ only**.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn(), groupBy: jest.fn(), count: jest.fn().mockResolvedValue(0), findMany: jest.fn().mockResolvedValue([]) },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getUsersByRole } from "../users";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("users-report gating", () => {
+  it("user role is rejected", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    await expect(getUsersByRole({ dateFrom: new Date(), dateTo: new Date() })).rejects.toThrow(/forbidden/i);
+  });
+
+  it("manager allowed", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    (prismadb.users.groupBy as jest.Mock).mockResolvedValue([]);
+    await expect(getUsersByRole({ dateFrom: new Date(), dateTo: new Date() })).resolves.toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Patch `users.ts`**
+
+Add a guard at the top of every exported function:
+
+```ts
+import { requireRole, AuthorizationError } from "@/lib/authz";
+
+async function ensureManagerOrAdmin() {
+  try {
+    await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+}
+
+export async function getActiveUsersByYear(filters: ReportFilters) {
+  await ensureManagerOrAdmin();
+  // existing body
+}
+
+// Same prefix to getActiveUsersLifetime, getUserGrowth, getUsersByRole.
+```
+
+- [ ] **Step 4: Test → PASS, commit**
+
+```bash
+git add actions/reports/users.ts actions/reports/__tests__/users-report-gating.test.ts
+git commit -m "fix(reports): gate users-directory report behind manager/admin"
+```
+
+---
+
+## Task 4: Patch report export route
+
+**Files:**
+- Modify: `app/api/reports/export/route.ts`
+- Create: `app/api/reports/export/__tests__/route.test.ts`
+
+Wire authentication, build scope, dispatch to category. For `category === "users"`, require manager+. For other categories, pass scope to the category functions.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { users: { findUnique: jest.fn() } },
+}));
+
+// Mock the report data dispatcher so we can assert it received the scope.
+jest.mock("@/actions/reports/dashboard", () => ({
+  getDashboardKPIs: jest.fn().mockResolvedValue([]),
+}));
+jest.mock("@/actions/reports/sales", () => ({
+  getRevenue: jest.fn().mockResolvedValue(0),
+  // ... add stubs as needed for the route's category dispatch
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { GET } from "../route";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/reports/export", () => {
+  it("401 unauth", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await GET(new NextRequest("http://localhost/api/reports/export?category=sales"));
+    expect(res.status).toBe(401);
+  });
+
+  it("403 when user requests users-directory report", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const res = await GET(new NextRequest("http://localhost/api/reports/export?category=users"));
+    expect(res.status).toBe(403);
+  });
+
+  it("user can export sales-category report (scope passed)", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const res = await GET(new NextRequest("http://localhost/api/reports/export?category=sales&format=csv"));
+    expect([200]).toContain(res.status);
+  });
+
+  it("400 for unknown category", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "manager" } as any);
+    const res = await GET(new NextRequest("http://localhost/api/reports/export?category=bogus"));
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Failing test**
+
+- [ ] **Step 3: Patch route**
+
+Replace the auth + dispatch section of `app/api/reports/export/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAuthenticated,
+  unauthorizedResponse,
+  forbiddenResponse,
+  AuthenticationError,
+  getReportScope,
+} from "@/lib/authz";
+import { generateCSV } from "@/actions/reports/export-csv";
+import { parseSearchParamsToFilters, REPORT_CATEGORIES } from "@/actions/reports/types";
+// existing imports for getReportData / per-category dispatcher
+
+export async function GET(request: NextRequest) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
+  }
+
+  const { searchParams } = request.nextUrl;
+  const category = searchParams.get("category") ?? "sales";
+  const format = searchParams.get("format") ?? "csv";
+
+  if (!REPORT_CATEGORIES.includes(category as any)) {
+    return NextResponse.json({ error: "Invalid category" }, { status: 400 });
+  }
+
+  if (category === "users" && user.role === "user") {
+    return forbiddenResponse();
+  }
+
+  const filters = parseSearchParamsToFilters(searchParams);
+  const scope = getReportScope(user);
+
+  // Pass scope through to whatever dispatcher the route uses.
+  // If `getReportData` is the dispatcher, update its signature too:
+  // getReportData(category, filters, scope)
+  const { data, headers } = await getReportData(category, filters, scope);
+
+  // ... existing CSV / PDF response handling unchanged
+}
+```
+
+`getReportData` (or whatever the route's dispatcher is named — confirm at file top) needs to accept `scope` and pass it into the per-category function it calls. Update its signature in lockstep.
+
+- [ ] **Step 4: Test → PASS, commit**
+
+```bash
+git add app/api/reports/export/route.ts app/api/reports/export/__tests__/route.test.ts
+git commit -m "fix(api): scope reports/export by role; gate users-directory report"
+```
+
+---
+
+## Task 5: Scope report config and schedule actions
+
+**Files:**
+- Modify: `actions/reports/config.ts`
+- Modify: `actions/reports/schedule.ts`
+- Create: `actions/reports/__tests__/config-scope.test.ts`
+- Create: `actions/reports/__tests__/schedule-scope.test.ts`
+
+Per spec §6.13:
+- **Configs:** users see `createdBy === user.id OR isShared`. Mutations require ownership-or-admin (managers cannot edit other users' private configs).
+- **Schedules:** users see only their own. Mutations require ownership-or-admin.
+
+- [ ] **Step 1: Patch `config.ts`**
+
+Add `requireAuthenticated` at the top of every exported function. Apply scope to `loadConfigs`. Add ownership-or-admin checks to `deleteConfig`, `duplicateConfig`, `toggleShare`, `saveConfig` (saveConfig sets `createdBy` from authenticated user — never trust caller-supplied id).
+
+Pseudocode for `loadConfigs`:
+```ts
+const user = await requireAuthenticated();
+const where =
+  user.role === "admin" || user.role === "manager"
+    ? { category }
+    : { category, OR: [{ createdBy: user.id }, { isShared: true }] };
+return prismadb.crm_Report_Config.findMany({ where });
+```
+
+For `deleteConfig`/`duplicateConfig`/`toggleShare`:
+```ts
+const user = await requireAuthenticated();
+const cfg = await prismadb.crm_Report_Config.findUnique({
+  where: { id: configId },
+  select: { id: true, createdBy: true },
+});
+if (!cfg) throw new Error("Not found");
+if (user.role !== "admin" && user.role !== "manager" && cfg.createdBy !== user.id) {
+  throw new Error("Forbidden");
+}
+```
+
+Note: managers can edit other users' shared configs but NOT private ones — adjust the check if the product wants this. Default per spec: managers can edit other users' configs (manager = business-wide).
+
+- [ ] **Step 2: Patch `schedule.ts`** — same shape but no `isShared` column. User scope = `createdBy === user.id`. Manager/admin = bare.
+
+- [ ] **Step 3: Tests** — for each file create a test asserting:
+  - 401 unauth
+  - User can read own + shared configs (configs only) / own schedules
+  - User cannot delete/edit other users' configs/schedules
+  - Manager/admin can do everything
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm jest 'actions/reports/__tests__/(config|schedule)-scope.test.ts'
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add actions/reports/config.ts actions/reports/schedule.ts actions/reports/__tests__/
+git commit -m "fix(reports): scope config and schedule reads/mutations by role and ownership"
+```
+
+---
+
+## Task 6: Scope dashboard task count + unified search
+
+**Files:**
+- Modify: `actions/dashboard/get-tasks-count.ts`
+- Create: `actions/dashboard/__tests__/get-tasks-count.test.ts`
+- Modify: `actions/fulltext/unified-search.ts`
+
+`getTasksCount()` is currently global. Switch to user-scoped by default; admins/managers get global. (The legacy `getUsersTasksCount(userId)` callers pass a specific id — leave that signature alone, but require auth.)
+
+`unifiedSearch` must apply per-entity scope filters. Re-use `getReportScope(user)` and merge into each query's where.
+
+- [ ] **Step 1: Patch `get-tasks-count.ts`**
+
+```ts
+"use server";
+import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  AuthenticationError,
+} from "@/lib/authz";
+
+export const getTasksCount = async () => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return 0;
+    throw e;
+  }
+  if (user.role === "admin" || user.role === "manager") {
+    return prismadb.tasks.count();
+  }
+  return prismadb.tasks.count({ where: { user: user.id } });
+};
+
+export const getUsersTasksCount = async (userId: string) => {
+  await requireAuthenticated();
+  return prismadb.tasks.count({ where: { user: userId } });
+};
+```
+
+- [ ] **Step 2: Patch `unified-search.ts`**
+
+After the `requireAuthenticated` (replace existing `getSession` block), import `getReportScope` and merge:
+
+```ts
+const user = await requireAuthenticated();
+const scope = getReportScope(user);
+
+const kwAccounts = await prismadb.crm_Accounts.findMany({
+  where: { name: { search: query }, ...scope.account },
+  // ...
+});
+
+const kwLeads = await prismadb.crm_Leads.findMany({
+  where: { /* existing search */, ...scope.lead },
+  // ...
+});
+
+// same for crm_Contacts (scope.contact), crm_Opportunities (scope.opportunity),
+// tasks (scope.task), crm_campaigns (scope.campaign).
+
+// User directory: only include if scope.allowUserDirectory
+let kwUsers: any[] = [];
+if (scope.allowUserDirectory) {
+  kwUsers = await prismadb.users.findMany({ /* existing */ });
+}
+```
+
+- [ ] **Step 3: Tests**
+
+`actions/dashboard/__tests__/get-tasks-count.test.ts` — three cases: 0 unauth, user gets scoped count, admin gets global count.
+
+`unified-search` testing is tricky because of multi-entity. Add one minimal test: when role is user, the user-directory section returns empty. (Mocking 8+ Prisma calls is overkill for this PR.)
+
+- [ ] **Step 4: Run tests, commit**
+
+```bash
+git add actions/dashboard/ actions/fulltext/ actions/dashboard/__tests__/
+git commit -m "fix(reports): scope dashboard tasks count and unified search by role"
+```
+
+---
+
+## Task 7: Scope Inngest scheduled-report sender
+
+**Files:**
+- Modify: `inngest/functions/reports/send-scheduled.ts`
+- Create: `inngest/functions/reports/__tests__/send-scheduled-scope.test.ts`
+
+Current behavior: cron-trigger fetches all active schedules and runs each one with no scope, emailing global data even though the schedule was created by a `user`. Fix: when running a schedule, build the scope from the schedule's `createdBy` user role and pass it to `getReportData`.
+
+- [ ] **Step 1: Patch the Inngest function**
+
+```ts
+import { mapLegacyRole } from "@/lib/authz";
+import { getReportScope } from "@/lib/authz";
+
+// Inside the per-schedule loop:
+const owner = await prismadb.users.findUnique({
+  where: { id: schedule.createdBy },
+  select: { id: true, role: true },
+});
+if (!owner) {
+  console.warn(`[send-scheduled] skip schedule ${schedule.id}: owner missing`);
+  continue;
+}
+const scope = getReportScope({ id: owner.id, role: mapLegacyRole(owner.role) });
+
+const { data, headers } = await getReportData(
+  schedule.reportConfig.category,
+  parseFiltersFromConfig(schedule.reportConfig.filters),
+  scope,
+);
+// ... existing email send
+```
+
+- [ ] **Step 2: Test**
+
+Create a focused unit test that mocks Prisma + email send, asserts that for a `user`-role schedule owner the dispatcher gets a scope with non-empty `opportunity.OR`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add inngest/functions/reports/send-scheduled.ts inngest/functions/reports/__tests__/
+git commit -m "fix(reports): scope scheduled-report data by schedule owner role"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Full suite**
+
+```bash
+pnpm jest 2>&1 | tail -8
+```
+Expected: B3 tests pass; no new failures in unrelated suites.
+
+- [ ] **Step 2: Manual checklist (dev)**
+
+1. As `bob` (user), `GET /api/reports/export?category=sales&format=csv` → 200, CSV contains only opportunities `bob` owns/created
+2. As `bob`, `GET /api/reports/export?category=users` → 403
+3. As `manager`, both → 200, full data
+4. As `bob`, browser dashboard → tasks count reflects only `bob`'s tasks
+5. As `manager`, dashboard tasks count is global
+6. Trigger Inngest scheduled sender (via Inngest dev UI) on a user-owned schedule → email arrives with user-scoped data, not global
+
+- [ ] **Step 3: Push and PR**
+
+```bash
+git push -u origin feat/authz-phase-b3
+gh pr create --base dev --head feat/authz-phase-b3 --title "fix(security): scope reports + dashboard + unified search by role (Phase B3)" --body "..."
+```
+
+Body references: spec §6.13/§7.6/§8.15-16, audit "Global Report Export"/"Global CRM Read Actions", manual test results.
+
+---
+
+## Acceptance Criteria
+
+- `getReportScope(user)` returns role-appropriate per-entity Prisma where fragments.
+- All six report-category modules accept and apply `ReportScope` (user gets ownership filter; manager/admin unfiltered).
+- `users` report category requires manager+ at every entry point.
+- `app/api/reports/export` requires auth, gates users-category, passes scope to dispatcher.
+- `actions/reports/config.ts` and `schedule.ts` apply ownership/role rules to read and mutation entry points.
+- `getTasksCount()` returns scoped count for `user` role, global for manager/admin.
+- `unifiedSearch` applies per-entity scope; user-directory facet is hidden from `user` role.
+- Inngest scheduled sender computes scope from schedule.createdBy.role, not global.
+
+## Out of B3 scope
+
+- Per-category report email templates (still send the same CSV/PDF; just with scoped data).
+- Inngest worker hardening for arbitrary event payload abuse (see B1 deferred work).
+- Activity feed scoping (`actions/crm/activities/get-activities-by-entity.ts`) — Phase D.
+- Documents listing scoping — Phase E.
+- Removing `Users.is_admin` — Phase F.

--- a/lib/authz/__tests__/scopes-crm-enrichment.test.ts
+++ b/lib/authz/__tests__/scopes-crm-enrichment.test.ts
@@ -1,0 +1,83 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contact_Enrichment: { findUnique: jest.fn() },
+    crm_Target_Enrichment: { findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  assertCanCancelContactEnrichment,
+  assertCanCancelTargetEnrichment,
+} from "../scopes/crm";
+
+const findContactE = prismadb.crm_Contact_Enrichment.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Contact_Enrichment.findUnique
+>;
+const findTargetE = prismadb.crm_Target_Enrichment.findUnique as jest.MockedFunction<
+  typeof prismadb.crm_Target_Enrichment.findUnique
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanCancelContactEnrichment", () => {
+  it("throws when enrichment not found", async () => {
+    findContactE.mockResolvedValue(null);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "u", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("user: passes when triggeredBy matches", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: "u1" } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("user: throws when triggeredBy is someone else", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: "other" } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("manager: passes regardless of triggeredBy", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: "other" } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "m1", role: "manager" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("admin: passes regardless of triggeredBy", async () => {
+    findContactE.mockResolvedValue({ id: "e1", triggeredBy: null } as any);
+    await expect(
+      assertCanCancelContactEnrichment({ id: "a1", role: "admin" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertCanCancelTargetEnrichment", () => {
+  it("user: passes when triggeredBy matches", async () => {
+    findTargetE.mockResolvedValue({ id: "e1", triggeredBy: "u1" } as any);
+    await expect(
+      assertCanCancelTargetEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("user: throws when triggeredBy is someone else", async () => {
+    findTargetE.mockResolvedValue({ id: "e1", triggeredBy: "other" } as any);
+    await expect(
+      assertCanCancelTargetEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("throws when not found", async () => {
+    findTargetE.mockResolvedValue(null);
+    await expect(
+      assertCanCancelTargetEnrichment({ id: "u1", role: "user" }, "e1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});

--- a/lib/authz/__tests__/scopes-crm-read.test.ts
+++ b/lib/authz/__tests__/scopes-crm-read.test.ts
@@ -2,8 +2,8 @@ import { AuthorizationError } from "../errors";
 
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
-    crm_Contacts: { findFirst: jest.fn() },
-    crm_Targets: { findFirst: jest.fn() },
+    crm_Contacts: { findFirst: jest.fn(), findMany: jest.fn() },
+    crm_Targets: { findFirst: jest.fn(), findMany: jest.fn() },
   },
 }));
 
@@ -13,6 +13,8 @@ import {
   assertCanWriteContact,
   assertCanReadTarget,
   assertCanWriteTarget,
+  filterAuthorizedContactIds,
+  filterAuthorizedTargetIds,
 } from "../scopes/crm";
 
 const findContact = prismadb.crm_Contacts.findFirst as jest.MockedFunction<
@@ -132,5 +134,62 @@ describe("assertCanWriteTarget", () => {
     await expect(
       assertCanWriteTarget({ id: "u3", role: "user" }, "t1"),
     ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("filterAuthorizedContactIds", () => {
+  it("admin: returns all input ids that exist (queries with bare where)", async () => {
+    (prismadb.crm_Contacts.findMany as jest.Mock) =
+      jest.fn().mockResolvedValue([{ id: "a" }, { id: "b" }]);
+    const out = await filterAuthorizedContactIds(
+      { id: "u", role: "admin" },
+      ["a", "b", "c"],
+    );
+    expect(out).toEqual(["a", "b"]);
+    expect(prismadb.crm_Contacts.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["a", "b", "c"] } },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped where with OR clauses", async () => {
+    (prismadb.crm_Contacts.findMany as jest.Mock) =
+      jest.fn().mockResolvedValue([{ id: "a" }]);
+    await filterAuthorizedContactIds(
+      { id: "u3", role: "user" },
+      ["a", "b"],
+    );
+    const arg = (prismadb.crm_Contacts.findMany as jest.Mock).mock.calls[0][0];
+    expect(arg.where).toMatchObject({
+      id: { in: ["a", "b"] },
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { created_by: "u3" },
+        { createdBy: "u3" },
+      ]),
+    });
+  });
+
+  it("returns empty array when input is empty (no DB call)", async () => {
+    const fn = jest.fn();
+    (prismadb.crm_Contacts.findMany as jest.Mock) = fn;
+    const out = await filterAuthorizedContactIds(
+      { id: "u", role: "user" },
+      [],
+    );
+    expect(out).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe("filterAuthorizedTargetIds", () => {
+  it("user: scoped to created_by", async () => {
+    (prismadb.crm_Targets.findMany as jest.Mock) =
+      jest.fn().mockResolvedValue([{ id: "t1" }]);
+    await filterAuthorizedTargetIds({ id: "u3", role: "user" }, ["t1", "t2"]);
+    expect(prismadb.crm_Targets.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1", "t2"] }, created_by: "u3" },
+      select: { id: true },
+    });
   });
 });

--- a/lib/authz/__tests__/scopes-crm-read.test.ts
+++ b/lib/authz/__tests__/scopes-crm-read.test.ts
@@ -1,0 +1,136 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contacts: { findFirst: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  assertCanReadContact,
+  assertCanWriteContact,
+  assertCanReadTarget,
+  assertCanWriteTarget,
+} from "../scopes/crm";
+
+const findContact = prismadb.crm_Contacts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Contacts.findFirst
+>;
+const findTarget = prismadb.crm_Targets.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Targets.findFirst
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanReadContact", () => {
+  it("admin: bare where, resolves on hit", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await expect(
+      assertCanReadContact({ id: "u", role: "admin" }, "c1"),
+    ).resolves.toBeUndefined();
+    expect(findContact).toHaveBeenCalledWith({
+      where: { id: "c1" },
+      select: { id: true },
+    });
+  });
+
+  it("manager: bare where, resolves on hit", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await assertCanReadContact({ id: "u", role: "manager" }, "c1");
+    expect(findContact).toHaveBeenCalledWith({
+      where: { id: "c1" },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped where with ownership OR clauses", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await assertCanReadContact({ id: "u3", role: "user" }, "c1");
+    const arg = findContact.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({
+      id: "c1",
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { created_by: "u3" },
+        { createdBy: "u3" },
+      ]),
+    });
+  });
+
+  it("throws AuthorizationError when no row", async () => {
+    findContact.mockResolvedValue(null);
+    await expect(
+      assertCanReadContact({ id: "u3", role: "user" }, "c1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteContact", () => {
+  it("user: same scope as read for now (Phase D may diverge)", async () => {
+    findContact.mockResolvedValue({ id: "c1" } as any);
+    await assertCanWriteContact({ id: "u3", role: "user" }, "c1");
+    const arg = findContact.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({
+      id: "c1",
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { created_by: "u3" },
+        { createdBy: "u3" },
+      ]),
+    });
+  });
+
+  it("throws AuthorizationError when no row", async () => {
+    findContact.mockResolvedValue(null);
+    await expect(
+      assertCanWriteContact({ id: "u3", role: "user" }, "c1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanReadTarget", () => {
+  it("admin: bare where", async () => {
+    findTarget.mockResolvedValue({ id: "t1" } as any);
+    await assertCanReadTarget({ id: "u", role: "admin" }, "t1");
+    expect(findTarget).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped to created_by", async () => {
+    findTarget.mockResolvedValue({ id: "t1" } as any);
+    await assertCanReadTarget({ id: "u3", role: "user" }, "t1");
+    expect(findTarget).toHaveBeenCalledWith({
+      where: { id: "t1", created_by: "u3" },
+      select: { id: true },
+    });
+  });
+
+  it("throws AuthorizationError on miss", async () => {
+    findTarget.mockResolvedValue(null);
+    await expect(
+      assertCanReadTarget({ id: "u3", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteTarget", () => {
+  it("user: scoped to created_by", async () => {
+    findTarget.mockResolvedValue({ id: "t1" } as any);
+    await assertCanWriteTarget({ id: "u3", role: "user" }, "t1");
+    expect(findTarget).toHaveBeenCalledWith({
+      where: { id: "t1", created_by: "u3" },
+      select: { id: true },
+    });
+  });
+
+  it("throws on miss", async () => {
+    findTarget.mockResolvedValue(null);
+    await expect(
+      assertCanWriteTarget({ id: "u3", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -17,3 +17,9 @@ export {
   tryScopedUpdateContact,
   tryScopedUpdateTarget,
 } from "./scopes/crm";
+export {
+  assertCanReadContact,
+  assertCanWriteContact,
+  assertCanReadTarget,
+  assertCanWriteTarget,
+} from "./scopes/crm";

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -27,3 +27,7 @@ export {
   filterAuthorizedContactIds,
   filterAuthorizedTargetIds,
 } from "./scopes/crm";
+export {
+  assertCanCancelContactEnrichment,
+  assertCanCancelTargetEnrichment,
+} from "./scopes/crm";

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -23,3 +23,7 @@ export {
   assertCanReadTarget,
   assertCanWriteTarget,
 } from "./scopes/crm";
+export {
+  filterAuthorizedContactIds,
+  filterAuthorizedTargetIds,
+} from "./scopes/crm";

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -1,5 +1,6 @@
 import { prismadb } from "@/lib/prisma";
 import { AuthzUser } from "../session";
+import { AuthorizationError } from "../errors";
 
 type ContactWhere = NonNullable<
   Parameters<typeof prismadb.crm_Contacts.updateMany>[0]
@@ -53,4 +54,71 @@ export async function tryScopedUpdateTarget(
     data: { ...data, updatedBy: user.id },
   });
   return result.count > 0;
+}
+
+// Read scope mirrors write scope in Phase B1.
+// Phase D may add separate read-only ownership rules (e.g., watchers).
+async function findContactInScope(user: AuthzUser, contactId: string) {
+  if (user.role === "admin" || user.role === "manager") {
+    return prismadb.crm_Contacts.findFirst({
+      where: { id: contactId },
+      select: { id: true },
+    });
+  }
+  return prismadb.crm_Contacts.findFirst({
+    where: {
+      id: contactId,
+      OR: [
+        { assigned_to: user.id },
+        { created_by: user.id },
+        { createdBy: user.id },
+      ],
+    },
+    select: { id: true },
+  });
+}
+
+async function findTargetInScope(user: AuthzUser, targetId: string) {
+  if (user.role === "admin" || user.role === "manager") {
+    return prismadb.crm_Targets.findFirst({
+      where: { id: targetId },
+      select: { id: true },
+    });
+  }
+  return prismadb.crm_Targets.findFirst({
+    where: { id: targetId, created_by: user.id },
+    select: { id: true },
+  });
+}
+
+export async function assertCanReadContact(
+  user: AuthzUser,
+  contactId: string,
+): Promise<void> {
+  const row = await findContactInScope(user, contactId);
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteContact(
+  user: AuthzUser,
+  contactId: string,
+): Promise<void> {
+  const row = await findContactInScope(user, contactId);
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanReadTarget(
+  user: AuthzUser,
+  targetId: string,
+): Promise<void> {
+  const row = await findTargetInScope(user, targetId);
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteTarget(
+  user: AuthzUser,
+  targetId: string,
+): Promise<void> {
+  const row = await findTargetInScope(user, targetId);
+  if (!row) throw new AuthorizationError();
 }

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -146,6 +146,32 @@ export async function filterAuthorizedContactIds(
   return rows.map((r: { id: string }) => r.id);
 }
 
+export async function assertCanCancelContactEnrichment(
+  user: AuthzUser,
+  enrichmentId: string,
+): Promise<void> {
+  const row = (await prismadb.crm_Contact_Enrichment.findUnique({
+    where: { id: enrichmentId },
+    select: { id: true, triggeredBy: true },
+  })) as { id: string; triggeredBy: string | null } | null;
+  if (!row) throw new AuthorizationError();
+  if (user.role === "admin" || user.role === "manager") return;
+  if (row.triggeredBy !== user.id) throw new AuthorizationError();
+}
+
+export async function assertCanCancelTargetEnrichment(
+  user: AuthzUser,
+  enrichmentId: string,
+): Promise<void> {
+  const row = (await prismadb.crm_Target_Enrichment.findUnique({
+    where: { id: enrichmentId },
+    select: { id: true, triggeredBy: true },
+  })) as { id: string; triggeredBy: string | null } | null;
+  if (!row) throw new AuthorizationError();
+  if (user.role === "admin" || user.role === "manager") return;
+  if (row.triggeredBy !== user.id) throw new AuthorizationError();
+}
+
 export async function filterAuthorizedTargetIds(
   user: AuthzUser,
   targetIds: string[],

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -122,3 +122,42 @@ export async function assertCanWriteTarget(
   const row = await findTargetInScope(user, targetId);
   if (!row) throw new AuthorizationError();
 }
+
+export async function filterAuthorizedContactIds(
+  user: AuthzUser,
+  contactIds: string[],
+): Promise<string[]> {
+  if (contactIds.length === 0) return [];
+  const baseWhere =
+    user.role === "admin" || user.role === "manager"
+      ? { id: { in: contactIds } }
+      : {
+          id: { in: contactIds },
+          OR: [
+            { assigned_to: user.id },
+            { created_by: user.id },
+            { createdBy: user.id },
+          ],
+        };
+  const rows = await prismadb.crm_Contacts.findMany({
+    where: baseWhere,
+    select: { id: true },
+  });
+  return rows.map((r: { id: string }) => r.id);
+}
+
+export async function filterAuthorizedTargetIds(
+  user: AuthzUser,
+  targetIds: string[],
+): Promise<string[]> {
+  if (targetIds.length === 0) return [];
+  const baseWhere =
+    user.role === "admin" || user.role === "manager"
+      ? { id: { in: targetIds } }
+      : { id: { in: targetIds }, created_by: user.id };
+  const rows = await prismadb.crm_Targets.findMany({
+    where: baseWhere,
+    select: { id: true },
+  });
+  return rows.map((r: { id: string }) => r.id);
+}


### PR DESCRIPTION
## Summary

Closes the remaining audit findings on every enrichment-related API route. After B1, no authenticated user can read, enrich, or cancel an enrichment for a contact/target they don't own.

## What changed

**New `lib/authz/scopes/crm.ts` helpers (Phase A extended):**
- \`assertCanReadContact\`, \`assertCanWriteContact\`, \`assertCanReadTarget\`, \`assertCanWriteTarget\` — throw \`AuthorizationError\` when the user can't access a row
- \`filterAuthorizedContactIds\`, \`filterAuthorizedTargetIds\` — for bulk endpoints
- \`assertCanCancelContactEnrichment\`, \`assertCanCancelTargetEnrichment\` — bind cancel to enrichment owner

**Routes patched (object-level auth before any DB write or Inngest send):**
- \`POST/DELETE /api/crm/contacts/enrich\` — \`assertCanWriteContact\` + \`assertCanCancelContactEnrichment\`
- \`POST /api/crm/contacts/enrich-bulk\` — fail-closed if any id unauthorized
- \`POST/DELETE /api/crm/targets/enrich\` — \`assertCanWriteTarget\` + \`assertCanCancelTargetEnrichment\`
- \`POST /api/crm/targets/enrich-bulk\` — fail-closed
- \`POST /api/crm/targets/[id]/enrich\`
- \`POST /api/crm/targets/[id]/contacts\` — parent target write scope
- \`POST /api/crm/targets/[id]/contacts/[contactId]/enrich\` — target write scope + linkage check

**Campaign re-exports auto-fixed:**
- \`/api/campaigns/targets/[id]/enrich\`
- \`/api/campaigns/targets/enrich\`
- \`/api/campaigns/targets/enrich-bulk\`

## Cancel binding (approach b)

\`DELETE\` no longer accepts unauthenticated cancels. Sequence: \`requireAuthenticated\` → look up \`enrichmentId\` from in-memory \`activeSessions\` map → \`assertCanCancel*Enrichment\` checks the row's \`triggeredBy === user.id\` (manager/admin pass).

## Test status

- 43/50 suites pass, 233/235 tests pass (baseline before B1: 34/41, 183/185)
- All new B1 unit + route tests pass (~30 new tests across 11 files)
- 7 pre-existing suite failures and 2 pre-existing test failures unchanged — no new regressions

## Test plan

- [ ] As \`bob\` (user, not owner), \`POST /api/crm/contacts/enrich\` with \`alice\`'s contactId → 404, no \`crm_Contact_Enrichment\` row created
- [ ] As \`bob\`, \`DELETE /api/crm/contacts/enrich?sessionId=<alice-active>\` → 404, alice's enrichment unchanged
- [ ] As \`bob\`, \`POST /api/crm/contacts/enrich-bulk\` with \`[alice-id, bob-id]\` → 403, no Inngest event
- [ ] Same three for targets
- [ ] As \`bob\`, \`POST /api/crm/targets/<alice-target>/contacts\` → 404
- [ ] As \`bob\`, \`POST /api/crm/targets/<alice-target>/contacts/<id>/enrich\` → 404
- [ ] Hit campaign re-exports with alice's targetId → 404 (re-export inherits)

## Out of B1 scope

- **Inngest worker re-validation.** Workers still trust \`triggeredBy\` and ids in event payload — separate hardening pass.
- **Redis-backed session store.** \`activeSessions\` is module-local; multi-replica edge cases out of scope.
- **B2 (invoice IDOR), B3 (reports scoping)** — separate PRs, plans included in this branch.

Plans: \`docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b{1,2,3}.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)