### PR TITLE
fix(security): close invoice IDOR (Phase B2)

### DIFF
--- a/__tests__/lib/invoices/permissions.test.ts
+++ b/__tests__/lib/invoices/permissions.test.ts
@@ -1,14 +1,26 @@
 import {
-  canEditInvoice, canIssueInvoice, canCancelInvoice, canAddPayment, isInvoiceImmutable,
+  canEditInvoice, canIssueInvoice, canCancelInvoice, canAddPayment, canReadInvoice, isInvoiceImmutable,
 } from "@/lib/invoices/permissions";
 
-const u  = { id: "u1", isAdmin: false };
-const ad = { id: "admin", isAdmin: true };
+const u  = { id: "u1", role: "user" as const };
+const mg = { id: "m",  role: "manager" as const };
+const ad = { id: "a",  role: "admin" as const };
 
 describe("isInvoiceImmutable", () => {
   it("DRAFT is mutable", () => expect(isInvoiceImmutable("DRAFT")).toBe(false));
   it.each(["ISSUED","SENT","PAID","PARTIALLY_PAID","CANCELLED"] as const)("%s is immutable", s =>
     expect(isInvoiceImmutable(s)).toBe(true));
+});
+
+describe("canReadInvoice", () => {
+  it("creator can read", () =>
+    expect(canReadInvoice({ status: "DRAFT", createdBy: "u1" }, u)).toBe(true));
+  it("non-creator user cannot read", () =>
+    expect(canReadInvoice({ status: "DRAFT", createdBy: "u2" }, u)).toBe(false));
+  it("manager can read any", () =>
+    expect(canReadInvoice({ status: "DRAFT", createdBy: "u2" }, mg)).toBe(true));
+  it("admin can read any", () =>
+    expect(canReadInvoice({ status: "PAID", createdBy: "u2" }, ad)).toBe(true));
 });
 
 describe("canEditInvoice", () => {
@@ -18,6 +30,8 @@ describe("canEditInvoice", () => {
     expect(canEditInvoice({ status: "DRAFT", createdBy: "u2" }, u)).toBe(false));
   it("admin can edit any DRAFT", () =>
     expect(canEditInvoice({ status: "DRAFT", createdBy: "u2" }, ad)).toBe(true));
+  it("manager can edit any DRAFT", () =>
+    expect(canEditInvoice({ status: "DRAFT", createdBy: "u2" }, mg)).toBe(true));
   it("nobody can edit ISSUED", () =>
     expect(canEditInvoice({ status: "ISSUED", createdBy: "u1" }, ad)).toBe(false));
 });
@@ -25,6 +39,8 @@ describe("canEditInvoice", () => {
 describe("canIssueInvoice", () => {
   it("creator can issue own DRAFT", () =>
     expect(canIssueInvoice({ status: "DRAFT", createdBy: "u1" }, u)).toBe(true));
+  it("manager can issue any DRAFT", () =>
+    expect(canIssueInvoice({ status: "DRAFT", createdBy: "u2" }, mg)).toBe(true));
   it("cannot issue non-DRAFT", () =>
     expect(canIssueInvoice({ status: "ISSUED", createdBy: "u1" }, u)).toBe(false));
 });
@@ -32,6 +48,8 @@ describe("canIssueInvoice", () => {
 describe("canCancelInvoice", () => {
   it("creator can cancel DRAFT", () =>
     expect(canCancelInvoice({ status: "DRAFT", createdBy: "u1" }, u)).toBe(true));
+  it("manager can cancel any DRAFT", () =>
+    expect(canCancelInvoice({ status: "DRAFT", createdBy: "u2" }, mg)).toBe(true));
   it("cannot cancel ISSUED", () =>
     expect(canCancelInvoice({ status: "ISSUED", createdBy: "u1" }, ad)).toBe(false));
 });
@@ -39,6 +57,8 @@ describe("canCancelInvoice", () => {
 describe("canAddPayment", () => {
   it("admin can add payment to ISSUED", () =>
     expect(canAddPayment({ status: "ISSUED", createdBy: "u2" }, ad)).toBe(true));
+  it("manager can add payment to ISSUED", () =>
+    expect(canAddPayment({ status: "ISSUED", createdBy: "u2" }, mg)).toBe(true));
   it("cannot add payment to DRAFT", () =>
     expect(canAddPayment({ status: "DRAFT", createdBy: "u1" }, u)).toBe(false));
   it("cannot add payment to CANCELLED", () =>

--- a/actions/invoices/__tests__/create-invoice-account-scope.test.ts
+++ b/actions/invoices/__tests__/create-invoice-account-scope.test.ts
@@ -1,0 +1,58 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    invoice_TaxRates: { findMany: jest.fn().mockResolvedValue([]) },
+    invoices: { create: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { createInvoice } from "../create-invoice";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fa = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const ci = prismadb.invoices.create as jest.MockedFunction<typeof prismadb.invoices.create>;
+
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+const validInput = {
+  type: "INVOICE",
+  accountId: ACCOUNT_ID,
+  currency: "USD",
+  lineItems: [
+    { position: 0, description: "x", quantity: 1, unitPrice: 100, discountPercent: 0 },
+  ],
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("createInvoice account-scope", () => {
+  it("throws when user has no access to accountId", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue(null);
+    await expect(createInvoice(validInput)).rejects.toThrow(/forbidden/i);
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("succeeds for user owning the account", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID } as any);
+    ci.mockResolvedValue({ id: "new" } as any);
+    await createInvoice(validInput);
+    expect(ci).toHaveBeenCalledTimes(1);
+  });
+
+  it("manager can create against any account", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID } as any);
+    ci.mockResolvedValue({ id: "new" } as any);
+    await createInvoice(validInput);
+    expect(ci).toHaveBeenCalled();
+  });
+});

--- a/actions/invoices/__tests__/duplicate-invoice.test.ts
+++ b/actions/invoices/__tests__/duplicate-invoice.test.ts
@@ -1,0 +1,55 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    invoices: { findUniqueOrThrow: jest.fn(), create: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { duplicateInvoice } from "../duplicate-invoice";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fi = prismadb.invoices.findUniqueOrThrow as jest.MockedFunction<typeof prismadb.invoices.findUniqueOrThrow>;
+const fa = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const ci = prismadb.invoices.create as jest.MockedFunction<typeof prismadb.invoices.create>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("duplicateInvoice", () => {
+  it("throws when unauthenticated", async () => {
+    gs.mockResolvedValue(null as any);
+    await expect(duplicateInvoice("i1")).rejects.toThrow();
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("throws when user cannot read source invoice", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ id: "src", createdBy: "other", status: "ISSUED", accountId: "a1", lineItems: [] } as any);
+    await expect(duplicateInvoice("i1")).rejects.toThrow(/forbidden/i);
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("throws when user cannot write the copied accountId", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ id: "src", createdBy: "u", status: "ISSUED", accountId: "a1", lineItems: [] } as any);
+    fa.mockResolvedValue(null);
+    await expect(duplicateInvoice("i1")).rejects.toThrow(/forbidden/i);
+    expect(ci).not.toHaveBeenCalled();
+  });
+
+  it("succeeds when both checks pass", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ id: "src", createdBy: "u", status: "ISSUED", accountId: "a1", lineItems: [], type: "INVOICE", currency: "USD", subtotal: "0", discountTotal: "0", vatTotal: "0", grandTotal: "0" } as any);
+    fa.mockResolvedValue({ id: "a1" } as any);
+    ci.mockResolvedValue({ id: "new" } as any);
+    await duplicateInvoice("i1");
+    expect(ci).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/invoices/add-payment.ts
+++ b/actions/invoices/add-payment.ts
@@ -5,6 +5,7 @@ import { getUser } from "@/actions/get-user";
 import { Decimal } from "decimal.js";
 import { addPaymentSchema } from "@/types/invoice";
 import { canAddPayment, type InvoiceStatus } from "@/lib/invoices/permissions";
+import { mapLegacyRole } from "@/lib/authz";
 import { serializeDecimals } from "@/lib/serialize-decimals";
 
 export async function addPayment(raw: unknown) {
@@ -20,7 +21,7 @@ export async function addPayment(raw: unknown) {
     if (
       !canAddPayment(
         { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
-        { id: user.id, isAdmin: user.is_admin }
+        { id: user.id, role: mapLegacyRole(user.role) }
       )
     ) {
       throw new Error("Cannot add payment to this invoice");

--- a/actions/invoices/cancel-invoice.ts
+++ b/actions/invoices/cancel-invoice.ts
@@ -3,6 +3,7 @@
 import { prismadb } from "@/lib/prisma";
 import { getUser } from "@/actions/get-user";
 import { canCancelInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
+import { mapLegacyRole } from "@/lib/authz";
 import { serializeDecimals } from "@/lib/serialize-decimals";
 
 export async function cancelInvoice(invoiceId: string) {
@@ -16,7 +17,7 @@ export async function cancelInvoice(invoiceId: string) {
   if (
     !canCancelInvoice(
       { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
-      { id: user.id, isAdmin: user.is_admin }
+      { id: user.id, role: mapLegacyRole(user.role) }
     )
   ) {
     throw new Error("Cannot cancel this invoice");

--- a/actions/invoices/create-invoice.ts
+++ b/actions/invoices/create-invoice.ts
@@ -1,15 +1,33 @@
 "use server";
 
 import { prismadb } from "@/lib/prisma";
-import { getUser } from "@/actions/get-user";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { Decimal } from "decimal.js";
 import { computeInvoiceTotals, computeLineTotal } from "@/lib/invoices/totals";
 import { createInvoiceSchema } from "@/types/invoice";
 import { serializeDecimals } from "@/lib/serialize-decimals";
 
 export async function createInvoice(raw: unknown) {
-  const user = await getUser();
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
   const input = createInvoiceSchema.parse(raw);
+
+  try {
+    await assertCanWriteAccount(user, input.accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
 
   const taxRates = await prismadb.invoice_TaxRates.findMany({
     where: {

--- a/actions/invoices/delete-payment.ts
+++ b/actions/invoices/delete-payment.ts
@@ -1,14 +1,21 @@
 "use server";
 
 import { prismadb } from "@/lib/prisma";
-import { getUser } from "@/actions/get-user";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { Decimal } from "decimal.js";
 
 export async function deletePayment(paymentId: string) {
-  const user = await getUser();
-
-  if (!user.is_admin) {
-    throw new Error("Only admins can delete payments");
+  let user;
+  try {
+    user = await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    if (e instanceof AuthorizationError) throw new Error("Only admins can delete payments");
+    throw e;
   }
 
   return prismadb.$transaction(async (tx) => {

--- a/actions/invoices/duplicate-invoice.ts
+++ b/actions/invoices/duplicate-invoice.ts
@@ -1,16 +1,44 @@
 "use server";
 
 import { prismadb } from "@/lib/prisma";
-import { getUser } from "@/actions/get-user";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+import { canReadInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
 import { serializeDecimals } from "@/lib/serialize-decimals";
 
 export async function duplicateInvoice(invoiceId: string) {
-  const user = await getUser();
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
 
   const source = await prismadb.invoices.findUniqueOrThrow({
     where: { id: invoiceId },
     include: { lineItems: { orderBy: { position: "asc" } } },
   });
+
+  if (
+    !canReadInvoice(
+      { status: source.status as InvoiceStatus, createdBy: source.createdBy },
+      { id: user.id, role: user.role },
+    )
+  ) {
+    throw new Error("Forbidden");
+  }
+
+  try {
+    await assertCanWriteAccount(user, source.accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
 
   const invoice = await prismadb.invoices.create({
     data: {

--- a/actions/invoices/issue-invoice.ts
+++ b/actions/invoices/issue-invoice.ts
@@ -5,6 +5,7 @@ import { getUser } from "@/actions/get-user";
 import { Decimal } from "decimal.js";
 import { computeInvoiceTotals } from "@/lib/invoices/totals";
 import { canIssueInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
+import { mapLegacyRole } from "@/lib/authz";
 import { consumeNextNumber } from "@/lib/invoices/numbering";
 import { fetchFxRate } from "@/lib/invoices/fx";
 import { issueInvoiceSchema } from "@/types/invoice";
@@ -29,7 +30,7 @@ export async function issueInvoice(raw: unknown) {
   if (
     !canIssueInvoice(
       { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
-      { id: user.id, isAdmin: user.is_admin }
+      { id: user.id, role: mapLegacyRole(user.role) }
     )
   ) {
     throw new Error("Cannot issue this invoice");

--- a/actions/invoices/regenerate-pdf.ts
+++ b/actions/invoices/regenerate-pdf.ts
@@ -3,6 +3,8 @@
 import { revalidatePath } from "next/cache";
 import { prismadb } from "@/lib/prisma";
 import { getUser } from "@/actions/get-user";
+import { mapLegacyRole } from "@/lib/authz";
+import { canReadInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
 import { renderInvoicePdf } from "@/lib/invoices/pdf/render";
 import { uploadInvoicePdf } from "@/lib/invoices/storage";
 import { buildInvoicePdfData } from "@/lib/invoices/pdf/build-pdf-data";
@@ -33,8 +35,13 @@ export async function regenerateInvoicePdf(
       },
     });
 
-    // Permission: admin OR the creator of the invoice
-    if (!user.is_admin && invoice.createdBy !== user.id) {
+    // Permission: manager/admin OR the creator of the invoice
+    if (
+      !canReadInvoice(
+        { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
+        { id: user.id, role: mapLegacyRole(user.role) },
+      )
+    ) {
       return { ok: false, error: "Forbidden" };
     }
 

--- a/actions/invoices/send-invoice-email.ts
+++ b/actions/invoices/send-invoice-email.ts
@@ -2,6 +2,8 @@
 
 import { prismadb } from "@/lib/prisma";
 import { getUser } from "@/actions/get-user";
+import { mapLegacyRole } from "@/lib/authz";
+import { canReadInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
 import resendHelper from "@/lib/resend";
 import { getInvoicePdfStream } from "@/lib/invoices/storage";
 import { InvoiceEmail } from "@/emails/InvoiceEmail";
@@ -29,7 +31,12 @@ export async function sendInvoiceEmail(input: SendInvoiceEmailInput) {
     },
   });
 
-  if (invoice.createdBy !== user.id && !user.is_admin) {
+  if (
+    !canReadInvoice(
+      { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
+      { id: user.id, role: mapLegacyRole(user.role) },
+    )
+  ) {
     throw new Error("Forbidden");
   }
 

--- a/actions/invoices/update-invoice.ts
+++ b/actions/invoices/update-invoice.ts
@@ -6,6 +6,7 @@ import { Decimal } from "decimal.js";
 import { computeInvoiceTotals, computeLineTotal } from "@/lib/invoices/totals";
 import { updateInvoiceSchema } from "@/types/invoice";
 import { canEditInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
+import { mapLegacyRole } from "@/lib/authz";
 import { serializeDecimals } from "@/lib/serialize-decimals";
 
 export async function updateInvoice(invoiceId: string, raw: unknown) {
@@ -20,7 +21,7 @@ export async function updateInvoice(invoiceId: string, raw: unknown) {
   if (
     !canEditInvoice(
       { status: existing.status as InvoiceStatus, createdBy: existing.createdBy },
-      { id: user.id, isAdmin: user.is_admin }
+      { id: user.id, role: mapLegacyRole(user.role) }
     )
   ) {
     throw new Error("Cannot edit this invoice");

--- a/actions/invoices/update-invoice.ts
+++ b/actions/invoices/update-invoice.ts
@@ -6,7 +6,11 @@ import { Decimal } from "decimal.js";
 import { computeInvoiceTotals, computeLineTotal } from "@/lib/invoices/totals";
 import { updateInvoiceSchema } from "@/types/invoice";
 import { canEditInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
-import { mapLegacyRole } from "@/lib/authz";
+import {
+  mapLegacyRole,
+  assertCanWriteAccount,
+  AuthorizationError,
+} from "@/lib/authz";
 import { serializeDecimals } from "@/lib/serialize-decimals";
 
 export async function updateInvoice(invoiceId: string, raw: unknown) {
@@ -25,6 +29,18 @@ export async function updateInvoice(invoiceId: string, raw: unknown) {
     )
   ) {
     throw new Error("Cannot edit this invoice");
+  }
+
+  if ("accountId" in (input as Record<string, unknown>) && (input as { accountId?: string }).accountId) {
+    try {
+      await assertCanWriteAccount(
+        { id: user.id, role: mapLegacyRole(user.role) },
+        (input as { accountId: string }).accountId,
+      );
+    } catch (e) {
+      if (e instanceof AuthorizationError) throw new Error("Forbidden");
+      throw e;
+    }
   }
 
   // If lineItems provided, recompute totals

--- a/app/api/invoices/[invoiceId]/pdf/__tests__/route.test.ts
+++ b/app/api/invoices/[invoiceId]/pdf/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    invoices: { findUnique: jest.fn() },
+  },
+}));
+jest.mock("@/lib/invoices/storage", () => ({
+  getInvoicePdfPresignedUrl: jest.fn().mockResolvedValue("https://s3.example/x"),
+}));
+
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { GET } from "../route";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fi = prismadb.invoices.findUnique as jest.MockedFunction<typeof prismadb.invoices.findUnique>;
+
+function req() {
+  return new NextRequest("http://localhost/api/invoices/i1/pdf");
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/invoices/[invoiceId]/pdf", () => {
+  it("401 unauth", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when user does not own the invoice", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ createdBy: "other", status: "ISSUED", pdfStorageKey: "k" } as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("404 when invoice not found", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue(null);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("creator gets redirect to presigned URL", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fi.mockResolvedValue({ createdBy: "u", status: "ISSUED", pdfStorageKey: "k" } as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect([302, 307]).toContain(res.status);
+  });
+
+  it("manager gets redirect for any invoice", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    fi.mockResolvedValue({ createdBy: "other", status: "ISSUED", pdfStorageKey: "k" } as any);
+    const res = await GET(req(), { params: Promise.resolve({ invoiceId: "i1" }) });
+    expect([302, 307]).toContain(res.status);
+  });
+});

--- a/app/api/invoices/[invoiceId]/pdf/route.ts
+++ b/app/api/invoices/[invoiceId]/pdf/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  unauthorizedResponse,
+  notFoundOrForbiddenResponse,
+  AuthenticationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
+import { canReadInvoice, type InvoiceStatus } from "@/lib/invoices/permissions";
 import { getInvoicePdfPresignedUrl } from "@/lib/invoices/storage";
 
 export async function GET(
@@ -8,24 +14,33 @@ export async function GET(
   { params }: { params: Promise<{ invoiceId: string }> }
 ) {
   const { invoiceId } = await params;
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return unauthorizedResponse();
+    throw e;
   }
 
   const invoice = await prismadb.invoices.findUnique({
     where: { id: invoiceId },
-    select: { pdfStorageKey: true },
+    select: { createdBy: true, status: true, pdfStorageKey: true },
   });
+  if (!invoice) return notFoundOrForbiddenResponse();
 
-  if (!invoice) {
-    return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+  if (
+    !canReadInvoice(
+      { status: invoice.status as InvoiceStatus, createdBy: invoice.createdBy },
+      { id: user.id, role: user.role },
+    )
+  ) {
+    return notFoundOrForbiddenResponse();
   }
 
   if (!invoice.pdfStorageKey) {
     return NextResponse.json(
       { error: "PDF not yet generated. Issue the invoice first." },
-      { status: 404 }
+      { status: 404 },
     );
   }
 

--- a/lib/authz/__tests__/scopes-crm-account.test.ts
+++ b/lib/authz/__tests__/scopes-crm-account.test.ts
@@ -1,0 +1,57 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Accounts: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { assertCanWriteAccount } from "../scopes/crm";
+
+const find = prismadb.crm_Accounts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Accounts.findFirst
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanWriteAccount", () => {
+  it("admin: bare where", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanWriteAccount({ id: "u", role: "admin" }, "a1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "a1" },
+      select: { id: true },
+    });
+  });
+
+  it("manager: bare where", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanWriteAccount({ id: "u", role: "manager" }, "a1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "a1" },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped with assigned/creator/watcher OR clauses", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanWriteAccount({ id: "u3", role: "user" }, "a1");
+    const arg = find.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({
+      id: "a1",
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { createdBy: "u3" },
+        { watchers: { some: { user_id: "u3" } } },
+      ]),
+    });
+  });
+
+  it("throws AuthorizationError when not in scope", async () => {
+    find.mockResolvedValue(null);
+    await expect(
+      assertCanWriteAccount({ id: "u3", role: "user" }, "a1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -31,3 +31,4 @@ export {
   assertCanCancelContactEnrichment,
   assertCanCancelTargetEnrichment,
 } from "./scopes/crm";
+export { assertCanWriteAccount } from "./scopes/crm";

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -187,3 +187,25 @@ export async function filterAuthorizedTargetIds(
   });
   return rows.map((r: { id: string }) => r.id);
 }
+
+export async function assertCanWriteAccount(
+  user: AuthzUser,
+  accountId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: accountId }
+      : {
+          id: accountId,
+          OR: [
+            { assigned_to: user.id },
+            { createdBy: user.id },
+            { watchers: { some: { user_id: user.id } } },
+          ],
+        };
+  const row = await prismadb.crm_Accounts.findFirst({
+    where,
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}

--- a/lib/invoices/permissions.ts
+++ b/lib/invoices/permissions.ts
@@ -1,31 +1,41 @@
+import type { AppRole } from "@/lib/authz";
+
 export type InvoiceStatus =
   | "DRAFT" | "ISSUED" | "SENT" | "PARTIALLY_PAID" | "PAID"
   | "OVERDUE" | "CANCELLED" | "DISPUTED" | "REFUNDED" | "WRITTEN_OFF";
 
-interface UserCtx { id: string; isAdmin: boolean; }
-interface InvoiceCtx { status: InvoiceStatus; createdBy: string; }
+export interface UserCtx { id: string; role: AppRole; }
+export interface InvoiceCtx { status: InvoiceStatus; createdBy: string; }
 
 export function isInvoiceImmutable(status: InvoiceStatus): boolean {
   return status !== "DRAFT";
 }
 
-function isOwnerOrAdmin(invoice: InvoiceCtx, user: UserCtx): boolean {
-  return user.isAdmin || invoice.createdBy === user.id;
+function isManagerOrAdmin(user: UserCtx): boolean {
+  return user.role === "manager" || user.role === "admin";
+}
+
+function isOwnerOrPrivileged(invoice: InvoiceCtx, user: UserCtx): boolean {
+  return isManagerOrAdmin(user) || invoice.createdBy === user.id;
+}
+
+export function canReadInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
+  return isOwnerOrPrivileged(invoice, user);
 }
 
 export function canEditInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
   if (isInvoiceImmutable(invoice.status)) return false;
-  return isOwnerOrAdmin(invoice, user);
+  return isOwnerOrPrivileged(invoice, user);
 }
 
 export function canIssueInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
   if (invoice.status !== "DRAFT") return false;
-  return isOwnerOrAdmin(invoice, user);
+  return isOwnerOrPrivileged(invoice, user);
 }
 
 export function canCancelInvoice(invoice: InvoiceCtx, user: UserCtx): boolean {
   if (invoice.status !== "DRAFT") return false;
-  return isOwnerOrAdmin(invoice, user);
+  return isOwnerOrPrivileged(invoice, user);
 }
 
 const PAYMENT_ALLOWED: ReadonlySet<InvoiceStatus> = new Set<InvoiceStatus>([
@@ -34,5 +44,5 @@ const PAYMENT_ALLOWED: ReadonlySet<InvoiceStatus> = new Set<InvoiceStatus>([
 
 export function canAddPayment(invoice: InvoiceCtx, user: UserCtx): boolean {
   if (!PAYMENT_ALLOWED.has(invoice.status)) return false;
-  return isOwnerOrAdmin(invoice, user);
+  return isOwnerOrPrivileged(invoice, user);
 }


### PR DESCRIPTION
## Summary

Closes the invoice authorization gaps from the audit: PDF download IDOR, unauthenticated `duplicateInvoice`, missing account-write check on `createInvoice`/`updateInvoice`. Also refactors `lib/invoices/permissions.ts` from boolean-only `isAdmin` to role-aware so `manager` and `admin` both pass invoice gates without per-call-site special cases.

## What changed

**New `lib/authz/scopes/crm.ts` helper:**
- `assertCanWriteAccount(user, accountId)` — user scope: `assigned_to=user.id OR createdBy=user.id OR exists in AccountWatchers`. Manager/admin: bare lookup.

**Role-aware invoice permissions:**
- `UserCtx` now `{ id: string, role: AppRole }` (was `{ id, isAdmin: boolean }`)
- New `canReadInvoice` helper (creator OR manager OR admin)
- All existing helpers (`canEditInvoice`, `canIssueInvoice`, `canCancelInvoice`, `canAddPayment`) now accept manager+admin

**Routes / actions patched:**
- `GET /api/invoices/[invoiceId]/pdf` — `canReadInvoice` check; 404 on permission failure
- `actions/invoices/duplicate-invoice.ts` — `requireAuthenticated` + `canReadInvoice` on source + `assertCanWriteAccount` on copied accountId (was zero auth)
- `actions/invoices/create-invoice.ts` — `assertCanWriteAccount(user, input.accountId)` before DB write
- `actions/invoices/update-invoice.ts` — `assertCanWriteAccount` when caller reassigns accountId
- `actions/invoices/delete-payment.ts` — switched from `user.is_admin` to `requireRole(["admin"])`
- `actions/invoices/{cancel,issue,add-payment,send-invoice-email,regenerate-pdf,update}-*.ts` — pass `{ id, role: mapLegacyRole(user.role) }` to permission helpers
- `send-invoice-email.ts` and `regenerate-pdf.ts` — replaced inline `createdBy/is_admin` checks with `canReadInvoice`

## Test status

- 47/54 suites pass, 257/259 tests pass (B1 baseline: 43/50, 233/235)
- ~24 new tests across permissions, PDF route, duplicate-invoice, account-scope-on-create
- 7 pre-existing suite failures + 2 pre-existing test failures unchanged — no new regressions

## Test plan

- [ ] As `bob` (user, not invoice creator), `GET /api/invoices/<alice-invoice>/pdf` → 404
- [ ] As `bob`, call `duplicateInvoice("<alice-invoice-id>")` server action → throws Forbidden, no new invoice row
- [ ] As `bob`, call `createInvoice({ accountId: "<alice-account>", ... })` → throws Forbidden
- [ ] As `bob`, call `updateInvoice("<bob-invoice>", { accountId: "<alice-account>" })` → throws Forbidden
- [ ] As `manager`, all four → succeed
- [ ] As any non-admin, `deletePayment(...)` → throws "Only admins can delete payments"

## Out of B2 scope

- Read-side scoping for invoice list/detail (Phase D/E)
- Removing `Users.is_admin` column (Phase F)

Plan: `docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-b2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)