### PR TITLE
docs(authz): Phase D1/D2/D3 implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d1.md
+++ b/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d1.md
@@ -1,0 +1,327 @@
+# Permission-Driven Authorization — Phase D1 (Accounts Read-Side) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Add user/manager/admin scoping to every CRM account read action. After D1, a `user` sees only accounts they're assigned to, created, or watch; `manager`/`admin` see all non-deleted accounts. This also adds reusable `accountUserScopeOR` and `accountReadScopeWhere` helpers that D2 will compose into linked-account checks for leads/contacts/opportunities/contracts.
+
+**Architecture:** Extend `lib/authz/scopes/crm.ts` with a single private helper `accountUserScopeOR(userId)` returning the `OR` array (`assigned_to | createdBy | watcher`) and an exported `accountReadScopeWhere(user)` building the full where (with `deletedAt: null` and the role gate). Apply to 3 read actions. The previously shipped `assertCanReadAccount` (none yet — `assertCanWriteAccount` exists from B2) is added too, mirroring the contact/target read assertion pattern.
+
+**Spec source:** §6.1 (CRM accounts), §8.1, §12 Phase 4.
+**Audit source:** "Global CRM Read Actions" — accounts row.
+
+---
+
+## File Structure
+
+**New tests:**
+- `lib/authz/__tests__/scopes-crm-account-read.test.ts`
+- `actions/crm/accounts/__tests__/get-accounts-scope.test.ts`
+- `actions/crm/accounts/__tests__/get-account-by-id-scope.test.ts`
+- `actions/crm/accounts/__tests__/search-accounts-scope.test.ts`
+
+**Modified:**
+- `lib/authz/scopes/crm.ts` — add `accountUserScopeOR` (private), `accountReadScopeWhere`, `assertCanReadAccount`
+- `lib/authz/index.ts` — re-export
+- `actions/crm/accounts/get-accounts.ts`
+- `actions/crm/accounts/get-account-by-id.ts`
+- `actions/crm/accounts/search-accounts.ts`
+
+---
+
+## Task 1: Account scope helpers + `assertCanReadAccount`
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts`
+- Create: `lib/authz/__tests__/scopes-crm-account-read.test.ts`
+- Modify: `lib/authz/index.ts`
+
+Add three pieces:
+
+```ts
+// Internal: the OR clauses describing user-level account ownership.
+// Exported via accountReadScopeWhere; D2 will reuse for nested linked-account scope.
+export function accountUserScopeOR(userId: string) {
+  return [
+    { assigned_to: userId },
+    { createdBy: userId },
+    { watchers: { some: { user_id: userId } } },
+  ] as const;
+}
+
+// Build a Prisma where for "this user can read this account".
+// Manager/admin: { deletedAt: null }
+// User:           { deletedAt: null, OR: accountUserScopeOR(user.id) }
+export function accountReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: accountUserScopeOR(user.id),
+  };
+}
+
+// Throws AuthorizationError if user can't read this account.
+export async function assertCanReadAccount(
+  user: AuthzUser,
+  accountId: string,
+): Promise<void> {
+  const row = await prismadb.crm_Accounts.findFirst({
+    where: { id: accountId, ...accountReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+```
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// lib/authz/__tests__/scopes-crm-account-read.test.ts
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Accounts: { findFirst: jest.fn() } },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  accountUserScopeOR,
+  accountReadScopeWhere,
+  assertCanReadAccount,
+} from "../scopes/crm";
+
+const find = prismadb.crm_Accounts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Accounts.findFirst
+>;
+beforeEach(() => jest.clearAllMocks());
+
+describe("accountUserScopeOR", () => {
+  it("returns three OR clauses for the user id", () => {
+    expect(accountUserScopeOR("u1")).toEqual([
+      { assigned_to: "u1" },
+      { createdBy: "u1" },
+      { watchers: { some: { user_id: "u1" } } },
+    ]);
+  });
+});
+
+describe("accountReadScopeWhere", () => {
+  it("admin / manager → only deletedAt:null", () => {
+    expect(accountReadScopeWhere({ id: "x", role: "admin" })).toEqual({ deletedAt: null });
+    expect(accountReadScopeWhere({ id: "x", role: "manager" })).toEqual({ deletedAt: null });
+  });
+  it("user → deletedAt + OR ownership clauses", () => {
+    expect(accountReadScopeWhere({ id: "u1", role: "user" })).toMatchObject({
+      deletedAt: null,
+      OR: expect.arrayContaining([
+        { assigned_to: "u1" },
+        { createdBy: "u1" },
+        { watchers: { some: { user_id: "u1" } } },
+      ]),
+    });
+  });
+});
+
+describe("assertCanReadAccount", () => {
+  it("throws when not in scope", async () => {
+    find.mockResolvedValue(null);
+    await expect(assertCanReadAccount({ id: "u", role: "user" }, "a1"))
+      .rejects.toBeInstanceOf(AuthorizationError);
+  });
+  it("admin: no OR clauses in where (just id + deletedAt)", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanReadAccount({ id: "x", role: "admin" }, "a1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "a1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Failing test → implement → PASS**
+
+- [ ] **Step 3: Add to barrel**
+
+```ts
+export {
+  accountUserScopeOR,
+  accountReadScopeWhere,
+  assertCanReadAccount,
+} from "./scopes/crm";
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/authz/scopes/crm.ts lib/authz/__tests__/scopes-crm-account-read.test.ts lib/authz/index.ts
+git commit -m "feat(authz): add account read-scope helpers"
+```
+
+---
+
+## Task 2: Patch `getAccounts`
+
+**Files:**
+- Modify: `actions/crm/accounts/get-accounts.ts`
+- Create: `actions/crm/accounts/__tests__/get-accounts-scope.test.ts`
+
+Current behavior: lists ALL non-deleted accounts with no auth check. After D1: `requireAuthenticated` + `accountReadScopeWhere(user)`.
+
+- [ ] **Step 1: Failing test** — 4 cases:
+  - 401 unauth → `prismadb.crm_Accounts.findMany` not called
+  - user → where contains `OR: [...accountUserScopeOR("u")...]`
+  - manager → where = `{ deletedAt: null }` (no OR)
+  - admin → same as manager
+
+Mock `@/lib/auth-server`, `@/lib/prisma` (`users.findUnique`, `crm_Accounts.findMany`).
+
+- [ ] **Step 2: Patch action**
+
+```ts
+import {
+  requireAuthenticated,
+  accountReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
+
+export async function getAccounts(/* existing args */) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  const where = accountReadScopeWhere(user);
+  return prismadb.crm_Accounts.findMany({
+    where,
+    // ... existing select / orderBy / take / skip preserved
+  });
+}
+```
+
+If the action is currently called without arguments and returns the array directly, preserve that contract — wrap auth failures in whatever shape callers expect (Phase A-style: return empty array or throw — match the file's existing style).
+
+- [ ] **Step 3: Test → PASS, commit**
+
+```bash
+git add actions/crm/accounts/get-accounts.ts actions/crm/accounts/__tests__/get-accounts-scope.test.ts
+git commit -m "fix(crm): scope account list by user/manager/admin role"
+```
+
+---
+
+## Task 3: Patch `getAccountById`
+
+**Files:**
+- Modify: `actions/crm/accounts/get-account-by-id.ts`
+- Create: `actions/crm/accounts/__tests__/get-account-by-id-scope.test.ts`
+
+Use `assertCanReadAccount` first (returns null/throws on out-of-scope), then existing detail query.
+
+- [ ] **Step 1: Failing test** — 4 cases (401, 404 out-of-scope, 200 owner, 200 manager).
+
+- [ ] **Step 2: Patch action**
+
+```ts
+import {
+  requireAuthenticated,
+  assertCanReadAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+export async function getAccountById(accountId: string) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null; // or { error: "Unauthorized" }
+    throw e;
+  }
+  try {
+    await assertCanReadAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+  // existing detail query (unchanged)
+  return prismadb.crm_Accounts.findUnique({ where: { id: accountId, deletedAt: null }, /* existing include */ });
+}
+```
+
+Match the existing return contract (some actions return the row directly; some return `{ data | error }`). Don't change the contract — only inject the gate.
+
+- [ ] **Step 3: Test → PASS, commit**
+
+```bash
+git add actions/crm/accounts/get-account-by-id.ts actions/crm/accounts/__tests__/get-account-by-id-scope.test.ts
+git commit -m "fix(crm): require account read scope on getAccountById"
+```
+
+---
+
+## Task 4: Patch `searchAccounts`
+
+**Files:**
+- Modify: `actions/crm/accounts/search-accounts.ts`
+- Create: `actions/crm/accounts/__tests__/search-accounts-scope.test.ts`
+
+Same pattern as `getAccounts` — auth + spread `accountReadScopeWhere(user)` into the existing where.
+
+- [ ] **Step 1: Failing test** — 3 cases (401, user → scoped where, manager → bare).
+
+- [ ] **Step 2: Patch**
+
+```ts
+const where = {
+  ...accountReadScopeWhere(user),
+  ...(search ? { name: { contains: search, mode: "insensitive" } } : {}),
+};
+```
+
+- [ ] **Step 3: Test → PASS, commit**
+
+```bash
+git add actions/crm/accounts/search-accounts.ts actions/crm/accounts/__tests__/search-accounts-scope.test.ts
+git commit -m "fix(crm): scope account search by user/manager/admin role"
+```
+
+---
+
+## Task 5: Verification + PR
+
+- [ ] **Step 1: Full suite + grep for residual unscoped account reads**
+
+```bash
+pnpm jest 2>&1 | tail -8
+grep -rn "prismadb\.crm_Accounts\.\(findMany\|findUnique\|findFirst\)" actions/ app/api/ --include="*.ts" | grep -v "__tests__\|scopes/crm" | head
+```
+The grep result should show only call sites that already have a scope layer above them or are intentionally global (e.g., similarity worker, admin tooling).
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin feat/authz-phase-d1
+gh pr create --base dev --head feat/authz-phase-d1 --title "fix(security): scope CRM account reads by role (Phase D1)" --body "..."
+```
+
+PR body references: spec §6.1, this plan, and notes that D2 will build linked-account scope on top.
+
+---
+
+## Acceptance Criteria
+
+- `getAccounts`, `getAccountById`, `searchAccounts` reject unauthenticated callers and apply user-level ownership filter.
+- `accountUserScopeOR(userId)` is exported and ready for D2 nested-scope reuse.
+- `assertCanReadAccount` follows the same pattern as `assertCanReadContact`/`assertCanReadTarget`.
+- New tests cover unauth/user/manager/admin shapes.
+
+## Out of D1 scope
+
+- Account `restore-account.ts` (admin-only — already gated separately)
+- Account-level write actions (already gated)
+- Linked-account scope on leads/contacts/opportunities/contracts — **D2**

--- a/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d2.md
+++ b/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d2.md
@@ -1,0 +1,279 @@
+# Permission-Driven Authorization — Phase D2 (Leads, Contacts, Opportunities, Contracts) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Add user/manager/admin scoping to every list/detail/search read action across the four big CRM entities — leads, contacts, opportunities, contracts. Each entity gets a `xxxReadScopeWhere(user)` helper that follows the spec §6 ownership rules including **linked-account scope** (the Phase B1 TODO is closed here): a user can read a lead/contact/opportunity/contract if they own the linked account, even if the row itself isn't directly assigned to them.
+
+**Architecture:** Extend `lib/authz/scopes/crm.ts` with four new exported helpers built on top of D1's `accountUserScopeOR`. Apply them to ~12 read action files. Detail queries get a corresponding `assertCanReadXxx` helper following the contact/target/account pattern. Where shapes use Prisma's nested relation filter syntax (`{ assigned_accounts: { OR: [...] } }`) so the entire query is a single round trip.
+
+**Spec source:** §6.2 (leads), §6.3 (contacts), §6.4 (opportunities), §6.5 (contracts), §8.2–8.5, §12 Phase 4.
+**Audit source:** "Global CRM Read Actions".
+
+**Depends on:** Phase D1 merged (`accountUserScopeOR`, `accountReadScopeWhere`).
+
+---
+
+## File Structure
+
+**New tests** (one per helper + per action file):
+- `lib/authz/__tests__/scopes-crm-entity-read.test.ts` — covers all 4 new helpers
+- `actions/crm/{leads,contacts,opportunities,contracts}/__tests__/{file-name}-scope.test.ts` — one per modified action
+
+**Modified:**
+- `lib/authz/scopes/crm.ts` — add `leadReadScopeWhere`, `contactReadScopeWhere`, `opportunityReadScopeWhere`, `contractReadScopeWhere`, `assertCanReadLead`, `assertCanReadOpportunity`, `assertCanReadContract` (note: `assertCanReadContact` already exists from B1)
+- `lib/authz/index.ts`
+- `actions/crm/get-leads.ts`, `actions/crm/get-lead.ts`, `actions/crm/get-leads-by-accountId.ts`
+- `actions/crm/get-contacts.ts`, `actions/crm/get-contact.ts`, `actions/crm/get-contacts-by-accountId.ts`, `actions/crm/get-contacts-by-opportunityId.ts`
+- `actions/crm/get-opportunities.ts`, `actions/crm/get-opportunities-with-includes.ts`, `actions/crm/get-opportunity.ts`
+- `actions/crm/get-contract.ts`, `actions/crm/get-contracts.ts`
+
+**Note on file paths:** Phase A audit said `actions/crm/leads/get-leads.ts` but the D-plans inventory shows files live at `actions/crm/get-*.ts` (flat). Implementer should `grep -rn "export async function get(Lead|Contact|Opportunity|Contract)"` first to confirm exact paths. The plan steps below assume the inventoried paths.
+
+---
+
+## Helper design (all four entities follow this shape)
+
+```ts
+// Lead — links to account via leads.accountsIDs (FK)
+export function leadReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { assigned_to: user.id },
+      { createdBy: user.id },
+      { assigned_accounts: { OR: accountUserScopeOR(user.id) } },
+    ],
+  };
+}
+
+// Contact — relation: assigned_accounts via accountsIDs FK; legacy fields included
+export function contactReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { assigned_to: user.id },
+      { created_by: user.id },
+      { createdBy: user.id },
+      { assigned_accounts: { OR: accountUserScopeOR(user.id) } },
+    ],
+  };
+}
+
+// Opportunity — relation: assigned_account via account FK
+// Use the actual relation name in the model (confirm via Prisma schema)
+export function opportunityReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { assigned_to: user.id },
+      { created_by: user.id },
+      { createdBy: user.id },
+      { assigned_account: { OR: accountUserScopeOR(user.id) } },
+    ],
+  };
+}
+
+// Contract — same as opportunity but only assigned_to + createdBy (no created_by) + linked account
+export function contractReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { assigned_to: user.id },
+      { createdBy: user.id },
+      { assigned_account: { OR: accountUserScopeOR(user.id) } },
+    ],
+  };
+}
+```
+
+`assertCanReadLead`, `assertCanReadOpportunity`, `assertCanReadContract` follow the pattern of `assertCanReadAccount`: `findFirst({ where: { id, ...xxxReadScopeWhere(user) }, select: { id: true } })` → throw `AuthorizationError` if null.
+
+For `assertCanReadContact` (already shipped in B1), this phase **upgrades** the helper body to add the linked-account branch — make the change in `lib/authz/scopes/crm.ts` and update the existing `scopes-crm-read.test.ts` to cover the new branch.
+
+---
+
+## Task 1: Entity scope helpers
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts` — add 4 `xxxReadScopeWhere` + 3 new `assertCanReadXxx` (`assertCanReadContact` body upgrade)
+- Create: `lib/authz/__tests__/scopes-crm-entity-read.test.ts`
+- Modify: `lib/authz/__tests__/scopes-crm-read.test.ts` — add coverage for new contact linked-account branch
+- Modify: `lib/authz/index.ts` — re-export
+
+- [ ] **Step 1: Failing test** for the 4 helpers + the 3 new asserts. Use the same shape as Phase D1 Task 1: each helper test has admin/manager/user cases and asserts the exact `OR` array structure.
+
+For the linked-account upgrade to `assertCanReadContact`, the test asserts that for `user` role, the where clause includes both the direct ownership OR (existing) and the new `{ assigned_accounts: { OR: [...] } }` clause.
+
+- [ ] **Step 2: Implement helpers per the design block above.**
+
+Inside `assertCanReadXxx`, use the appropriate model (`crm_Leads`, `crm_Opportunities`, `crm_Contracts`). For `assertCanReadContact` upgrade, the body becomes:
+```ts
+const row = await prismadb.crm_Contacts.findFirst({
+  where: { id: contactId, ...contactReadScopeWhere(user) },
+  select: { id: true },
+});
+if (!row) throw new AuthorizationError();
+```
+This replaces the previous direct-only ownership check. **Run the existing T1 test from B1 to confirm it still passes** — the new branch is additive (more rows match, not fewer for the user the row already belonged to).
+
+- [ ] **Step 3: Add to barrel**
+
+```ts
+export {
+  leadReadScopeWhere,
+  contactReadScopeWhere,
+  opportunityReadScopeWhere,
+  contractReadScopeWhere,
+  assertCanReadLead,
+  assertCanReadOpportunity,
+  assertCanReadContract,
+} from "./scopes/crm";
+```
+
+- [ ] **Step 4: Test → PASS, commit**
+
+```bash
+git add lib/authz/scopes/crm.ts lib/authz/__tests__/ lib/authz/index.ts
+git commit -m "feat(authz): add lead/contact/opportunity/contract read-scope helpers (linked-account aware)"
+```
+
+---
+
+## Task 2: Patch lead read actions
+
+**Files:**
+- Modify: `actions/crm/get-leads.ts`, `actions/crm/get-lead.ts`, `actions/crm/get-leads-by-accountId.ts`
+- Create: `__tests__/` files for each (follow pattern from D1 Task 2/3/4)
+
+For each:
+- `get-leads.ts` — list pattern: `requireAuthenticated` → spread `leadReadScopeWhere(user)` into existing where → existing query runs
+- `get-lead.ts` — detail pattern: `requireAuthenticated` → `assertCanReadLead(user, leadId)` (throws on miss → return null/error per existing contract) → existing detail query
+- `get-leads-by-accountId.ts` — list-by-account pattern: `requireAuthenticated` → `assertCanReadAccount(user, accountId)` to verify access to the parent account first → then list scoped by both `accountsIDs: accountId` AND `leadReadScopeWhere(user)` (defense in depth: a user with parent-account access still sees only leads they can see directly)
+
+Tests: 4 cases per file (401, user out-of-scope, user in-scope, manager).
+
+- [ ] **Step 1–3 per file** (test → patch → commit)
+
+```bash
+git add actions/crm/get-leads.ts actions/crm/get-lead.ts actions/crm/get-leads-by-accountId.ts actions/crm/__tests__/
+git commit -m "fix(crm): scope lead reads by role and linked-account access"
+```
+
+---
+
+## Task 3: Patch contact read actions
+
+**Files:**
+- Modify: `actions/crm/get-contacts.ts`, `actions/crm/get-contact.ts`, `actions/crm/get-contacts-by-accountId.ts`, `actions/crm/get-contacts-by-opportunityId.ts`
+
+Same pattern as Task 2:
+- `get-contacts.ts` — list with `contactReadScopeWhere`
+- `get-contact.ts` — detail with `assertCanReadContact` (uses upgraded helper from Task 1)
+- `get-contacts-by-accountId.ts` — `assertCanReadAccount` first, then list scoped
+- `get-contacts-by-opportunityId.ts` — `assertCanReadOpportunity` first, then list with `contactReadScopeWhere(user)` AND the existing `opportunities: { some: { opportunity_id: opportunityId } }` filter
+
+```bash
+git add actions/crm/get-contact*.ts actions/crm/__tests__/
+git commit -m "fix(crm): scope contact reads by role and linked-account/opportunity access"
+```
+
+---
+
+## Task 4: Patch opportunity read actions
+
+**Files:**
+- Modify: `actions/crm/get-opportunities.ts`, `actions/crm/get-opportunities-with-includes.ts`, `actions/crm/get-opportunity.ts`
+
+Same pattern: list functions spread `opportunityReadScopeWhere(user)` into where; detail uses `assertCanReadOpportunity`. The cached variant `get-opportunities-with-includes.ts` may use Next.js `unstable_cache` — the cache key MUST include `user.id` (or `user.role` if managers/admins all share global cache, but user IDs each get their own slot). Otherwise one user's cached result leaks to another. Pattern:
+
+```ts
+export async function getOpportunitiesWithIncludes() {
+  const user = await requireAuthenticated();
+  const cached = unstable_cache(
+    async () => prismadb.crm_Opportunities.findMany({
+      where: opportunityReadScopeWhere(user),
+      // ... existing select / include
+    }),
+    ["opportunities-with-includes", user.role === "user" ? user.id : "global"],
+    { /* existing tags / revalidate */ },
+  );
+  return cached();
+}
+```
+
+- [ ] Implement + tests + commit:
+
+```bash
+git add actions/crm/get-opportunities*.ts actions/crm/get-opportunity.ts actions/crm/__tests__/
+git commit -m "fix(crm): scope opportunity reads by role; cache key respects user scope"
+```
+
+---
+
+## Task 5: Patch contract read actions
+
+**Files:**
+- Modify: `actions/crm/get-contract.ts`, `actions/crm/get-contracts.ts`
+
+`get-contracts.ts` overloads on argument: list-all OR list-by-account. Both branches use `contractReadScopeWhere(user)`; the by-account branch additionally `assertCanReadAccount` first.
+
+```bash
+git add actions/crm/get-contract.ts actions/crm/get-contracts.ts actions/crm/__tests__/
+git commit -m "fix(crm): scope contract reads by role and linked-account access"
+```
+
+---
+
+## Task 6: Verification + PR
+
+- [ ] **Step 1: Full suite + cross-cutting grep**
+
+```bash
+pnpm jest 2>&1 | tail -8
+grep -rn "prismadb\.crm_\(Leads\|Contacts\|Opportunities\|Contracts\)\.\(findMany\|findUnique\|findFirst\)" actions/ app/api/ --include="*.ts" | grep -v "__tests__\|scopes/crm" | head
+```
+Confirm no remaining unscoped reads in user-facing paths. Calls in `actions/crm/{leads,contacts,opportunities,contracts}/{create,update,delete,restore}-*.ts` are write actions (already use scope helpers in earlier phases) and don't apply.
+
+- [ ] **Step 2: Manual cross-user attack checklist** (against deployed dev):
+  - As `bob`, list endpoints / pages → only `bob`'s rows
+  - As `bob`, navigate directly to `/crm/leads/<alice-lead-id>` → 404 / not found
+  - As `bob`, view an account `bob` has watcher access to → linked leads/contacts/opportunities show up (linked-account scope works)
+  - As `manager`, list endpoints → all rows
+  - As `admin`, restore endpoints still work
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feat/authz-phase-d2
+gh pr create --base dev --head feat/authz-phase-d2 --title "fix(security): scope CRM lead/contact/opportunity/contract reads by role (Phase D2)" --body "..."
+```
+
+PR body references: spec §6.2–6.5, this plan, the linked-account scope closure of B1's TODO.
+
+---
+
+## Acceptance Criteria
+
+- Every list/detail/search read action across leads, contacts, opportunities, contracts requires authentication and applies a role-aware where filter.
+- `assertCanReadContact` body now includes linked-account scope (B1 TODO closed).
+- The `getOpportunitiesWithIncludes` cache key includes user identity for `user`-role callers.
+- New tests cover unauth/user/manager/admin per action; helper tests cover role permutations.
+
+## Out of D2 scope
+
+- Targets, target lists, activities, audit logs, similarity — **D3**
+- Restore actions (admin-only — keep current admin guards untouched)
+- Write actions (already gated in earlier phases)
+- Removing the dual `created_by`/`createdBy` columns — Phase F

--- a/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d3.md
+++ b/docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d3.md
@@ -1,0 +1,307 @@
+# Permission-Driven Authorization — Phase D3 (Targets, Lists, Activities, Audit, Similarity) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Close the remaining CRM read-side scope gaps from the audit. After D3, target/list lookups, entity-keyed activity feeds, audit logs, and pgvector similarity searches all enforce role-based scope. This phase finishes the spec §6 / §8 read-side migration.
+
+**Architecture:** Five distinct sub-shapes, each with its own helper:
+
+1. **Targets + lists** — single-creator scope. Adds `targetReadScopeWhere`, `targetListReadScopeWhere`, `assertCanReadTargetList`.
+2. **Activities-by-entity** — heterogeneous: resolve to the linked entity's scope. New `assertCanReadActivityForEntity(user, entityType, entityId)` dispatches to existing `assertCanRead*` helpers based on `entityType`.
+3. **Audit-log-by-entity** — same dispatch as activities.
+4. **Audit-log-admin** — already admin-gated; just normalize to canonical `requireRole(["admin"])`.
+5. **Similarity (pgvector raw SQL)** — post-filter the SQL result set through `filterAuthorized*Ids` so out-of-scope candidates are dropped before being returned.
+
+**Spec source:** §6.8 (targets), §8.7, §8.8, §8.10, §12 Phase 4.
+**Audit source:** "Global CRM Read Actions" residuals.
+
+**Depends on:** D1 + D2 merged. Reuses `assertCanReadAccount`, `assertCanReadLead`, `assertCanReadContact`, `assertCanReadOpportunity`, `assertCanReadContract`, `assertCanReadTarget` (B1), `filterAuthorizedContactIds`, `filterAuthorizedTargetIds` (B1).
+
+---
+
+## File Structure
+
+**New tests:**
+- `lib/authz/__tests__/scopes-crm-target-read.test.ts`
+- `lib/authz/__tests__/scopes-crm-activity-dispatch.test.ts`
+- `actions/crm/__tests__/get-target*-scope.test.ts`
+- `actions/crm/activities/__tests__/get-activities-by-entity-scope.test.ts`
+- `actions/crm/audit-log/__tests__/get-audit-log-by-entity-scope.test.ts`
+- `actions/crm/similarity/__tests__/scope.test.ts`
+
+**Modified:**
+- `lib/authz/scopes/crm.ts` — add `targetReadScopeWhere`, `targetListReadScopeWhere`, `assertCanReadTargetList`, `assertCanReadActivityForEntity`
+- `lib/authz/index.ts`
+- `actions/crm/get-target.ts`, `get-targets.ts`, `get-target-list.ts`, `get-target-lists.ts`
+- `actions/crm/activities/get-activities-by-entity.ts`
+- `actions/crm/audit-log/get-audit-log-by-entity.ts`
+- `actions/crm/audit-log/get-audit-log-admin.ts` — normalize admin guard
+- `actions/crm/similarity/get-similar-{accounts,contacts,leads,opportunities}.ts`
+
+---
+
+## Task 1: Target + target-list scope helpers
+
+```ts
+// crm_Targets has no deletedAt and no assigned_to — only created_by.
+export function targetReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") return {};
+  return { created_by: user.id };
+}
+
+// crm_TargetLists has deletedAt + created_by.
+export function targetListReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return { deletedAt: null, created_by: user.id };
+}
+
+export async function assertCanReadTargetList(user: AuthzUser, listId: string) {
+  const row = await prismadb.crm_TargetLists.findFirst({
+    where: { id: listId, ...targetListReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+```
+
+`assertCanReadTarget` already exists from B1; no change.
+
+- [ ] **Step 1: Failing test** at `lib/authz/__tests__/scopes-crm-target-read.test.ts` covering admin/manager/user shapes for both helpers + `assertCanReadTargetList` (404 case + 200 case).
+
+- [ ] **Step 2: Implement, add to barrel, test → PASS, commit**
+
+```bash
+git commit -m "feat(authz): add target and target-list read-scope helpers"
+```
+
+---
+
+## Task 2: Patch target read actions
+
+**Files:**
+- Modify: `actions/crm/get-target.ts`, `get-targets.ts`, `get-target-list.ts`, `get-target-lists.ts`
+
+Apply patterns from D1/D2:
+- `get-target.ts` — `requireAuthenticated` + `assertCanReadTarget` (existing) → existing detail query
+- `get-targets.ts` — `requireAuthenticated` + spread `targetReadScopeWhere(user)` into where
+- `get-target-list.ts` — `requireAuthenticated` + `assertCanReadTargetList`
+- `get-target-lists.ts` — `requireAuthenticated` + spread `targetListReadScopeWhere(user)`
+
+- [ ] One test file per action (same shape as D1 — 401, user-out, user-in, manager).
+
+- [ ] Commit:
+
+```bash
+git commit -m "fix(crm): scope target and target-list reads by role"
+```
+
+---
+
+## Task 3: Activity / audit dispatch helper
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts` — add `assertCanReadActivityForEntity`
+- Create: `lib/authz/__tests__/scopes-crm-activity-dispatch.test.ts`
+
+```ts
+type ScopedEntityType =
+  | "account" | "lead" | "contact" | "opportunity" | "contract" | "target" | "target_list";
+
+export async function assertCanReadActivityForEntity(
+  user: AuthzUser,
+  entityType: string,
+  entityId: string,
+): Promise<void> {
+  switch (entityType.toLowerCase()) {
+    case "account":     return assertCanReadAccount(user, entityId);
+    case "lead":        return assertCanReadLead(user, entityId);
+    case "contact":     return assertCanReadContact(user, entityId);
+    case "opportunity": return assertCanReadOpportunity(user, entityId);
+    case "contract":    return assertCanReadContract(user, entityId);
+    case "target":      return assertCanReadTarget(user, entityId);
+    case "target_list":
+    case "targetlist":  return assertCanReadTargetList(user, entityId);
+    default:
+      // Unknown entity types: managers/admins can see; users cannot.
+      if (user.role === "user") throw new AuthorizationError();
+      return;
+  }
+}
+```
+
+- [ ] **Step 1: Failing test** — one case per entity type plus the unknown-type fallback.
+
+Mock all 7 individual `assertCanRead*` helpers via `jest.spyOn` or `jest.mock("../scopes/crm")` partial mock. For each entity type, assert the correct helper is called with the correct args.
+
+- [ ] **Step 2: Implement, barrel, test → PASS, commit**
+
+```bash
+git commit -m "feat(authz): add activity-for-entity scope dispatch helper"
+```
+
+---
+
+## Task 4: Patch `getActivitiesByEntity`
+
+**Files:**
+- Modify: `actions/crm/activities/get-activities-by-entity.ts`
+- Create test
+
+Current behavior: paginated activities for a given `entityType + entityId` with no auth. Fix: `requireAuthenticated` → `assertCanReadActivityForEntity(user, entityType, entityId)` (returns 404/empty on miss) → existing query.
+
+- [ ] **Step 1: Failing test**:
+  - 401 unauth → no DB query
+  - 404 (or empty page) when user can't read the entity
+  - 200 with activities when user can read the entity (manager+ for any entity, user for their own)
+  - Mock `@/lib/auth-server`, `@/lib/prisma`, AND the dispatch helper itself (`jest.mock("@/lib/authz")` partial — keep `requireAuthenticated`, mock `assertCanReadActivityForEntity` to throw or resolve depending on case).
+
+- [ ] **Step 2: Patch action**, ensure existing pagination cursor logic is unchanged.
+
+- [ ] **Commit:**
+
+```bash
+git commit -m "fix(crm): require entity-scoped read access on activity feed"
+```
+
+---
+
+## Task 5: Patch `getAuditLogByEntity` + normalize `getAuditLogAdmin`
+
+**Files:**
+- Modify: `actions/crm/audit-log/get-audit-log-by-entity.ts` — same pattern as Task 4 using `assertCanReadActivityForEntity` (audit logs share the same entity model)
+- Modify: `actions/crm/audit-log/get-audit-log-admin.ts` — replace existing `session.user.role !== "admin"` check with canonical `requireRole(["admin"])` (matches Phase C pattern)
+
+- [ ] Test + patch each:
+  - `get-audit-log-by-entity.ts` — 4 cases (401, user-not-in-scope, user-in-scope, manager)
+  - `get-audit-log-admin.ts` — 3 cases (401, user → forbidden, admin → success)
+
+- [ ] **Commit:**
+
+```bash
+git commit -m "fix(crm): scope audit-log-by-entity and normalize audit-log-admin to canonical helper"
+```
+
+---
+
+## Task 6: Filter pgvector similarity results
+
+**Files:**
+- Modify: `actions/crm/similarity/get-similar-accounts.ts`
+- Modify: `actions/crm/similarity/get-similar-contacts.ts`
+- Modify: `actions/crm/similarity/get-similar-leads.ts`
+- Modify: `actions/crm/similarity/get-similar-opportunities.ts`
+
+These use raw SQL to query pgvector. We can't easily inject a Prisma `where` into the raw query, but we **can** post-filter results: take the SQL result set, then call `filterAuthorizedXxxIds(user, candidateIds)` and return only matches.
+
+Pattern (each file):
+
+```ts
+import {
+  requireAuthenticated,
+  assertCanReadAccount, // or appropriate per file
+  filterAuthorizedContactIds, // or relevant filter
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+export async function getSimilarContacts(recordId: string, limit = 10) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
+  // Step 1: ensure user can read the BASE record. Without this, info disclosure
+  // happens via "we ran the query" timing.
+  try {
+    await assertCanReadContact(user, recordId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
+
+  // Step 2: existing raw SQL — fetches up to `limit * 3` candidates so post-filter
+  // still returns useful results for user-role callers with narrower scope.
+  const candidates: Array<{ id: string; /* + similarity fields */ }> =
+    await prismadb.$queryRaw`
+      ... existing pgvector query, but ORDER BY distance LIMIT ${limit * 3} ...
+    `;
+
+  // Step 3: post-filter
+  const ids = candidates.map((c) => c.id);
+  const allowed = new Set(await filterAuthorizedContactIds(user, ids));
+  const filtered = candidates.filter((c) => allowed.has(c.id)).slice(0, limit);
+  return filtered;
+}
+```
+
+For `getSimilarAccounts`, you'd need an `filterAuthorizedAccountIds` helper — add it to `lib/authz/scopes/crm.ts` (mirroring `filterAuthorizedContactIds`) using `accountReadScopeWhere`.
+
+For `getSimilarLeads` and `getSimilarOpportunities`, add `filterAuthorizedLeadIds` and `filterAuthorizedOpportunityIds` similarly — small utility additions reusing the read-scope helpers.
+
+- [ ] **Step 1: Add the three new filter helpers** (`Account`, `Lead`, `Opportunity`) — small extension to `lib/authz/scopes/crm.ts`. One unit test per helper.
+
+- [ ] **Step 2–5: Patch each similarity action** (one task subset per file). Test cases per file:
+  - 401 unauth → empty result
+  - 404/empty when user can't read the base record
+  - results filtered correctly for user role
+  - manager/admin gets unfiltered results
+
+- [ ] **Commit:**
+
+```bash
+git commit -m "fix(crm): scope pgvector similarity results by user/manager/admin"
+```
+
+---
+
+## Task 7: Verification + PR
+
+- [ ] **Step 1: Full suite + grep for residual unscoped reads on the affected models**
+
+```bash
+pnpm jest 2>&1 | tail -8
+grep -rn "prismadb\.crm_\(Targets\|TargetLists\|Activities\|AuditLog\)\." actions/ app/api/ --include="*.ts" | grep -v "__tests__\|scopes/crm" | head
+```
+
+- [ ] **Step 2: Manual checklist (dev)**:
+  - As `bob`, list targets → only `bob`'s
+  - As `bob`, view activity feed for `alice`'s opportunity → 404/empty
+  - As `bob`, similarity search on a contact `bob` cannot read → empty
+  - As `bob`, similarity search on `bob`'s contact → returns only contacts `bob` can read
+  - As `manager`, all the above → full results
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feat/authz-phase-d3
+gh pr create --base dev --head feat/authz-phase-d3 --title "fix(security): scope targets, activities, audit log, similarity (Phase D3)" --body "..."
+```
+
+PR body references: spec §6.8/§8.7/§8.8/§8.10, this plan, residual-scope items going to Phase E (products, campaigns, documents, projects).
+
+---
+
+## Acceptance Criteria
+
+- Every list/detail target read action requires auth + role-scoped filter.
+- `getActivitiesByEntity` and `getAuditLogByEntity` resolve scope through the entity dispatcher and reject out-of-scope readers.
+- `getAuditLogAdmin` uses canonical `requireRole(["admin"])`.
+- All four similarity actions verify access to the base record AND post-filter result sets through scope.
+- New filter helpers (`filterAuthorizedAccountIds`, `filterAuthorizedLeadIds`, `filterAuthorizedOpportunityIds`) exist alongside the B1 contact/target ones.
+
+## Out of D3 scope
+
+- **Phase E** picks up: products, campaigns + templates, documents, projects (boards/tasks), full invoice list-scoping.
+- **Phase F** removes `is_admin` / `is_account_admin` columns and switches `Users.role` to a Prisma enum.
+- Removing dual `created_by`/`createdBy` columns is a separate cleanup (Phase F).
+
+---
+
+## Phase D summary (across D1 + D2 + D3)
+
+After all three PRs merge, the residual audit gaps for CRM core (accounts/leads/contacts/opportunities/contracts/targets/activities/audit/similarity) are closed. Total ~25 read action files patched; ~10 new helpers added to `lib/authz/scopes/crm.ts`. The `Users.role` is now consulted for every CRM read operation.


### PR DESCRIPTION
## Summary

Plans for the next three Phase D PRs splitting CRM read-side scoping into three reviewable, independently shippable chunks. Each plan follows the established pattern from Phases A–C (TDD per task, scope helpers in \`lib/authz/scopes/crm.ts\`, mock-based unit tests, manual cross-user attack checklist before merge).

## What changed

- \`docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d1.md\` — Accounts (foundation; introduces \`accountUserScopeOR\`, \`accountReadScopeWhere\`, \`assertCanReadAccount\`)
- \`docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d2.md\` — Leads, Contacts, Opportunities, Contracts (adds linked-account scope, closes B1 TODO)
- \`docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d3.md\` — Targets, Lists, Activities, Audit Log, pgvector Similarity

## Dependency graph

D1 → D2 → D3 (sequential, like B1→B2→B3). D1 ships the account helpers D2 reuses for nested linked-account scope. D2 ships the per-entity asserts D3's activity/audit dispatch needs.

## Volume estimate

- D1: ~5 tasks, 3 actions patched
- D2: ~6 tasks, 12 actions patched (the largest sub-phase)
- D3: ~7 tasks, 10 actions patched + raw SQL post-filter pattern for similarity

Total Phase D: ~25 read actions hardened, ~10 new helpers, all backed by unit tests.

## Test plan

This is a docs-only PR. Smoke check: confirm the markdown renders; review acceptance criteria; flag scope concerns before D1 implementation starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)