### PR TITLE
fix(security): scope CRM account reads by role (Phase D1)

### DIFF
--- a/actions/crm/accounts/__tests__/get-account-by-id-scope.test.ts
+++ b/actions/crm/accounts/__tests__/get-account-by-id-scope.test.ts
@@ -1,0 +1,58 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn(), findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getAccountById } from "@/actions/crm/accounts/get-account-by-id";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getAccountById scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns null and does not query detail", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getAccountById("a1");
+    expect(res).toBeNull();
+    expect(prismadb.crm_Accounts.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns null when assertCanReadAccount finds no row (out-of-scope)", async () => {
+    mockUser("user", "u1");
+    // assertCanReadAccount.findFirst returns null -> AuthorizationError
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getAccountById("a1");
+    expect(res).toBeNull();
+    // detail findFirst should not produce data — only the assert call happened
+    expect(prismadb.crm_Accounts.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("owner (user role) with scope match returns account", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock)
+      // assert call
+      .mockResolvedValueOnce({ id: "a1" })
+      // detail call
+      .mockResolvedValueOnce({ id: "a1", name: "Acme" });
+    const res = await getAccountById("a1");
+    expect(res).toEqual({ id: "a1", name: "Acme" });
+    expect(prismadb.crm_Accounts.findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it("manager returns account", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock)
+      .mockResolvedValueOnce({ id: "a1" })
+      .mockResolvedValueOnce({ id: "a1", name: "Acme" });
+    const res = await getAccountById("a1");
+    expect(res).toEqual({ id: "a1", name: "Acme" });
+  });
+});

--- a/actions/crm/accounts/__tests__/get-accounts-scope.test.ts
+++ b/actions/crm/accounts/__tests__/get-accounts-scope.test.ts
@@ -1,0 +1,65 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getAccounts } from "@/actions/crm/accounts/get-accounts";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getAccounts scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated does not query and returns error", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getAccounts();
+    expect(prismadb.crm_Accounts.findMany).not.toHaveBeenCalled();
+    expect(res).toHaveProperty("error");
+  });
+
+  it("user role scopes by assigned/createdBy/watchers OR + deletedAt:null", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    await getAccounts();
+    expect(prismadb.crm_Accounts.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          deletedAt: null,
+          OR: [
+            { assigned_to: "u1" },
+            { createdBy: "u1" },
+            { watchers: { some: { user_id: "u1" } } },
+          ],
+        }),
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
+      }),
+    );
+  });
+
+  it("manager role: where = { deletedAt: null } (no OR)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    await getAccounts();
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ deletedAt: null });
+    expect(call.where.OR).toBeUndefined();
+  });
+
+  it("admin role: where = { deletedAt: null } (no OR)", async () => {
+    mockUser("admin", "a1");
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    await getAccounts();
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ deletedAt: null });
+    expect(call.where.OR).toBeUndefined();
+  });
+});

--- a/actions/crm/accounts/__tests__/search-accounts-scope.test.ts
+++ b/actions/crm/accounts/__tests__/search-accounts-scope.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findMany: jest.fn(), count: jest.fn() },
+    $transaction: jest.fn((ops: Promise<unknown>[]) => Promise.all(ops)),
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { searchAccounts } from "@/actions/crm/accounts/search-accounts";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("searchAccounts scope", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.crm_Accounts.count as jest.Mock).mockResolvedValue(0);
+    (prismadb.$transaction as jest.Mock).mockImplementation((ops: Promise<unknown>[]) =>
+      Promise.all(ops),
+    );
+  });
+
+  it("unauthenticated does not query and returns error", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await searchAccounts({ search: "acme" });
+    expect(prismadb.crm_Accounts.findMany).not.toHaveBeenCalled();
+    expect(res).toHaveProperty("error");
+  });
+
+  it("user role: where contains search term AND ownership OR + deletedAt:null", async () => {
+    mockUser("user", "u1");
+    await searchAccounts({ search: "acme" });
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        deletedAt: null,
+        name: { contains: "acme", mode: "insensitive" },
+        OR: [
+          { assigned_to: "u1" },
+          { createdBy: "u1" },
+          { watchers: { some: { user_id: "u1" } } },
+        ],
+      }),
+    );
+  });
+
+  it("manager role: where = search term + deletedAt:null, no OR", async () => {
+    mockUser("manager", "m1");
+    await searchAccounts({ search: "acme" });
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({
+      deletedAt: null,
+      name: { contains: "acme", mode: "insensitive" },
+    });
+    expect(call.where.OR).toBeUndefined();
+  });
+});

--- a/actions/crm/accounts/get-account-by-id.ts
+++ b/actions/crm/accounts/get-account-by-id.ts
@@ -1,8 +1,29 @@
 "use server";
 
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export async function getAccountById(accountId: string) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
+
+  try {
+    await assertCanReadAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+
   const account = await prismadb.crm_Accounts.findFirst({
     where: { id: accountId, deletedAt: null },
     select: { id: true, name: true },

--- a/actions/crm/accounts/get-accounts.ts
+++ b/actions/crm/accounts/get-accounts.ts
@@ -1,15 +1,24 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  accountReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getAccounts = async () => {
   try {
+    const user = await requireAuthenticated();
     const accounts = await prismadb.crm_Accounts.findMany({
-      where: { deletedAt: null },
+      where: accountReadScopeWhere(user),
       select: { id: true, name: true },
       orderBy: { name: "asc" },
     });
     return { data: accounts };
   } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return { error: "Unauthorized" };
+    }
     return { error: "Failed to fetch accounts" };
   }
 };

--- a/actions/crm/accounts/search-accounts.ts
+++ b/actions/crm/accounts/search-accounts.ts
@@ -1,6 +1,11 @@
 "use server";
 
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  accountReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 const PAGE_SIZE_MAX = 100;
 
@@ -13,23 +18,40 @@ export async function searchAccounts({
   skip?: number;
   take?: number;
 } = {}) {
-  const safeTake = Math.min(PAGE_SIZE_MAX, Math.max(1, take));
-  const safeSkip = Math.max(0, skip);
+  try {
+    const user = await requireAuthenticated();
 
-  const where = search
-    ? { name: { contains: search, mode: "insensitive" as const }, deletedAt: null }
-    : { deletedAt: null };
+    const safeTake = Math.min(PAGE_SIZE_MAX, Math.max(1, take));
+    const safeSkip = Math.max(0, skip);
 
-  const [accounts, total] = await prismadb.$transaction([
-    prismadb.crm_Accounts.findMany({
-      where,
-      select: { id: true, name: true },
-      orderBy: { name: "asc" },
-      skip: safeSkip,
-      take: safeTake,
-    }),
-    prismadb.crm_Accounts.count({ where }),
-  ]);
+    const where = {
+      ...accountReadScopeWhere(user),
+      ...(search
+        ? { name: { contains: search, mode: "insensitive" as const } }
+        : {}),
+    };
 
-  return { accounts, total, hasMore: safeSkip + safeTake < total };
+    const [accounts, total] = await prismadb.$transaction([
+      prismadb.crm_Accounts.findMany({
+        where,
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
+        skip: safeSkip,
+        take: safeTake,
+      }),
+      prismadb.crm_Accounts.count({ where }),
+    ]);
+
+    return { accounts, total, hasMore: safeSkip + safeTake < total };
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return { error: "Unauthorized", accounts: [], total: 0, hasMore: false };
+    }
+    return {
+      error: "Failed to search accounts",
+      accounts: [],
+      total: 0,
+      hasMore: false,
+    };
+  }
 }

--- a/lib/authz/__tests__/scopes-crm-account-read.test.ts
+++ b/lib/authz/__tests__/scopes-crm-account-read.test.ts
@@ -1,0 +1,60 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Accounts: { findFirst: jest.fn() } },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  accountUserScopeOR,
+  accountReadScopeWhere,
+  assertCanReadAccount,
+} from "../scopes/crm";
+
+const find = prismadb.crm_Accounts.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_Accounts.findFirst
+>;
+beforeEach(() => jest.clearAllMocks());
+
+describe("accountUserScopeOR", () => {
+  it("returns three OR clauses for the user id", () => {
+    expect(accountUserScopeOR("u1")).toEqual([
+      { assigned_to: "u1" },
+      { createdBy: "u1" },
+      { watchers: { some: { user_id: "u1" } } },
+    ]);
+  });
+});
+
+describe("accountReadScopeWhere", () => {
+  it("admin / manager → only deletedAt:null", () => {
+    expect(accountReadScopeWhere({ id: "x", role: "admin" })).toEqual({ deletedAt: null });
+    expect(accountReadScopeWhere({ id: "x", role: "manager" })).toEqual({ deletedAt: null });
+  });
+  it("user → deletedAt + OR ownership clauses", () => {
+    expect(accountReadScopeWhere({ id: "u1", role: "user" })).toMatchObject({
+      deletedAt: null,
+      OR: expect.arrayContaining([
+        { assigned_to: "u1" },
+        { createdBy: "u1" },
+        { watchers: { some: { user_id: "u1" } } },
+      ]),
+    });
+  });
+});
+
+describe("assertCanReadAccount", () => {
+  it("throws when not in scope", async () => {
+    find.mockResolvedValue(null);
+    await expect(assertCanReadAccount({ id: "u", role: "user" }, "a1"))
+      .rejects.toBeInstanceOf(AuthorizationError);
+  });
+  it("admin: no OR clauses in where (just id + deletedAt)", async () => {
+    find.mockResolvedValue({ id: "a1" } as any);
+    await assertCanReadAccount({ id: "x", role: "admin" }, "a1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "a1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -32,5 +32,10 @@ export {
   assertCanCancelTargetEnrichment,
 } from "./scopes/crm";
 export { assertCanWriteAccount } from "./scopes/crm";
+export {
+  accountUserScopeOR,
+  accountReadScopeWhere,
+  assertCanReadAccount,
+} from "./scopes/crm";
 export type { ReportScope } from "./scopes/report-scope";
 export { getReportScope } from "./scopes/report-scope";

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -188,6 +188,41 @@ export async function filterAuthorizedTargetIds(
   return rows.map((r: { id: string }) => r.id);
 }
 
+// Internal: the OR clauses describing user-level account ownership.
+// Exported via accountReadScopeWhere; D2 will reuse for nested linked-account scope.
+export function accountUserScopeOR(userId: string) {
+  return [
+    { assigned_to: userId },
+    { createdBy: userId },
+    { watchers: { some: { user_id: userId } } },
+  ] as const;
+}
+
+// Build a Prisma where for "this user can read this account".
+// Manager/admin: { deletedAt: null }
+// User:           { deletedAt: null, OR: accountUserScopeOR(user.id) }
+export function accountReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: accountUserScopeOR(user.id),
+  };
+}
+
+// Throws AuthorizationError if user can't read this account.
+export async function assertCanReadAccount(
+  user: AuthzUser,
+  accountId: string,
+): Promise<void> {
+  const row = await prismadb.crm_Accounts.findFirst({
+    where: { id: accountId, ...accountReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
 export async function assertCanWriteAccount(
   user: AuthzUser,
   accountId: string,
@@ -197,11 +232,7 @@ export async function assertCanWriteAccount(
       ? { id: accountId }
       : {
           id: accountId,
-          OR: [
-            { assigned_to: user.id },
-            { createdBy: user.id },
-            { watchers: { some: { user_id: user.id } } },
-          ],
+          OR: accountUserScopeOR(user.id),
         };
   const row = await prismadb.crm_Accounts.findFirst({
     where,


### PR DESCRIPTION
## Summary

Adds user/manager/admin scoping to every CRM account read action. After D1, a `user` sees only accounts they're assigned to, created, or watch; `manager`/`admin` see all non-deleted accounts. Also ships reusable `accountUserScopeOR` and `accountReadScopeWhere` helpers that D2 will compose into linked-account checks for leads/contacts/opportunities/contracts.

## What changed

**New helpers in `lib/authz/scopes/crm.ts`:**
- `accountUserScopeOR(userId)` — exported OR clause array (`assigned_to | createdBy | watcher`); reusable for nested linked-account scope in D2
- `accountReadScopeWhere(user)` — full where with `deletedAt: null` and role gating (admin/manager: bare deletedAt, user: deletedAt + OR ownership)
- `assertCanReadAccount(user, accountId)` — throws `AuthorizationError` on out-of-scope; mirrors `assertCanReadContact`/`assertCanReadTarget` shape from B1

**Refactor:**
- `assertCanWriteAccount` (B2) now uses `accountUserScopeOR` internally — DRY without behavior change. B2 tests still pass.

**Read actions patched:**
- `actions/crm/accounts/get-accounts.ts` — `requireAuthenticated` + spread `accountReadScopeWhere(user)`
- `actions/crm/accounts/get-account-by-id.ts` — `assertCanReadAccount` returns `null` (404-equivalent) on out-of-scope to avoid existence leak
- `actions/crm/accounts/search-accounts.ts` — spread `accountReadScopeWhere(user)` alongside the search term

## Test status

- 61/67 suites pass, 336/337 tests pass (Phase C baseline: 57/63, 320/321)
- 16 new tests across helper + 3 actions
- Same 6 pre-existing suite failures + 1 pre-existing test failure unchanged — no new regressions

## Test plan

- [ ] As `bob` (user, no account ownership), list accounts page → empty
- [ ] As `bob`, navigate directly to `/crm/accounts/<alice-account>` → 404 / not-found page
- [ ] As `bob`, after `alice` adds him to `AccountWatchers` for one account, that account appears in the list
- [ ] As `manager`, list accounts → all non-deleted accounts
- [ ] As `bob`, search by partial name → only accounts `bob` can read

## Out of D1 scope

- **D2** picks up: leads, contacts, opportunities, contracts (will reuse `accountUserScopeOR` for nested linked-account scope, closing B1 TODO)
- **D3**: targets, target lists, activities, audit log, pgvector similarity
- Restore actions (admin-only — already gated separately)
- Write actions (already gated in earlier phases)

Plan: `docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)