### PR TITLE
fix(security): admin server action lockdown (Phase C)

### DIFF
--- a/actions/admin/send-mail-to-all/index.ts
+++ b/actions/admin/send-mail-to-all/index.ts
@@ -1,6 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
-
 import { render } from "@react-email/render";
 
 import { SendMailToAll } from "./schema";
@@ -11,21 +9,23 @@ import resendHelper from "@/lib/resend";
 import { createSafeAction } from "@/lib/create-safe-action";
 import MessageToAllUsers from "@/emails/admin/MessageToAllUser";
 import sendEmail from "@/lib/sendmail";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-
-  if (!session) {
-    return {
-      error: "You must be authenticated.",
-    };
-  }
-
-  //Only admin can send mail to all users
-  if (session.user.role !== "admin") {
-    return {
-      error: "You are not authorized to perform this action.",
-    };
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) {
+      return { error: "You must be authenticated." };
+    }
+    if (e instanceof AuthorizationError) {
+      return { error: "You are not authorized to perform this action." };
+    }
+    throw e;
   }
 
   const resend = await resendHelper();

--- a/actions/admin/users/__tests__/activate-deactivate.test.ts
+++ b/actions/admin/users/__tests__/activate-deactivate.test.ts
@@ -1,0 +1,48 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn(), update: jest.fn().mockResolvedValue({ id: "x" }) },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/sendmail", () => ({ __esModule: true, default: jest.fn() }));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { activateUser } from "../activate-user";
+import { deactivateUser } from "../deactivate-user";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const upd = prismadb.users.update as jest.MockedFunction<typeof prismadb.users.update>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe.each([
+  ["activateUser", activateUser],
+  ["deactivateUser", deactivateUser],
+])("%s admin gate", (_, fn) => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await fn("u1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when not admin", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const res = await fn("target");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("admin succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "a" } } as any);
+    fu.mockResolvedValue({ id: "a", role: "admin" } as any);
+    upd.mockResolvedValue({ id: "target" } as any);
+    const res = await fn("target");
+    expect(res).toMatchObject({ data: expect.anything() });
+    expect(upd).toHaveBeenCalled();
+  });
+});

--- a/actions/admin/users/activate-user.ts
+++ b/actions/admin/users/activate-user.ts
@@ -1,12 +1,21 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import sendEmail from "@/lib/sendmail";
 import { revalidatePath } from "next/cache";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const activateUser = async (userId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   if (!userId) return { error: "userId is required" };
 

--- a/actions/admin/users/deactivate-user.ts
+++ b/actions/admin/users/deactivate-user.ts
@@ -1,11 +1,20 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deactivateUser = async (userId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   if (!userId) return { error: "userId is required" };
 

--- a/actions/admin/users/delete-user.ts
+++ b/actions/admin/users/delete-user.ts
@@ -1,13 +1,20 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteUser = async (userId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
-  if (session.user.role !== "admin") return { error: "Forbidden" };
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   if (!userId) return { error: "userId is required" };
 

--- a/actions/admin/users/invite-user.ts
+++ b/actions/admin/users/invite-user.ts
@@ -1,19 +1,33 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import InviteUserEmail from "@/emails/InviteUser";
 import resendHelper from "@/lib/resend";
 import { revalidatePath } from "next/cache";
 import { Language } from "@prisma/client";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const inviteUser = async (data: {
   name: string;
   email: string;
   language: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-  if (session.user.role !== "admin") return { error: "Forbidden" };
+  let actor;
+  try {
+    actor = await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  const inviter = await prismadb.users.findUnique({
+    where: { id: actor.id },
+    select: { name: true },
+  });
 
   const { name, email, language } = data;
 
@@ -66,7 +80,7 @@ export const inviteUser = async (data: {
       to: user.email,
       subject: `You have been invited to ${process.env.NEXT_PUBLIC_APP_NAME}`,
       react: InviteUserEmail({
-        invitedByUsername: session.user?.name || "admin",
+        invitedByUsername: inviter?.name || "admin",
         username: user.name!,
         userLanguage: language,
       }),

--- a/app/[locale]/(routes)/admin/actions/api-keys.ts
+++ b/app/[locale]/(routes)/admin/actions/api-keys.ts
@@ -1,10 +1,23 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
-
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { encrypt, decrypt } from "@/lib/email-crypto";
 import { ApiKeyProvider } from "@prisma/client";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+async function ensureAdmin(): Promise<void> {
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+}
 
 const PROVIDER_ENV_MAP: Record<ApiKeyProvider, string> = {
   OPENAI: "OPENAI_API_KEY",
@@ -20,8 +33,7 @@ export type ProviderStatus = {
 };
 
 export async function getSystemApiKeys(): Promise<ProviderStatus[]> {
-  const session = await getSession();
-  if (!session || session.user.role !== "admin") throw new Error("Unauthorized");
+  await ensureAdmin();
 
   const providers = Object.values(ApiKeyProvider) as ApiKeyProvider[];
 
@@ -59,8 +71,7 @@ export async function upsertSystemApiKey(
   provider: ApiKeyProvider,
   key: string
 ): Promise<void> {
-  const session = await getSession();
-  if (!session || session.user.role !== "admin") throw new Error("Unauthorized");
+  await ensureAdmin();
 
   const encryptedKey = encrypt(key);
 
@@ -81,8 +92,7 @@ export async function upsertSystemApiKey(
 }
 
 export async function deleteSystemApiKey(provider: ApiKeyProvider): Promise<void> {
-  const session = await getSession();
-  if (!session || session.user.role !== "admin") throw new Error("Unauthorized");
+  await ensureAdmin();
 
   await prismadb.apiKeys.deleteMany({
     where: { scope: "SYSTEM", provider },

--- a/app/[locale]/(routes)/admin/invoices/settings/_actions/invoice-settings.ts
+++ b/app/[locale]/(routes)/admin/invoices/settings/_actions/invoice-settings.ts
@@ -3,7 +3,11 @@
 import { z } from "zod";
 import { revalidatePath } from "next/cache";
 import { prismadb } from "@/lib/prisma";
-import { getUser } from "@/actions/get-user";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const requiredStr = (label: string, max: number) =>
   z.string().trim().min(1, `${label} is required`).max(max, `${label} must be ≤ ${max} chars`);
@@ -63,13 +67,13 @@ export type ActionResult<T = unknown> =
 export async function saveInvoiceSettings(
   input: InvoiceSettingsInput
 ): Promise<ActionResult> {
-  let user;
   try {
-    user = await getUser();
-  } catch {
-    return { ok: false, error: "Unauthorized" };
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { ok: false, error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { ok: false, error: "Forbidden" };
+    throw e;
   }
-  if (!user.is_admin) return { ok: false, error: "Forbidden" };
 
   const parsed = settingsSchema.safeParse(input);
   if (!parsed.success) {

--- a/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-c.md
+++ b/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-c.md
@@ -1,0 +1,352 @@
+# Permission-Driven Authorization — Phase C (Admin Action Lockdown) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Close the remaining unguarded admin server actions and normalize every admin guard to the canonical `requireRole(["admin"])` helper. After C, no admin action is callable from a non-admin session, and zero authorization decisions reference legacy `session.user.role === "admin"` strings or `user.is_admin` booleans.
+
+**Architecture:** Mechanical refactor — every targeted file replaces its current auth check with the canonical pattern:
+
+```ts
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+// At the top of every exported async function (or via a private ensureAdmin helper):
+let actor;
+try {
+  actor = await requireRole(["admin"]);
+} catch (e) {
+  if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+  if (e instanceof AuthorizationError) return { error: "Forbidden" };
+  throw e;
+}
+```
+
+For files that THROW on errors instead of returning `{ error }`, throw `Error("Unauthorized")` / `Error("Forbidden")` instead.
+
+**Spec source:** §12 Phase 3, §8.18.
+**Audit source:** "Admin CRM Settings Actions Without Admin Check" (resolved Phase A), "Admin Currency Actions Without Admin Check" (resolved Phase A), and the residual list flagged in §3.3.
+
+---
+
+## File List
+
+| File | Current state | Return shape |
+|---|---|---|
+| `actions/admin/users/activate-user.ts` | **NO ROLE CHECK** | `{ data \| error }` |
+| `actions/admin/users/deactivate-user.ts` | **NO ROLE CHECK** | `{ data \| error }` |
+| `actions/admin/users/delete-user.ts` | legacy `session.user.role` | `{ data \| error }` |
+| `actions/admin/users/invite-user.ts` | legacy `session.user.role` | `{ data \| error }` |
+| `actions/admin/send-mail-to-all/index.ts` | legacy `session.user.role` | `{ error \| ok }` |
+| `app/[locale]/(routes)/admin/invoices/settings/_actions/invoice-settings.ts` | legacy `user.is_admin` | `{ ok \| error }` |
+| `app/[locale]/(routes)/admin/actions/api-keys.ts` (3 functions: get/upsert/delete) | legacy `session.user.role` | throws |
+
+Files already guarded canonically (Phase A): `crm-settings.ts`, `currencies.ts`, `set-role.ts`. **Skip.**
+
+---
+
+## Task 1: Fix `activate-user.ts` and `deactivate-user.ts` (critical — no current guards)
+
+**Files:**
+- Modify: `actions/admin/users/activate-user.ts`
+- Modify: `actions/admin/users/deactivate-user.ts`
+- Create: `actions/admin/users/__tests__/activate-deactivate.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+`actions/admin/users/__tests__/activate-deactivate.test.ts`:
+```ts
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn(), update: jest.fn().mockResolvedValue({ id: "x" }) },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { activateUser } from "../activate-user";
+import { deactivateUser } from "../deactivate-user";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const upd = prismadb.users.update as jest.MockedFunction<typeof prismadb.users.update>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe.each([
+  ["activateUser", activateUser],
+  ["deactivateUser", deactivateUser],
+])("%s admin gate", (_, fn) => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await fn("u1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when not admin", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const res = await fn("target");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("admin succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "a" } } as any);
+    fu.mockResolvedValue({ id: "a", role: "admin" } as any);
+    upd.mockResolvedValue({ id: "target" } as any);
+    const res = await fn("target");
+    expect(res).toMatchObject({ data: expect.anything() });
+    expect(upd).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+pnpm jest 'actions/admin/users/__tests__/activate-deactivate.test.ts'
+```
+
+- [ ] **Step 3: Patch both files**
+
+For each (`activate-user.ts` and `deactivate-user.ts`), replace the opening session check with:
+```ts
+"use server";
+import { prismadb } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+export const activateUser = async (userId: string) => { // or deactivateUser
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  // existing body unchanged: status update, revalidatePath, return { data }
+};
+```
+
+Preserve every existing line of business logic — only swap the guard.
+
+- [ ] **Step 4: Test → PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add actions/admin/users/activate-user.ts actions/admin/users/deactivate-user.ts actions/admin/users/__tests__/activate-deactivate.test.ts
+git commit -m "fix(admin): require admin role on activate/deactivate user (close audit gap)"
+```
+
+---
+
+## Task 2: Normalize `delete-user.ts` and `invite-user.ts`
+
+**Files:**
+- Modify: `actions/admin/users/delete-user.ts`
+- Modify: `actions/admin/users/invite-user.ts`
+
+These already have admin checks via legacy `session.user.role === "admin"`. Switch to `requireRole(["admin"])` for consistency with Phase A patterns.
+
+- [ ] **Step 1: For each file**, replace the existing `if (!session) ... if (session.user.role !== "admin") ...` block with the canonical pattern:
+
+```ts
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
+
+export const deleteUser = async (userId: string) => {
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  // existing body unchanged
+};
+```
+
+For `invite-user.ts`, the `actor.id` value (used in audit logging or owner-stamping) was previously read from `session.user.id` — now read from the result of `requireRole`:
+```ts
+let actor;
+try { actor = await requireRole(["admin"]); }
+catch (e) { /* same shape */ }
+// ... use actor.id where session.user.id was used
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+pnpm tsc --noEmit 2>&1 | grep -E "delete-user|invite-user" | head
+```
+Expected: no new errors in these files.
+
+- [ ] **Step 3: Run any existing tests for these files**
+
+```bash
+pnpm jest 'actions/admin/users' 2>&1 | tail -10
+```
+If existing tests break because they didn't mock `prismadb.users.findUnique` (which `requireRole` calls under the hood), update mocks the same way Phase A T14 did for `crm-settings-actions.test.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add actions/admin/users/delete-user.ts actions/admin/users/invite-user.ts
+git commit -m "refactor(admin): normalize delete-user and invite-user to canonical requireRole helper"
+```
+
+---
+
+## Task 3: Normalize `send-mail-to-all/index.ts`
+
+**Files:**
+- Modify: `actions/admin/send-mail-to-all/index.ts`
+
+Same pattern. The handler is wrapped by `createSafeAction` — find the inner handler function, replace the auth block with `requireRole(["admin"])` returning `{ error: "Unauthorized" | "Forbidden" }`.
+
+- [ ] **Step 1: Read the file** — note the inner handler function name and current auth check.
+
+- [ ] **Step 2: Apply the canonical pattern** — same shape as Tasks 1/2.
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+git add actions/admin/send-mail-to-all/index.ts
+git commit -m "refactor(admin): normalize send-mail-to-all to canonical requireRole helper"
+```
+
+---
+
+## Task 4: Normalize `admin/invoices/settings`
+
+**Files:**
+- Modify: `app/[locale]/(routes)/admin/invoices/settings/_actions/invoice-settings.ts`
+
+Currently uses `user.is_admin` boolean. Replace with `requireRole(["admin"])`.
+
+- [ ] **Step 1: Read the file** — note the export(s). Plan calls out one export `saveInvoiceSettings` returning `{ ok | error }`.
+
+- [ ] **Step 2: Replace the `getUser()` + `user.is_admin` block with `requireRole(["admin"])`**:
+
+```ts
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
+
+export async function saveInvoiceSettings(input: InvoiceSettingsInput) {
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { ok: false, error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { ok: false, error: "Forbidden" };
+    throw e;
+  }
+
+  // existing body unchanged
+}
+```
+
+If the function uses `user.id` elsewhere in the body, capture it from `requireRole`:
+```ts
+let actor;
+try { actor = await requireRole(["admin"]); }
+catch (e) { /* ... */ }
+// use actor.id where user.id was used
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+git add 'app/[locale]/(routes)/admin/invoices/settings/_actions/invoice-settings.ts'
+git commit -m "refactor(admin): normalize invoice-settings to canonical requireRole helper"
+```
+
+---
+
+## Task 5: Normalize admin/actions/api-keys
+
+**Files:**
+- Modify: `app/[locale]/(routes)/admin/actions/api-keys.ts` (3 functions: `getSystemApiKeys`, `upsertSystemApiKey`, `deleteSystemApiKey`)
+
+These currently throw `Error("Unauthorized")` from a legacy `session.user.role !== "admin"` check.
+
+- [ ] **Step 1: Replace the auth section of each function with the throwing variant**:
+
+```ts
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
+
+async function ensureAdmin() {
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+}
+
+export async function getSystemApiKeys() {
+  await ensureAdmin();
+  // existing body
+}
+// Same pattern in upsert + delete.
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+git add 'app/[locale]/(routes)/admin/actions/api-keys.ts'
+git commit -m "refactor(admin): normalize system-api-keys actions to canonical requireRole helper"
+```
+
+---
+
+## Task 6: Verification + PR
+
+- [ ] **Step 1: Final search for residual legacy patterns in admin actions**
+
+```bash
+grep -rn "is_admin\|session\.user\.role" actions/admin/ 'app/[locale]/(routes)/admin/' 2>/dev/null | grep -v "__tests__\|node_modules\|migrations" | head
+```
+Expected: empty (or only references inside comments/test files).
+
+- [ ] **Step 2: Full suite**
+
+```bash
+pnpm jest 2>&1 | tail -8
+```
+Expected: same baseline failure pattern as B3 merged into dev. New `activate-deactivate.test.ts` passes.
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feat/authz-phase-c
+gh pr create --base dev --head feat/authz-phase-c --title "fix(security): admin server action lockdown (Phase C)" --body "..."
+```
+
+PR body references: spec §8.18, plan, manual test plan (one curl per affected action — should return Unauthorized/Forbidden for non-admin sessions).
+
+---
+
+## Acceptance Criteria
+
+- `activate-user.ts` and `deactivate-user.ts` reject non-admin sessions (closes audit gap).
+- All 7 admin action files use `requireRole(["admin"])` as the sole auth gate.
+- No remaining `session.user.role === "admin"` or `user.is_admin` references in admin actions.
+- New unit test verifies activate/deactivate are role-gated; existing tests still pass.
+
+## Out of C scope
+
+- Read-side scoping for any resource (Phase D).
+- Removing `Users.is_admin` column (Phase F — there are still consumers in non-admin code paths).
+- Profile API keys (`profile/actions/api-keys.ts`) — user-scoped, not admin.


### PR DESCRIPTION
## Summary

Closes the remaining unguarded admin server actions and normalizes every admin guard to the canonical `requireRole(["admin"])` helper. After C, no admin action is callable from a non-admin session, and all authorization decisions in admin code paths use the canonical helper.

## What changed

**Critical fix (audit gap closed):**
- `actions/admin/users/activate-user.ts` — was unguarded; now requires admin role
- `actions/admin/users/deactivate-user.ts` — was unguarded; now requires admin role

**Normalized to canonical `requireRole(["admin"])`:**
- `actions/admin/users/delete-user.ts` (was legacy `session.user.role`)
- `actions/admin/users/invite-user.ts` (was legacy `session.user.role` — also fetches inviter's display name from DB now since `actor` from `requireRole` is `{ id, role }`)
- `actions/admin/send-mail-to-all/index.ts` (was legacy `session.user.role`)
- `app/[locale]/(routes)/admin/invoices/settings/_actions/invoice-settings.ts` (was legacy `user.is_admin`)
- `app/[locale]/(routes)/admin/actions/api-keys.ts` — 3 functions (`getSystemApiKeys`, `upsertSystemApiKey`, `deleteSystemApiKey`) — extracted shared `ensureAdmin()` helper that throws

## Residual `is_admin`/`session.user.role` references

Two intentional uses remain in `actions/admin/users/`:
- `set-role.ts:25` — writes `is_admin` to DB to keep the legacy column synced (Phase F removal)
- `delete-user.ts:31` — reads `is_admin` in the returned user shape (no authz decision)

Both are column reads/writes, not authorization checks.

## Test status

- 57/63 suites pass, 320/321 tests pass (B3 baseline: 56/62, 314/315)
- 6 new tests covering activate/deactivate role gating
- Same 6 pre-existing suite failures + 1 pre-existing test failure unchanged — no new regressions

## Test plan

- [ ] As `bob` (user, not admin), call `activateUser("<some-userId>")` → returns `{ error: "Forbidden" }`, no DB change
- [ ] As `bob`, call `deactivateUser(...)` → `{ error: "Forbidden" }`
- [ ] As `bob`, call `deleteUser(...)` → `{ error: "Forbidden" }`
- [ ] As `bob`, call `inviteUser(...)` → `{ error: "Forbidden" }`
- [ ] As `bob`, call `sendMailToAll(...)` → `{ error: "You are not authorized to perform this action." }`
- [ ] As `bob`, call `saveInvoiceSettings(...)` → `{ ok: false, error: "Forbidden" }`
- [ ] As `bob`, call `getSystemApiKeys()` → throws `Forbidden`
- [ ] As `admin`, all six → succeed

## Out of C scope

- Read-side scoping for any resource (Phase D)
- Removing `Users.is_admin` and `is_account_admin` columns (Phase F — `set-role.ts` still syncs `is_admin` for legacy consumers in non-admin code paths)

Plan: `docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-c.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)