### PR TITLE
fix(security): scope targets, activities, audit log, similarity (Phase D3)

### DIFF
--- a/actions/crm/__tests__/get-target-list-scope.test.ts
+++ b/actions/crm/__tests__/get-target-list-scope.test.ts
@@ -1,0 +1,59 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_TargetLists: { findFirst: jest.fn(), findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTargetList } from "@/actions/crm/get-target-list";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTargetList scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns null and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTargetList("l1");
+    expect(res).toBeNull();
+    expect(prismadb.crm_TargetLists.findFirst).not.toHaveBeenCalled();
+    expect(prismadb.crm_TargetLists.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope returns null (assert miss)", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_TargetLists.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getTargetList("l1");
+    expect(res).toBeNull();
+    expect(prismadb.crm_TargetLists.findFirst).toHaveBeenCalledTimes(1);
+    expect(prismadb.crm_TargetLists.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("owner returns target list detail (deletedAt:null + created_by)", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_TargetLists.findFirst as jest.Mock).mockResolvedValue({ id: "l1" });
+    (prismadb.crm_TargetLists.findUnique as jest.Mock).mockResolvedValue({ id: "l1", name: "L" });
+    const res = await getTargetList("l1");
+    expect(res).toEqual({ id: "l1", name: "L" });
+    const assertCall = (prismadb.crm_TargetLists.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.created_by).toBe("u1");
+    expect(assertCall.where.deletedAt).toBeNull();
+  });
+
+  it("manager returns target list (deletedAt:null only, no created_by)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_TargetLists.findFirst as jest.Mock).mockResolvedValue({ id: "l1" });
+    (prismadb.crm_TargetLists.findUnique as jest.Mock).mockResolvedValue({ id: "l1", name: "L" });
+    const res = await getTargetList("l1");
+    expect(res).toEqual({ id: "l1", name: "L" });
+    const assertCall = (prismadb.crm_TargetLists.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.created_by).toBeUndefined();
+    expect(assertCall.where.deletedAt).toBeNull();
+  });
+});

--- a/actions/crm/__tests__/get-target-lists-scope.test.ts
+++ b/actions/crm/__tests__/get-target-lists-scope.test.ts
@@ -1,0 +1,52 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_TargetLists: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTargetLists } from "@/actions/crm/get-target-lists";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTargetLists scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTargetLists();
+    expect(res).toEqual([]);
+    expect(prismadb.crm_TargetLists.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where includes deletedAt:null and created_by:u1", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_TargetLists.findMany as jest.Mock).mockResolvedValue([]);
+    await getTargetLists();
+    const call = (prismadb.crm_TargetLists.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.deletedAt).toBeNull();
+    expect(call.where.created_by).toBe("u1");
+  });
+
+  it("manager: where = { deletedAt:null } (no created_by)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_TargetLists.findMany as jest.Mock).mockResolvedValue([]);
+    await getTargetLists();
+    const call = (prismadb.crm_TargetLists.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ deletedAt: null });
+    expect(call.where.created_by).toBeUndefined();
+  });
+
+  it("returns rows from prisma", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_TargetLists.findMany as jest.Mock).mockResolvedValue([{ id: "l1" }]);
+    const res = await getTargetLists();
+    expect(res).toEqual([{ id: "l1" }]);
+  });
+});

--- a/actions/crm/__tests__/get-target-scope.test.ts
+++ b/actions/crm/__tests__/get-target-scope.test.ts
@@ -1,0 +1,60 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: { findFirst: jest.fn(), findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTarget } from "@/actions/crm/get-target";
+
+const VALID_ID = "11111111-1111-1111-1111-111111111111";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTarget scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns null and does not query target", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTarget(VALID_ID);
+    expect(res).toBeNull();
+    expect(prismadb.crm_Targets.findFirst).not.toHaveBeenCalled();
+    expect(prismadb.crm_Targets.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope returns null (assert miss)", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Targets.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getTarget(VALID_ID);
+    expect(res).toBeNull();
+    expect(prismadb.crm_Targets.findFirst).toHaveBeenCalledTimes(1);
+    expect(prismadb.crm_Targets.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("owner returns target detail", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Targets.findFirst as jest.Mock).mockResolvedValue({ id: VALID_ID });
+    (prismadb.crm_Targets.findUnique as jest.Mock).mockResolvedValue({ id: VALID_ID, name: "T1" });
+    const res = await getTarget(VALID_ID);
+    expect(res).toEqual({ id: VALID_ID, name: "T1" });
+    const assertCall = (prismadb.crm_Targets.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.created_by).toBe("u1");
+    expect(assertCall.where.deletedAt).toBeUndefined();
+  });
+
+  it("manager returns target detail (no created_by filter)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Targets.findFirst as jest.Mock).mockResolvedValue({ id: VALID_ID });
+    (prismadb.crm_Targets.findUnique as jest.Mock).mockResolvedValue({ id: VALID_ID, name: "T1" });
+    const res = await getTarget(VALID_ID);
+    expect(res).toEqual({ id: VALID_ID, name: "T1" });
+    const assertCall = (prismadb.crm_Targets.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.created_by).toBeUndefined();
+  });
+});

--- a/actions/crm/__tests__/get-targets-scope.test.ts
+++ b/actions/crm/__tests__/get-targets-scope.test.ts
@@ -25,21 +25,20 @@ describe("getTargets scope", () => {
     expect(prismadb.crm_Targets.findMany).not.toHaveBeenCalled();
   });
 
-  it("user role: where = { created_by: u1 } (no deletedAt — hard delete model)", async () => {
+  it("user role: where = { deletedAt: null, created_by: u1 }", async () => {
     mockUser("user", "u1");
     (prismadb.crm_Targets.findMany as jest.Mock).mockResolvedValue([]);
     await getTargets();
     const call = (prismadb.crm_Targets.findMany as jest.Mock).mock.calls[0][0];
-    expect(call.where.created_by).toBe("u1");
-    expect(call.where.deletedAt).toBeUndefined();
+    expect(call.where).toMatchObject({ deletedAt: null, created_by: "u1" });
   });
 
-  it("manager: where = {} (no scope, no deletedAt)", async () => {
+  it("manager: where = { deletedAt: null }", async () => {
     mockUser("manager", "m1");
     (prismadb.crm_Targets.findMany as jest.Mock).mockResolvedValue([]);
     await getTargets();
     const call = (prismadb.crm_Targets.findMany as jest.Mock).mock.calls[0][0];
-    expect(call.where).toEqual({});
+    expect(call.where).toEqual({ deletedAt: null });
   });
 
   it("returns rows from prisma", async () => {

--- a/actions/crm/__tests__/get-targets-scope.test.ts
+++ b/actions/crm/__tests__/get-targets-scope.test.ts
@@ -1,0 +1,51 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Targets: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTargets } from "@/actions/crm/get-targets";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTargets scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTargets();
+    expect(res).toEqual([]);
+    expect(prismadb.crm_Targets.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where = { created_by: u1 } (no deletedAt — hard delete model)", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Targets.findMany as jest.Mock).mockResolvedValue([]);
+    await getTargets();
+    const call = (prismadb.crm_Targets.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.created_by).toBe("u1");
+    expect(call.where.deletedAt).toBeUndefined();
+  });
+
+  it("manager: where = {} (no scope, no deletedAt)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Targets.findMany as jest.Mock).mockResolvedValue([]);
+    await getTargets();
+    const call = (prismadb.crm_Targets.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({});
+  });
+
+  it("returns rows from prisma", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Targets.findMany as jest.Mock).mockResolvedValue([{ id: "t1" }]);
+    const res = await getTargets();
+    expect(res).toEqual([{ id: "t1" }]);
+  });
+});

--- a/actions/crm/activities/__tests__/get-activities-by-entity-scope.test.ts
+++ b/actions/crm/activities/__tests__/get-activities-by-entity-scope.test.ts
@@ -1,0 +1,78 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_ActivityLinks: { findMany: jest.fn() },
+    crm_Activities: { findMany: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getActivitiesByEntity } from "../get-activities-by-entity";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fa = (prismadb as any).crm_Accounts.findFirst as jest.Mock;
+const linksFm = (prismadb as any).crm_ActivityLinks.findMany as jest.Mock;
+const actsFm = (prismadb as any).crm_Activities.findMany as jest.Mock;
+
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getActivitiesByEntity entity-scope", () => {
+  it("returns empty when unauthenticated and does not query activities", async () => {
+    gs.mockResolvedValue(null as any);
+    const r = await getActivitiesByEntity("account", ACCOUNT_ID);
+    expect(r).toEqual({ data: [], nextCursor: null });
+    expect(linksFm).not.toHaveBeenCalled();
+    expect(actsFm).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when user cannot read the entity", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue(null); // assertCanReadAccount throws
+    const r = await getActivitiesByEntity("account", ACCOUNT_ID);
+    expect(r).toEqual({ data: [], nextCursor: null });
+    expect(linksFm).not.toHaveBeenCalled();
+    expect(actsFm).not.toHaveBeenCalled();
+  });
+
+  it("returns activities when user can read the entity", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID });
+    linksFm.mockResolvedValue([{ activityId: "a1" }]);
+    const act = {
+      id: "a1",
+      type: "note",
+      title: "t",
+      description: null,
+      date: new Date("2026-01-01"),
+      duration: null,
+      outcome: null,
+      status: "completed",
+      metadata: null,
+      createdAt: new Date(),
+      createdBy: null,
+      created_by_user: null,
+      links: [],
+    };
+    actsFm.mockResolvedValue([act]);
+    const r = await getActivitiesByEntity("account", ACCOUNT_ID);
+    expect(r.data).toHaveLength(1);
+    expect(actsFm).toHaveBeenCalledTimes(1);
+  });
+
+  it("manager can read any entity activity feed", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID });
+    linksFm.mockResolvedValue([]);
+    const r = await getActivitiesByEntity("account", ACCOUNT_ID);
+    expect(r).toEqual({ data: [], nextCursor: null });
+  });
+});

--- a/actions/crm/activities/get-activities-by-entity.ts
+++ b/actions/crm/activities/get-activities-by-entity.ts
@@ -1,5 +1,11 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadActivityForEntity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const PAGE_SIZE = 25;
 
@@ -26,6 +32,19 @@ export const getActivitiesByEntity = async (
   entityId: string,
   cursor?: ActivityCursor
 ): Promise<{ data: ActivityWithLinks[]; nextCursor: ActivityCursor | null }> => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { data: [], nextCursor: null };
+    throw e;
+  }
+  try {
+    await assertCanReadActivityForEntity(user, entityType, entityId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { data: [], nextCursor: null };
+    throw e;
+  }
   try {
     // Use `as any` for both models — same pattern as crm_AuditLog throughout the codebase
     // (Prisma client cache may not include new models until IDE restarts)

--- a/actions/crm/audit-log/__tests__/get-audit-log-admin-scope.test.ts
+++ b/actions/crm/audit-log/__tests__/get-audit-log-admin-scope.test.ts
@@ -1,0 +1,45 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_AuditLog: { findMany: jest.fn(), count: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getAuditLogAdmin } from "../get-audit-log-admin";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const auditFm = (prismadb as any).crm_AuditLog.findMany as jest.Mock;
+const auditCount = (prismadb as any).crm_AuditLog.count as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getAuditLogAdmin role guard", () => {
+  it("returns Unauthorized when not authenticated", async () => {
+    gs.mockResolvedValue(null as any);
+    const r = await getAuditLogAdmin();
+    expect(r).toEqual({ error: "Unauthorized" });
+    expect(auditFm).not.toHaveBeenCalled();
+  });
+
+  it("returns Forbidden when user is not admin", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const r = await getAuditLogAdmin();
+    expect(r).toEqual({ error: "Forbidden" });
+    expect(auditFm).not.toHaveBeenCalled();
+  });
+
+  it("returns audit log data for admin", async () => {
+    gs.mockResolvedValue({ user: { id: "a" } } as any);
+    fu.mockResolvedValue({ id: "a", role: "admin" } as any);
+    auditFm.mockResolvedValue([{ id: "e1" }]);
+    auditCount.mockResolvedValue(1);
+    const r = await getAuditLogAdmin();
+    expect(r).toEqual({ data: [{ id: "e1" }], total: 1, page: 1, totalPages: 1 });
+    expect(auditFm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/crm/audit-log/__tests__/get-audit-log-by-entity-scope.test.ts
+++ b/actions/crm/audit-log/__tests__/get-audit-log-by-entity-scope.test.ts
@@ -1,0 +1,62 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_AuditLog: { findMany: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getAuditLogByEntity } from "../get-audit-log-by-entity";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fa = (prismadb as any).crm_Accounts.findFirst as jest.Mock;
+const auditFm = (prismadb as any).crm_AuditLog.findMany as jest.Mock;
+
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getAuditLogByEntity entity-scope", () => {
+  it("returns empty page when unauthenticated and does not query audit log", async () => {
+    gs.mockResolvedValue(null as any);
+    const r = await getAuditLogByEntity("account", ACCOUNT_ID);
+    expect(r).toEqual({ data: [], nextCursor: null });
+    expect(auditFm).not.toHaveBeenCalled();
+  });
+
+  it("returns empty page when user cannot read the entity", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue(null);
+    const r = await getAuditLogByEntity("account", ACCOUNT_ID);
+    expect(r).toEqual({ data: [], nextCursor: null });
+    expect(auditFm).not.toHaveBeenCalled();
+  });
+
+  it("returns audit entries when user can read the entity", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID });
+    auditFm.mockResolvedValue([
+      { id: "e1", entityType: "account", entityId: ACCOUNT_ID, user: null },
+    ]);
+    const r = await getAuditLogByEntity("account", ACCOUNT_ID);
+    expect(r.data).toHaveLength(1);
+    expect(r.nextCursor).toBeNull();
+    expect(auditFm).toHaveBeenCalledTimes(1);
+  });
+
+  it("manager can read any entity audit log", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID });
+    auditFm.mockResolvedValue([]);
+    const r = await getAuditLogByEntity("account", ACCOUNT_ID);
+    expect(r).toEqual({ data: [], nextCursor: null });
+    expect(auditFm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/crm/audit-log/get-audit-log-admin.ts
+++ b/actions/crm/audit-log/get-audit-log-admin.ts
@@ -1,6 +1,10 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 interface AuditLogAdminFilters {
   entityType?: string;
@@ -12,9 +16,13 @@ interface AuditLogAdminFilters {
 }
 
 export const getAuditLogAdmin = async (filters: AuditLogAdminFilters = {}) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-  if (session.user.role !== "admin") return { error: "Forbidden" };
+  try {
+    await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   const { entityType, action, userId, dateFrom, dateTo, page = 1 } = filters;
   const take = 50;

--- a/actions/crm/audit-log/get-audit-log-by-entity.ts
+++ b/actions/crm/audit-log/get-audit-log-by-entity.ts
@@ -1,11 +1,31 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadActivityForEntity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getAuditLogByEntity = async (
   entityType: string,
   entityId: string,
   cursor?: string
 ) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { data: [], nextCursor: null };
+    throw e;
+  }
+  try {
+    await assertCanReadActivityForEntity(user, entityType, entityId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { data: [], nextCursor: null };
+    throw e;
+  }
+
   const take = 25;
 
   const entries = await (prismadb as any).crm_AuditLog.findMany({

--- a/actions/crm/get-target-list.ts
+++ b/actions/crm/get-target-list.ts
@@ -1,7 +1,28 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadTargetList,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getTargetList = async (id: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
+
+  try {
+    await assertCanReadTargetList(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+
   const targetList = await prismadb.crm_TargetLists.findUnique({
     where: { id },
     include: {

--- a/actions/crm/get-target-lists.ts
+++ b/actions/crm/get-target-lists.ts
@@ -1,9 +1,22 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  targetListReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getTargetLists = async () => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
   const targetLists = await prismadb.crm_TargetLists.findMany({
-    where: { deletedAt: null },
+    where: { ...targetListReadScopeWhere(user) },
     orderBy: { created_on: "desc" },
     include: {
       crate_by_user: { select: { name: true } },

--- a/actions/crm/get-target.ts
+++ b/actions/crm/get-target.ts
@@ -1,11 +1,32 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadTarget,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export const getTarget = async (targetId: string) => {
   if (!UUID_REGEX.test(targetId)) return null;
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
+
+  try {
+    await assertCanReadTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
 
   const target = await prismadb.crm_Targets.findUnique({
     where: { id: targetId },

--- a/actions/crm/get-targets.ts
+++ b/actions/crm/get-targets.ts
@@ -1,9 +1,22 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  targetReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getTargets = async () => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
   const targets = await prismadb.crm_Targets.findMany({
-    where: { deletedAt: null },
+    where: { ...targetReadScopeWhere(user) },
     orderBy: { created_on: "desc" },
     include: {
       crate_by_user: { select: { name: true } },

--- a/actions/crm/similarity/__tests__/get-similar-accounts-scope.test.ts
+++ b/actions/crm/similarity/__tests__/get-similar-accounts-scope.test.ts
@@ -1,0 +1,87 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn(), findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getSimilarAccounts } from "../get-similar-accounts";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getSimilarAccounts scope", () => {
+  it("unauthenticated → empty records, no SQL", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarAccounts("a1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("user can't read base record → empty records, no SQL", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarAccounts("a1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("in-scope user: returns only authorized similar candidates", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }]) // source embedding
+      .mockResolvedValueOnce([
+        { id: "x1", name: "X1", email: null, similarity: 0.9 },
+        { id: "x2", name: "X2", email: null, similarity: 0.8 },
+        { id: "x3", name: "X3", email: null, similarity: 0.7 },
+        { id: "x4", name: "X4", email: null, similarity: 0.6 },
+        { id: "x5", name: "X5", email: null, similarity: 0.5 },
+      ]);
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([
+      { id: "x2" },
+      { id: "x4" },
+    ]);
+
+    const res = await getSimilarAccounts("a1", 5);
+    expect(res.status).toBe("ok");
+    if (res.status !== "ok") return;
+    expect(res.records.map((r) => r.id)).toEqual(["x2", "x4"]);
+  });
+
+  it("manager: filter returns all candidates (unfiltered)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }])
+      .mockResolvedValueOnce([
+        { id: "x1", name: "X1", email: null, similarity: 0.9 },
+        { id: "x2", name: "X2", email: null, similarity: 0.8 },
+      ]);
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([
+      { id: "x1" },
+      { id: "x2" },
+    ]);
+
+    const res = await getSimilarAccounts("a1", 5);
+    expect(res.status).toBe("ok");
+    if (res.status !== "ok") return;
+    expect(res.records.map((r) => r.id)).toEqual(["x1", "x2"]);
+  });
+
+  it("returns no_embedding when source has no embedding", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.$queryRaw as jest.Mock).mockResolvedValueOnce([]);
+    const res = await getSimilarAccounts("a1");
+    expect(res).toEqual({ status: "no_embedding" });
+  });
+});

--- a/actions/crm/similarity/__tests__/get-similar-contacts-scope.test.ts
+++ b/actions/crm/similarity/__tests__/get-similar-contacts-scope.test.ts
@@ -1,0 +1,73 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Contacts: { findFirst: jest.fn(), findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getSimilarContacts } from "../get-similar-contacts";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getSimilarContacts scope", () => {
+  it("unauthenticated → empty records, no SQL", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarContacts("c1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("user can't read base contact → empty records, no SQL", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Contacts.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarContacts("c1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("in-scope user: returns only authorized similar candidates", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Contacts.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }])
+      .mockResolvedValueOnce([
+        { id: "y1", first_name: "A", last_name: "B", position: null, similarity: 0.9 },
+        { id: "y2", first_name: "C", last_name: "D", position: null, similarity: 0.8 },
+        { id: "y3", first_name: "E", last_name: "F", position: null, similarity: 0.7 },
+        { id: "y4", first_name: "G", last_name: "H", position: null, similarity: 0.6 },
+        { id: "y5", first_name: "I", last_name: "J", position: null, similarity: 0.5 },
+      ]);
+    (prismadb.crm_Contacts.findMany as jest.Mock).mockResolvedValue([
+      { id: "y1" },
+      { id: "y3" },
+    ]);
+
+    const res = await getSimilarContacts("c1", 5);
+    if (res.status !== "ok") throw new Error("expected ok");
+    expect(res.records.map((r) => r.id)).toEqual(["y1", "y3"]);
+  });
+
+  it("manager: returns unfiltered candidates", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Contacts.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }])
+      .mockResolvedValueOnce([
+        { id: "y1", first_name: "A", last_name: "B", position: null, similarity: 0.9 },
+      ]);
+    (prismadb.crm_Contacts.findMany as jest.Mock).mockResolvedValue([{ id: "y1" }]);
+
+    const res = await getSimilarContacts("c1");
+    if (res.status !== "ok") throw new Error("expected ok");
+    expect(res.records.map((r) => r.id)).toEqual(["y1"]);
+  });
+});

--- a/actions/crm/similarity/__tests__/get-similar-leads-scope.test.ts
+++ b/actions/crm/similarity/__tests__/get-similar-leads-scope.test.ts
@@ -1,0 +1,77 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Leads: { findFirst: jest.fn(), findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getSimilarLeads } from "../get-similar-leads";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getSimilarLeads scope", () => {
+  it("unauthenticated → empty records, no SQL", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarLeads("l1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("user can't read base lead → empty records, no SQL", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Leads.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarLeads("l1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("in-scope user: returns only authorized similar candidates", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Leads.findFirst as jest.Mock).mockResolvedValue({ id: "l1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }])
+      .mockResolvedValueOnce([
+        { id: "z1", firstName: "A", lastName: "B", status: null, similarity: 0.9 },
+        { id: "z2", firstName: "C", lastName: "D", status: null, similarity: 0.8 },
+        { id: "z3", firstName: "E", lastName: "F", status: null, similarity: 0.7 },
+        { id: "z4", firstName: "G", lastName: "H", status: null, similarity: 0.6 },
+        { id: "z5", firstName: "I", lastName: "J", status: null, similarity: 0.5 },
+      ]);
+    (prismadb.crm_Leads.findMany as jest.Mock).mockResolvedValue([
+      { id: "z2" },
+      { id: "z5" },
+    ]);
+
+    const res = await getSimilarLeads("l1", 5);
+    if (res.status !== "ok") throw new Error("expected ok");
+    expect(res.records.map((r) => r.id)).toEqual(["z2", "z5"]);
+  });
+
+  it("manager: returns unfiltered candidates", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Leads.findFirst as jest.Mock).mockResolvedValue({ id: "l1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }])
+      .mockResolvedValueOnce([
+        { id: "z1", firstName: "A", lastName: "B", status: null, similarity: 0.9 },
+        { id: "z2", firstName: "C", lastName: "D", status: null, similarity: 0.8 },
+      ]);
+    (prismadb.crm_Leads.findMany as jest.Mock).mockResolvedValue([
+      { id: "z1" },
+      { id: "z2" },
+    ]);
+
+    const res = await getSimilarLeads("l1");
+    if (res.status !== "ok") throw new Error("expected ok");
+    expect(res.records.map((r) => r.id)).toEqual(["z1", "z2"]);
+  });
+});

--- a/actions/crm/similarity/__tests__/get-similar-opportunities-scope.test.ts
+++ b/actions/crm/similarity/__tests__/get-similar-opportunities-scope.test.ts
@@ -1,0 +1,73 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Opportunities: { findFirst: jest.fn(), findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getSimilarOpportunities } from "../get-similar-opportunities";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getSimilarOpportunities scope", () => {
+  it("unauthenticated → empty records, no SQL", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarOpportunities("o1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("user can't read base opportunity → empty records, no SQL", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getSimilarOpportunities("o1");
+    expect(res).toEqual({ status: "ok", records: [] });
+    expect(prismadb.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("in-scope user: returns only authorized similar candidates", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({ id: "o1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }])
+      .mockResolvedValueOnce([
+        { id: "p1", name: "P1", stage_name: null, similarity: 0.9 },
+        { id: "p2", name: "P2", stage_name: null, similarity: 0.8 },
+        { id: "p3", name: "P3", stage_name: null, similarity: 0.7 },
+        { id: "p4", name: "P4", stage_name: null, similarity: 0.6 },
+        { id: "p5", name: "P5", stage_name: null, similarity: 0.5 },
+      ]);
+    (prismadb.crm_Opportunities.findMany as jest.Mock).mockResolvedValue([
+      { id: "p3" },
+      { id: "p4" },
+    ]);
+
+    const res = await getSimilarOpportunities("o1", 5);
+    if (res.status !== "ok") throw new Error("expected ok");
+    expect(res.records.map((r) => r.id)).toEqual(["p3", "p4"]);
+  });
+
+  it("manager: returns unfiltered candidates", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({ id: "o1" });
+    (prismadb.$queryRaw as jest.Mock)
+      .mockResolvedValueOnce([{ embedding: "[0.1]" }])
+      .mockResolvedValueOnce([
+        { id: "p1", name: "P1", stage_name: null, similarity: 0.9 },
+      ]);
+    (prismadb.crm_Opportunities.findMany as jest.Mock).mockResolvedValue([{ id: "p1" }]);
+
+    const res = await getSimilarOpportunities("o1");
+    if (res.status !== "ok") throw new Error("expected ok");
+    expect(res.records.map((r) => r.id)).toEqual(["p1"]);
+  });
+});

--- a/actions/crm/similarity/get-similar-accounts.ts
+++ b/actions/crm/similarity/get-similar-accounts.ts
@@ -1,5 +1,12 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadAccount,
+  filterAuthorizedAccountIds,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export type SimilarRecord = {
   id: string;
@@ -18,6 +25,22 @@ export async function getSimilarAccounts(
   recordId: string,
   limit = 5
 ): Promise<SimilarityResult> {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+  try {
+    await assertCanReadAccount(user, recordId);
+  } catch (e) {
+    if (e instanceof AuthorizationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+
   try {
     const rows = await prismadb.$queryRaw<{ embedding: string }[]>`
       SELECT embedding::text FROM "crm_Embeddings_Accounts"
@@ -26,6 +49,7 @@ export async function getSimilarAccounts(
     if (rows.length === 0) return { status: "no_embedding" };
     const sourceEmbedding = rows[0].embedding;
 
+    const overFetch = limit * 3;
     const similar = await prismadb.$queryRaw<
       { id: string; name: string; email: string | null; similarity: number }[]
     >`
@@ -35,18 +59,25 @@ export async function getSimilarAccounts(
       JOIN   "crm_Embeddings_Accounts" e ON e.account_id = a.id
       WHERE  a.id != ${recordId}::uuid
       ORDER  BY e.embedding <=> ${sourceEmbedding}::vector
-      LIMIT  ${limit}
+      LIMIT  ${overFetch}
     `;
+
+    const allowed = new Set(
+      await filterAuthorizedAccountIds(user, similar.map((r) => r.id)),
+    );
 
     return {
       status: "ok",
-      records: similar.map((r) => ({
-        id: r.id,
-        name: r.name,
-        subtitle: r.email ?? "",
-        similarity: Number(r.similarity),
-        href: `/crm/accounts/${r.id}`,
-      })),
+      records: similar
+        .filter((r) => allowed.has(r.id))
+        .slice(0, limit)
+        .map((r) => ({
+          id: r.id,
+          name: r.name,
+          subtitle: r.email ?? "",
+          similarity: Number(r.similarity),
+          href: `/crm/accounts/${r.id}`,
+        })),
     };
   } catch (error) {
     console.error("[GET_SIMILAR_ACCOUNTS]", error);

--- a/actions/crm/similarity/get-similar-contacts.ts
+++ b/actions/crm/similarity/get-similar-contacts.ts
@@ -1,11 +1,34 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadContact,
+  filterAuthorizedContactIds,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import type { SimilarityResult } from "./get-similar-accounts";
 
 export async function getSimilarContacts(
   recordId: string,
   limit = 5
 ): Promise<SimilarityResult> {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+  try {
+    await assertCanReadContact(user, recordId);
+  } catch (e) {
+    if (e instanceof AuthorizationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+
   try {
     const rows = await prismadb.$queryRaw<{ embedding: string }[]>`
       SELECT embedding::text FROM "crm_Embeddings_Contacts"
@@ -14,6 +37,7 @@ export async function getSimilarContacts(
     if (rows.length === 0) return { status: "no_embedding" };
     const sourceEmbedding = rows[0].embedding;
 
+    const overFetch = limit * 3;
     const similar = await prismadb.$queryRaw<
       { id: string; first_name: string | null; last_name: string; position: string | null; similarity: number }[]
     >`
@@ -23,18 +47,25 @@ export async function getSimilarContacts(
       JOIN   "crm_Embeddings_Contacts" e ON e.contact_id = c.id
       WHERE  c.id != ${recordId}::uuid
       ORDER  BY e.embedding <=> ${sourceEmbedding}::vector
-      LIMIT  ${limit}
+      LIMIT  ${overFetch}
     `;
+
+    const allowed = new Set(
+      await filterAuthorizedContactIds(user, similar.map((r) => r.id)),
+    );
 
     return {
       status: "ok",
-      records: similar.map((r) => ({
-        id: r.id,
-        name: `${r.first_name ?? ""} ${r.last_name}`.trim(),
-        subtitle: r.position ?? "",
-        similarity: Number(r.similarity),
-        href: `/crm/contacts/${r.id}`,
-      })),
+      records: similar
+        .filter((r) => allowed.has(r.id))
+        .slice(0, limit)
+        .map((r) => ({
+          id: r.id,
+          name: `${r.first_name ?? ""} ${r.last_name}`.trim(),
+          subtitle: r.position ?? "",
+          similarity: Number(r.similarity),
+          href: `/crm/contacts/${r.id}`,
+        })),
     };
   } catch (error) {
     console.error("[GET_SIMILAR_CONTACTS]", error);

--- a/actions/crm/similarity/get-similar-leads.ts
+++ b/actions/crm/similarity/get-similar-leads.ts
@@ -1,11 +1,34 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadLead,
+  filterAuthorizedLeadIds,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import type { SimilarityResult } from "./get-similar-accounts";
 
 export async function getSimilarLeads(
   recordId: string,
   limit = 5
 ): Promise<SimilarityResult> {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+  try {
+    await assertCanReadLead(user, recordId);
+  } catch (e) {
+    if (e instanceof AuthorizationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+
   try {
     const rows = await prismadb.$queryRaw<{ embedding: string }[]>`
       SELECT embedding::text FROM "crm_Embeddings_Leads"
@@ -14,6 +37,7 @@ export async function getSimilarLeads(
     if (rows.length === 0) return { status: "no_embedding" };
     const sourceEmbedding = rows[0].embedding;
 
+    const overFetch = limit * 3;
     const similar = await prismadb.$queryRaw<
       { id: string; firstName: string | null; lastName: string; status: string | null; similarity: number }[]
     >`
@@ -23,18 +47,25 @@ export async function getSimilarLeads(
       JOIN   "crm_Embeddings_Leads" e ON e.lead_id = l.id
       WHERE  l.id != ${recordId}::uuid
       ORDER  BY e.embedding <=> ${sourceEmbedding}::vector
-      LIMIT  ${limit}
+      LIMIT  ${overFetch}
     `;
+
+    const allowed = new Set(
+      await filterAuthorizedLeadIds(user, similar.map((r) => r.id)),
+    );
 
     return {
       status: "ok",
-      records: similar.map((r) => ({
-        id: r.id,
-        name: `${r.firstName ?? ""} ${r.lastName}`.trim(),
-        subtitle: r.status ?? "",
-        similarity: Number(r.similarity),
-        href: `/crm/leads/${r.id}`,
-      })),
+      records: similar
+        .filter((r) => allowed.has(r.id))
+        .slice(0, limit)
+        .map((r) => ({
+          id: r.id,
+          name: `${r.firstName ?? ""} ${r.lastName}`.trim(),
+          subtitle: r.status ?? "",
+          similarity: Number(r.similarity),
+          href: `/crm/leads/${r.id}`,
+        })),
     };
   } catch (error) {
     console.error("[GET_SIMILAR_LEADS]", error);

--- a/actions/crm/similarity/get-similar-opportunities.ts
+++ b/actions/crm/similarity/get-similar-opportunities.ts
@@ -1,11 +1,34 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadOpportunity,
+  filterAuthorizedOpportunityIds,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import type { SimilarityResult } from "./get-similar-accounts";
 
 export async function getSimilarOpportunities(
   recordId: string,
   limit = 5
 ): Promise<SimilarityResult> {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+  try {
+    await assertCanReadOpportunity(user, recordId);
+  } catch (e) {
+    if (e instanceof AuthorizationError)
+      return { status: "ok", records: [] };
+    throw e;
+  }
+
   try {
     const rows = await prismadb.$queryRaw<{ embedding: string }[]>`
       SELECT embedding::text FROM "crm_Embeddings_Opportunities"
@@ -14,6 +37,7 @@ export async function getSimilarOpportunities(
     if (rows.length === 0) return { status: "no_embedding" };
     const sourceEmbedding = rows[0].embedding;
 
+    const overFetch = limit * 3;
     const similar = await prismadb.$queryRaw<
       { id: string; name: string; stage_name: string | null; similarity: number }[]
     >`
@@ -24,18 +48,25 @@ export async function getSimilarOpportunities(
       LEFT JOIN "crm_Opportunities_Sales_Stages" s ON s.id = o.sales_stage
       WHERE  o.id != ${recordId}::uuid
       ORDER  BY e.embedding <=> ${sourceEmbedding}::vector
-      LIMIT  ${limit}
+      LIMIT  ${overFetch}
     `;
+
+    const allowed = new Set(
+      await filterAuthorizedOpportunityIds(user, similar.map((r) => r.id)),
+    );
 
     return {
       status: "ok",
-      records: similar.map((r) => ({
-        id: r.id,
-        name: r.name ?? "",
-        subtitle: r.stage_name ?? "",
-        similarity: Number(r.similarity),
-        href: `/crm/opportunities/${r.id}`,
-      })),
+      records: similar
+        .filter((r) => allowed.has(r.id))
+        .slice(0, limit)
+        .map((r) => ({
+          id: r.id,
+          name: r.name ?? "",
+          subtitle: r.stage_name ?? "",
+          similarity: Number(r.similarity),
+          href: `/crm/opportunities/${r.id}`,
+        })),
     };
   } catch (error) {
     console.error("[GET_SIMILAR_OPPORTUNITIES]", error);

--- a/lib/authz/__tests__/scopes-crm-activity-dispatch.test.ts
+++ b/lib/authz/__tests__/scopes-crm-activity-dispatch.test.ts
@@ -1,0 +1,103 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_Leads: { findFirst: jest.fn() },
+    crm_Contacts: { findFirst: jest.fn() },
+    crm_Opportunities: { findFirst: jest.fn() },
+    crm_Contracts: { findFirst: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+    crm_TargetLists: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { AuthorizationError } from "../errors";
+import { assertCanReadActivityForEntity } from "../scopes/crm";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+type ModelKey =
+  | "crm_Accounts"
+  | "crm_Leads"
+  | "crm_Contacts"
+  | "crm_Opportunities"
+  | "crm_Contracts"
+  | "crm_Targets"
+  | "crm_TargetLists";
+
+const cases: Array<[string, ModelKey]> = [
+  ["account", "crm_Accounts"],
+  ["lead", "crm_Leads"],
+  ["contact", "crm_Contacts"],
+  ["opportunity", "crm_Opportunities"],
+  ["contract", "crm_Contracts"],
+  ["target", "crm_Targets"],
+  ["target_list", "crm_TargetLists"],
+  ["targetlist", "crm_TargetLists"],
+];
+
+describe("assertCanReadActivityForEntity", () => {
+  it.each(cases)(
+    "dispatches %s to %s.findFirst",
+    async (entityType, model) => {
+      (prismadb[model].findFirst as jest.Mock).mockResolvedValue({ id: "x" });
+      await assertCanReadActivityForEntity(
+        { id: "u", role: "admin" },
+        entityType,
+        "x",
+      );
+      expect(prismadb[model].findFirst as jest.Mock).toHaveBeenCalled();
+    },
+  );
+
+  it("dispatches case-insensitively (Account → account branch)", async () => {
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({
+      id: "x",
+    });
+    await assertCanReadActivityForEntity(
+      { id: "u", role: "admin" },
+      "Account",
+      "x",
+    );
+    expect(prismadb.crm_Accounts.findFirst as jest.Mock).toHaveBeenCalled();
+  });
+
+  it("propagates AuthorizationError when underlying assert rejects", async () => {
+    (prismadb.crm_Leads.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      assertCanReadActivityForEntity({ id: "u", role: "user" }, "lead", "x"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("unknown entity type: user → AuthorizationError", async () => {
+    await expect(
+      assertCanReadActivityForEntity(
+        { id: "u", role: "user" },
+        "weird_type",
+        "x",
+      ),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("unknown entity type: manager → resolves silently", async () => {
+    await expect(
+      assertCanReadActivityForEntity(
+        { id: "u", role: "manager" },
+        "weird_type",
+        "x",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("unknown entity type: admin → resolves silently", async () => {
+    await expect(
+      assertCanReadActivityForEntity(
+        { id: "u", role: "admin" },
+        "weird_type",
+        "x",
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/lib/authz/__tests__/scopes-crm-filter-ids.test.ts
+++ b/lib/authz/__tests__/scopes-crm-filter-ids.test.ts
@@ -1,0 +1,163 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Accounts: { findMany: jest.fn() },
+    crm_Leads: { findMany: jest.fn() },
+    crm_Opportunities: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  filterAuthorizedAccountIds,
+  filterAuthorizedLeadIds,
+  filterAuthorizedOpportunityIds,
+} from "../scopes/crm";
+
+const accountsFindMany = prismadb.crm_Accounts.findMany as jest.Mock;
+const leadsFindMany = prismadb.crm_Leads.findMany as jest.Mock;
+const oppFindMany = prismadb.crm_Opportunities.findMany as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("filterAuthorizedAccountIds", () => {
+  it("empty input → empty, no DB call", async () => {
+    const out = await filterAuthorizedAccountIds(
+      { id: "u", role: "user" },
+      [],
+    );
+    expect(out).toEqual([]);
+    expect(accountsFindMany).not.toHaveBeenCalled();
+  });
+
+  it("admin: { id: { in }, deletedAt: null }", async () => {
+    accountsFindMany.mockResolvedValue([{ id: "a1" }, { id: "a2" }]);
+    const out = await filterAuthorizedAccountIds(
+      { id: "u", role: "admin" },
+      ["a1", "a2", "a3"],
+    );
+    expect(out).toEqual(["a1", "a2"]);
+    expect(accountsFindMany).toHaveBeenCalledWith({
+      where: { id: { in: ["a1", "a2", "a3"] }, deletedAt: null },
+      select: { id: true },
+    });
+  });
+
+  it("user: composes accountReadScopeWhere (deletedAt + ownership OR)", async () => {
+    accountsFindMany.mockResolvedValue([{ id: "a1" }]);
+    await filterAuthorizedAccountIds(
+      { id: "u3", role: "user" },
+      ["a1", "a2"],
+    );
+    const arg = accountsFindMany.mock.calls[0][0];
+    expect(arg.where).toMatchObject({
+      id: { in: ["a1", "a2"] },
+      deletedAt: null,
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { createdBy: "u3" },
+        { watchers: { some: { user_id: "u3" } } },
+      ]),
+    });
+  });
+});
+
+describe("filterAuthorizedLeadIds", () => {
+  it("empty input → empty, no DB call", async () => {
+    const out = await filterAuthorizedLeadIds(
+      { id: "u", role: "user" },
+      [],
+    );
+    expect(out).toEqual([]);
+    expect(leadsFindMany).not.toHaveBeenCalled();
+  });
+
+  it("admin: { id: { in }, deletedAt: null }", async () => {
+    leadsFindMany.mockResolvedValue([{ id: "l1" }]);
+    const out = await filterAuthorizedLeadIds(
+      { id: "u", role: "admin" },
+      ["l1", "l2"],
+    );
+    expect(out).toEqual(["l1"]);
+    expect(leadsFindMany).toHaveBeenCalledWith({
+      where: { id: { in: ["l1", "l2"] }, deletedAt: null },
+      select: { id: true },
+    });
+  });
+
+  it("user: composes leadReadScopeWhere with linked-account branch", async () => {
+    leadsFindMany.mockResolvedValue([{ id: "l1" }]);
+    await filterAuthorizedLeadIds(
+      { id: "u3", role: "user" },
+      ["l1", "l2"],
+    );
+    const arg = leadsFindMany.mock.calls[0][0];
+    expect(arg.where).toMatchObject({
+      id: { in: ["l1", "l2"] },
+      deletedAt: null,
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { createdBy: "u3" },
+        {
+          assigned_accounts: {
+            OR: expect.arrayContaining([
+              { assigned_to: "u3" },
+              { createdBy: "u3" },
+              { watchers: { some: { user_id: "u3" } } },
+            ]),
+          },
+        },
+      ]),
+    });
+  });
+});
+
+describe("filterAuthorizedOpportunityIds", () => {
+  it("empty input → empty, no DB call", async () => {
+    const out = await filterAuthorizedOpportunityIds(
+      { id: "u", role: "user" },
+      [],
+    );
+    expect(out).toEqual([]);
+    expect(oppFindMany).not.toHaveBeenCalled();
+  });
+
+  it("manager: { id: { in }, deletedAt: null }", async () => {
+    oppFindMany.mockResolvedValue([{ id: "o1" }]);
+    const out = await filterAuthorizedOpportunityIds(
+      { id: "u", role: "manager" },
+      ["o1", "o2"],
+    );
+    expect(out).toEqual(["o1"]);
+    expect(oppFindMany).toHaveBeenCalledWith({
+      where: { id: { in: ["o1", "o2"] }, deletedAt: null },
+      select: { id: true },
+    });
+  });
+
+  it("user: composes opportunityReadScopeWhere with linked-account branch", async () => {
+    oppFindMany.mockResolvedValue([{ id: "o1" }]);
+    await filterAuthorizedOpportunityIds(
+      { id: "u3", role: "user" },
+      ["o1", "o2"],
+    );
+    const arg = oppFindMany.mock.calls[0][0];
+    expect(arg.where).toMatchObject({
+      id: { in: ["o1", "o2"] },
+      deletedAt: null,
+      OR: expect.arrayContaining([
+        { assigned_to: "u3" },
+        { created_by: "u3" },
+        { createdBy: "u3" },
+        {
+          assigned_account: {
+            OR: expect.arrayContaining([
+              { assigned_to: "u3" },
+              { createdBy: "u3" },
+              { watchers: { some: { user_id: "u3" } } },
+            ]),
+          },
+        },
+      ]),
+    });
+  });
+});

--- a/lib/authz/__tests__/scopes-crm-read.test.ts
+++ b/lib/authz/__tests__/scopes-crm-read.test.ts
@@ -157,7 +157,7 @@ describe("assertCanWriteTarget", () => {
 });
 
 describe("filterAuthorizedContactIds", () => {
-  it("admin: returns all input ids that exist (queries with bare where)", async () => {
+  it("admin: returns all input ids that exist (queries with deletedAt:null)", async () => {
     (prismadb.crm_Contacts.findMany as jest.Mock) =
       jest.fn().mockResolvedValue([{ id: "a" }, { id: "b" }]);
     const out = await filterAuthorizedContactIds(
@@ -166,12 +166,12 @@ describe("filterAuthorizedContactIds", () => {
     );
     expect(out).toEqual(["a", "b"]);
     expect(prismadb.crm_Contacts.findMany).toHaveBeenCalledWith({
-      where: { id: { in: ["a", "b", "c"] } },
+      where: { id: { in: ["a", "b", "c"] }, deletedAt: null },
       select: { id: true },
     });
   });
 
-  it("user: scoped where with OR clauses", async () => {
+  it("user: scoped where with OR clauses (D2 upgrade includes linked-account)", async () => {
     (prismadb.crm_Contacts.findMany as jest.Mock) =
       jest.fn().mockResolvedValue([{ id: "a" }]);
     await filterAuthorizedContactIds(
@@ -181,10 +181,20 @@ describe("filterAuthorizedContactIds", () => {
     const arg = (prismadb.crm_Contacts.findMany as jest.Mock).mock.calls[0][0];
     expect(arg.where).toMatchObject({
       id: { in: ["a", "b"] },
+      deletedAt: null,
       OR: expect.arrayContaining([
         { assigned_to: "u3" },
         { created_by: "u3" },
         { createdBy: "u3" },
+        {
+          assigned_accounts: {
+            OR: expect.arrayContaining([
+              { assigned_to: "u3" },
+              { createdBy: "u3" },
+              { watchers: { some: { user_id: "u3" } } },
+            ]),
+          },
+        },
       ]),
     });
   });

--- a/lib/authz/__tests__/scopes-crm-target-read.test.ts
+++ b/lib/authz/__tests__/scopes-crm-target-read.test.ts
@@ -20,12 +20,13 @@ const findList = prismadb.crm_TargetLists.findFirst as jest.MockedFunction<
 beforeEach(() => jest.clearAllMocks());
 
 describe("targetReadScopeWhere", () => {
-  it("admin/manager → {} (no deletedAt; crm_Targets is hard-delete)", () => {
-    expect(targetReadScopeWhere({ id: "x", role: "admin" })).toEqual({});
-    expect(targetReadScopeWhere({ id: "x", role: "manager" })).toEqual({});
+  it("admin/manager → { deletedAt: null }", () => {
+    expect(targetReadScopeWhere({ id: "x", role: "admin" })).toEqual({ deletedAt: null });
+    expect(targetReadScopeWhere({ id: "x", role: "manager" })).toEqual({ deletedAt: null });
   });
-  it("user → { created_by: user.id }", () => {
+  it("user → { deletedAt: null, created_by: user.id }", () => {
     expect(targetReadScopeWhere({ id: "u1", role: "user" })).toEqual({
+      deletedAt: null,
       created_by: "u1",
     });
   });

--- a/lib/authz/__tests__/scopes-crm-target-read.test.ts
+++ b/lib/authz/__tests__/scopes-crm-target-read.test.ts
@@ -1,0 +1,74 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_TargetLists: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  targetReadScopeWhere,
+  targetListReadScopeWhere,
+  assertCanReadTargetList,
+} from "../scopes/crm";
+
+const findList = prismadb.crm_TargetLists.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_TargetLists.findFirst
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("targetReadScopeWhere", () => {
+  it("admin/manager → {} (no deletedAt; crm_Targets is hard-delete)", () => {
+    expect(targetReadScopeWhere({ id: "x", role: "admin" })).toEqual({});
+    expect(targetReadScopeWhere({ id: "x", role: "manager" })).toEqual({});
+  });
+  it("user → { created_by: user.id }", () => {
+    expect(targetReadScopeWhere({ id: "u1", role: "user" })).toEqual({
+      created_by: "u1",
+    });
+  });
+});
+
+describe("targetListReadScopeWhere", () => {
+  it("admin/manager → { deletedAt: null }", () => {
+    expect(targetListReadScopeWhere({ id: "x", role: "admin" })).toEqual({
+      deletedAt: null,
+    });
+    expect(targetListReadScopeWhere({ id: "x", role: "manager" })).toEqual({
+      deletedAt: null,
+    });
+  });
+  it("user → { deletedAt: null, created_by: user.id }", () => {
+    expect(targetListReadScopeWhere({ id: "u1", role: "user" })).toEqual({
+      deletedAt: null,
+      created_by: "u1",
+    });
+  });
+});
+
+describe("assertCanReadTargetList", () => {
+  it("admin: where { id, deletedAt:null }", async () => {
+    findList.mockResolvedValue({ id: "tl1" } as any);
+    await assertCanReadTargetList({ id: "x", role: "admin" }, "tl1");
+    expect(findList).toHaveBeenCalledWith({
+      where: { id: "tl1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+  it("user: where merges created_by scope (200 hit)", async () => {
+    findList.mockResolvedValue({ id: "tl1" } as any);
+    await assertCanReadTargetList({ id: "u1", role: "user" }, "tl1");
+    expect(findList).toHaveBeenCalledWith({
+      where: { id: "tl1", deletedAt: null, created_by: "u1" },
+      select: { id: true },
+    });
+  });
+  it("throws AuthorizationError on miss (404)", async () => {
+    findList.mockResolvedValue(null);
+    await expect(
+      assertCanReadTargetList({ id: "u1", role: "user" }, "tl1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -46,5 +46,10 @@ export {
   assertCanReadOpportunity,
   assertCanReadContract,
 } from "./scopes/crm";
+export {
+  targetReadScopeWhere,
+  targetListReadScopeWhere,
+  assertCanReadTargetList,
+} from "./scopes/crm";
 export type { ReportScope } from "./scopes/report-scope";
 export { getReportScope } from "./scopes/report-scope";

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -26,6 +26,9 @@ export {
 export {
   filterAuthorizedContactIds,
   filterAuthorizedTargetIds,
+  filterAuthorizedAccountIds,
+  filterAuthorizedLeadIds,
+  filterAuthorizedOpportunityIds,
 } from "./scopes/crm";
 export {
   assertCanCancelContactEnrichment,

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -51,5 +51,6 @@ export {
   targetListReadScopeWhere,
   assertCanReadTargetList,
 } from "./scopes/crm";
+export { assertCanReadActivityForEntity } from "./scopes/crm";
 export type { ReportScope } from "./scopes/report-scope";
 export { getReportScope } from "./scopes/report-scope";

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -347,13 +347,13 @@ export async function assertCanReadContract(
 
 // ---------------------------------------------------------------------------
 // D3.T1: Target + Target-list read-scope helpers.
-// crm_Targets has NO deletedAt (hard delete); crm_TargetLists HAS deletedAt.
+// Both crm_Targets and crm_TargetLists support soft-delete (deletedAt).
 // assertCanReadTarget (B1) is reused as-is for the per-row target check.
 // ---------------------------------------------------------------------------
 
 export function targetReadScopeWhere(user: AuthzUser) {
-  if (user.role === "admin" || user.role === "manager") return {};
-  return { created_by: user.id };
+  if (user.role === "admin" || user.role === "manager") return { deletedAt: null };
+  return { deletedAt: null, created_by: user.id };
 }
 
 export function targetListReadScopeWhere(user: AuthzUser) {

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -344,3 +344,30 @@ export async function assertCanReadContract(
   });
   if (!row) throw new AuthorizationError();
 }
+
+// ---------------------------------------------------------------------------
+// D3.T1: Target + Target-list read-scope helpers.
+// crm_Targets has NO deletedAt (hard delete); crm_TargetLists HAS deletedAt.
+// assertCanReadTarget (B1) is reused as-is for the per-row target check.
+// ---------------------------------------------------------------------------
+
+export function targetReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") return {};
+  return { created_by: user.id };
+}
+
+export function targetListReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") return { deletedAt: null };
+  return { deletedAt: null, created_by: user.id };
+}
+
+export async function assertCanReadTargetList(
+  user: AuthzUser,
+  listId: string,
+): Promise<void> {
+  const row = await prismadb.crm_TargetLists.findFirst({
+    where: { id: listId, ...targetListReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -371,3 +371,36 @@ export async function assertCanReadTargetList(
   });
   if (!row) throw new AuthorizationError();
 }
+
+// ---------------------------------------------------------------------------
+// D3.T3: Activity / audit dispatch helper.
+// Resolves an entityType string to the matching assertCanRead* helper.
+// Used by activity-feed (T4) and audit-log-by-entity (T5).
+// Unknown entity types: managers/admins pass; users are denied.
+// ---------------------------------------------------------------------------
+export async function assertCanReadActivityForEntity(
+  user: AuthzUser,
+  entityType: string,
+  entityId: string,
+): Promise<void> {
+  switch (entityType.toLowerCase()) {
+    case "account":
+      return assertCanReadAccount(user, entityId);
+    case "lead":
+      return assertCanReadLead(user, entityId);
+    case "contact":
+      return assertCanReadContact(user, entityId);
+    case "opportunity":
+      return assertCanReadOpportunity(user, entityId);
+    case "contract":
+      return assertCanReadContract(user, entityId);
+    case "target":
+      return assertCanReadTarget(user, entityId);
+    case "target_list":
+    case "targetlist":
+      return assertCanReadTargetList(user, entityId);
+    default:
+      if (user.role === "user") throw new AuthorizationError();
+      return;
+  }
+}

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -131,19 +131,44 @@ export async function filterAuthorizedContactIds(
   contactIds: string[],
 ): Promise<string[]> {
   if (contactIds.length === 0) return [];
-  const baseWhere =
-    user.role === "admin" || user.role === "manager"
-      ? { id: { in: contactIds } }
-      : {
-          id: { in: contactIds },
-          OR: [
-            { assigned_to: user.id },
-            { created_by: user.id },
-            { createdBy: user.id },
-          ],
-        };
   const rows = await prismadb.crm_Contacts.findMany({
-    where: baseWhere,
+    where: { id: { in: contactIds }, ...contactReadScopeWhere(user) },
+    select: { id: true },
+  });
+  return rows.map((r: { id: string }) => r.id);
+}
+
+export async function filterAuthorizedAccountIds(
+  user: AuthzUser,
+  accountIds: string[],
+): Promise<string[]> {
+  if (accountIds.length === 0) return [];
+  const rows = await prismadb.crm_Accounts.findMany({
+    where: { id: { in: accountIds }, ...accountReadScopeWhere(user) },
+    select: { id: true },
+  });
+  return rows.map((r: { id: string }) => r.id);
+}
+
+export async function filterAuthorizedLeadIds(
+  user: AuthzUser,
+  leadIds: string[],
+): Promise<string[]> {
+  if (leadIds.length === 0) return [];
+  const rows = await prismadb.crm_Leads.findMany({
+    where: { id: { in: leadIds }, ...leadReadScopeWhere(user) },
+    select: { id: true },
+  });
+  return rows.map((r: { id: string }) => r.id);
+}
+
+export async function filterAuthorizedOpportunityIds(
+  user: AuthzUser,
+  opportunityIds: string[],
+): Promise<string[]> {
+  if (opportunityIds.length === 0) return [];
+  const rows = await prismadb.crm_Opportunities.findMany({
+    where: { id: { in: opportunityIds }, ...opportunityReadScopeWhere(user) },
     select: { id: true },
   });
   return rows.map((r: { id: string }) => r.id);


### PR DESCRIPTION
## Summary

Closes the remaining CRM read-side scope gaps from the audit. After D3, target/list lookups, entity-keyed activity feeds, audit logs, and pgvector similarity searches all enforce role-based scope. **Phase D is complete** with this PR.

## What changed

**New helpers in \`lib/authz/scopes/crm.ts\`:**
- \`targetReadScopeWhere(user)\` + \`targetListReadScopeWhere(user)\` (both include \`deletedAt: null\` — soft-delete confirmed in schema)
- \`assertCanReadTargetList(user, listId)\`
- \`assertCanReadActivityForEntity(user, entityType, entityId)\` — dispatcher routing to \`assertCanReadAccount/Lead/Contact/Opportunity/Contract/Target/TargetList\` based on \`entityType\` (case-insensitive). Unknown types: managers/admins pass, users denied.
- \`filterAuthorizedAccountIds\`, \`filterAuthorizedLeadIds\`, \`filterAuthorizedOpportunityIds\` — for the similarity post-filter pattern.
- \`filterAuthorizedContactIds\` (B1) **upgraded** to compose \`contactReadScopeWhere\` so it now includes linked-account scope + \`deletedAt: null\`.

**Read actions patched:**
- Targets (4): \`get-target\`, \`get-targets\`, \`get-target-list\`, \`get-target-lists\`
- Activities (1): \`actions/crm/activities/get-activities-by-entity\` — \`requireAuthenticated\` + dispatcher
- Audit log (2): \`get-audit-log-by-entity\` (dispatcher), \`get-audit-log-admin\` (normalized to canonical \`requireRole(["admin"])\`)
- Similarity (4): \`get-similar-{accounts,contacts,leads,opportunities}\` — \`requireAuthenticated\` + base-record \`assertCanRead*\` + raw SQL with over-fetch (\`LIMIT × 3\`) + post-filter via \`filterAuthorized*Ids\`

**Bug fix:**
- D3.T1's plan claimed \`crm_Targets\` had no \`deletedAt\` (hard-delete). Schema audit during T2 implementation revealed the field exists. Helper and tests corrected before commit (commit \`7a8fc2e\`).

## Test status

- 91/97 suites pass, 490/491 tests pass (D2 baseline: 77/83, 417/418)
- ~73 new tests across helpers + 11 actions
- Same 6 pre-existing suite failures + 1 pre-existing test failure unchanged — no new regressions

## Test plan

- [ ] As \`bob\` (user), list \`/crm/targets\` → only \`bob\`'s targets (created_by check)
- [ ] As \`bob\`, view activity feed for \`alice\`'s opportunity → empty
- [ ] As \`bob\`, similarity search on \`alice\`'s contact → empty (base record assert blocks)
- [ ] As \`bob\`, similarity search on \`bob\`'s contact → returns ONLY contacts \`bob\` can read (post-filter applied)
- [ ] As \`bob\`, \`getAuditLogAdmin\` → \`{ error: "Forbidden" }\`
- [ ] As \`manager\`, all the above → full results

## Phase D summary (D1 + D2 + D3 combined)

Across 3 PRs, 25 read action files hardened, 18+ new helpers in \`lib/authz/scopes/crm.ts\`, ~170 new tests. Every CRM core read operation (accounts, leads, contacts, opportunities, contracts, targets, target lists, activities, audit logs, similarity) now consults \`Users.role\` and applies role-appropriate scope.

The B1 Phase 4 TODO (linked-account scope on contact reads) is closed — \`assertCanReadContact\` and \`filterAuthorizedContactIds\` both compose \`contactReadScopeWhere\` which includes the \`{ assigned_accounts: { OR: accountUserScopeOR(user.id) } }\` branch.

## Out of D3 scope

- **Phase E**: products, campaigns + templates, documents, projects (boards/tasks), full invoice list-scoping
- **Phase F**: remove \`is_admin\` / \`is_account_admin\` columns; switch \`Users.role\` to a Prisma enum
- pgvector similarity over-fetch factor (\`limit × 3\`) is fixed; tunable in a follow-up if user-role narrow scopes return too few results

Plan: \`docs/superpowers/plans/2026-05-02-permission-driven-migration-phase-d3.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)