### PR TITLE
docs(authz): Phase E1/E2/E3/E4 implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e1.md
+++ b/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e1.md
@@ -1,0 +1,193 @@
+# Permission-Driven Authorization — Phase E1 (Products + Account-Products + Invoice list-scoping) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Add role-based authorization to the products module, account-product assignments, and the only remaining unscoped invoice read action (`get-invoices-by-accountId`). Bundles three small areas because they share the account-scope helpers shipped in D1/D2.
+
+**Product policy decision (spec §15.2):** This plan applies the spec's recommended default — **products are catalog data shared across accounts, so mutations are manager/admin only**. Reads stay open to authenticated users (every role uses products in invoices/contracts/opportunity line items). If you want user-owned products instead, swap manager-only mutations for `createdBy`-based scope and add ownership checks to update/delete.
+
+**Architecture:**
+1. Products: read = `requireAuthenticated` (any role); create/update/delete/import = `requireRole(["manager", "admin"])`.
+2. Account-products: assignment is account write — use `assertCanWriteAccount(user, accountId)`. Reads use `assertCanReadAccount`.
+3. Invoice list-by-account: same pattern — `assertCanReadAccount` then list with existing where, no extra invoice scope helper needed (B2 already covers per-row read via `canReadInvoice`).
+
+**Spec source:** §6.6 (Products), §6.7 (Account-products), §6.11/§7.6 (invoice reads), §8.6, §8.13, §12 Phase 5.
+**Audit source:** Implicit — products were not in the original audit but flagged in spec §6 review.
+
+**Depends on:** D1+D2+D3 merged (`assertCanReadAccount`, `assertCanWriteAccount`).
+
+---
+
+## File Structure
+
+**New tests:**
+- `actions/crm/products/__tests__/create-product-scope.test.ts`
+- `actions/crm/products/__tests__/update-product-scope.test.ts`
+- `actions/crm/products/__tests__/delete-product-scope.test.ts`
+- `actions/crm/products/__tests__/import-products-scope.test.ts`
+- `actions/crm/products/__tests__/get-products-scope.test.ts`
+- `actions/crm/products/__tests__/get-product-scope.test.ts`
+- `actions/crm/account-products/__tests__/assign-product-scope.test.ts`
+- `actions/crm/account-products/__tests__/update-assignment-scope.test.ts`
+- `actions/crm/account-products/__tests__/remove-assignment-scope.test.ts`
+- `actions/crm/account-products/__tests__/get-account-products-scope.test.ts`
+- `actions/invoices/__tests__/get-invoices-by-accountId-scope.test.ts`
+
+**Modified:**
+- `actions/crm/products/{create,update,delete}-product/index.ts`, `import-products.ts`
+- `actions/crm/products/get-product.ts`, `get-products.ts`
+- `actions/crm/account-products/{assign,update,remove}*/index.ts`, `get-account-products.ts`
+- `actions/invoices/get-invoices-by-accountId.ts`
+
+---
+
+## Task 1: Product mutation gates (manager+)
+
+**Files:** `create-product`, `update-product`, `delete-product`, `import-products`.
+
+For each, replace the `getSession` block with `requireRole(["manager", "admin"])`. Match existing return contract (each currently returns `{data|error}` via createSafeAction).
+
+- [ ] **Step 1**: One test file per action — 3 cases (401 unauth, 403 user-role rejected, 200 manager succeeds, 200 admin succeeds — 4 cases combined).
+- [ ] **Step 2**: Patch each:
+  ```ts
+  import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
+
+  // inside handler:
+  let actor;
+  try { actor = await requireRole(["manager", "admin"]); }
+  catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  // existing body — replace `session.user.id` with `actor.id`
+  ```
+- [ ] **Step 3**: Commit: `fix(products): require manager/admin role on product mutations`
+
+---
+
+## Task 2: Product reads (any authenticated role)
+
+**Files:** `get-product.ts`, `get-products.ts`.
+
+Both currently have NO auth check. Add `requireAuthenticated` only — no scope filter (catalog data is global).
+
+- [ ] **Step 1**: Test files — 2 cases each (401 unauth → empty/null, 200 user/manager/admin → data).
+- [ ] **Step 2**: Patch — `requireAuthenticated` with `AuthenticationError → return [] | null` per existing contract.
+- [ ] **Step 3**: Commit: `fix(products): require authentication on product read actions`
+
+---
+
+## Task 3: Account-product assignments
+
+**Files:** `assign-product/index.ts`, `update-assignment/index.ts`, `remove-assignment/index.ts`.
+
+Mutations require **account write access** (manager/admin can write any; user must own the account via assigned_to/createdBy/watcher). Use `assertCanWriteAccount`.
+
+- [ ] **Step 1**: Test files — 4 cases per action (401, account-out-of-scope → forbidden, in-scope user → success, manager → success).
+- [ ] **Step 2**: Patch each:
+  ```ts
+  import {
+    requireAuthenticated,
+    assertCanWriteAccount,
+    AuthenticationError,
+    AuthorizationError,
+  } from "@/lib/authz";
+
+  let user;
+  try { user = await requireAuthenticated(); }
+  catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try { await assertCanWriteAccount(user, accountId); }
+  catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  // existing body — accountId for assign comes from input.accountId; for update/remove,
+  // load the assignment first to find its accountId, then assert
+  ```
+
+  For `update-assignment` and `remove-assignment`, the input is `{ id }` (assignment id) — load the assignment to get `accountId` first, then `assertCanWriteAccount`. If the assignment doesn't exist, return `{ error: "Not found" }`.
+
+- [ ] **Step 3**: Commit: `fix(account-products): require account write scope on assignment mutations`
+
+---
+
+## Task 4: Account-product reads
+
+**Files:** `get-account-products.ts`.
+
+Takes `accountId` as input. Requires `assertCanReadAccount` first; return `[]` on miss to avoid existence leak.
+
+- [ ] **Step 1**: Test — 4 cases (401, out-of-scope → empty, in-scope user → data, manager → data).
+- [ ] **Step 2**: Patch:
+  ```ts
+  let user;
+  try { user = await requireAuthenticated(); }
+  catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+  try { await assertCanReadAccount(user, accountId); }
+  catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
+  // existing query unchanged
+  ```
+- [ ] **Step 3**: Commit: `fix(account-products): require account read scope on get-account-products`
+
+---
+
+## Task 5: Invoice list by account
+
+**File:** `actions/invoices/get-invoices-by-accountId.ts`.
+
+Same pattern as Task 4 — gate on `assertCanReadAccount(user, accountId)`. The invoice rows themselves are filtered down further only when the user lacks access to specific invoices (B2's `canReadInvoice` already gates per-row reads, but list contexts return all rows for an account the caller can access — that's the spec's intent). Defense in depth: also filter out invoices where `createdBy !== user.id && user.role === "user"` IF the product owner wants stricter list scoping. **Default: just gate on account access** — simpler and matches the spec.
+
+- [ ] **Step 1**: Test — 4 cases (401, out-of-scope account → empty, in-scope user → list, manager → list).
+- [ ] **Step 2**: Patch (same shape as Task 4).
+- [ ] **Step 3**: Commit: `fix(invoices): require account read scope on get-invoices-by-accountId`
+
+---
+
+## Task 6: Verification + PR
+
+- [ ] **Step 1**: Full suite + grep for residual unscoped product/account-product reads:
+  ```bash
+  pnpm jest 2>&1 | tail -8
+  grep -rn "prismadb\.crm_\(Products\|AccountProducts\)\." actions/ --include="*.ts" | grep -v "__tests__" | head
+  ```
+
+- [ ] **Step 2**: Manual checklist:
+  - As `bob` (user), call `createProduct` → forbidden
+  - As `bob`, list products → succeeds (catalog read)
+  - As `bob`, `getAccountProducts(<alice-account>)` → empty (no access)
+  - As `bob`, `assignProduct({ accountId: <alice-account>, ... })` → forbidden
+  - As `manager`, all the above → succeed
+
+- [ ] **Step 3**: Push + PR
+  ```bash
+  git push -u origin feat/authz-phase-e1
+  gh pr create --base dev --head feat/authz-phase-e1 --title "fix(security): scope products + account-products + invoice list (Phase E1)"
+  ```
+
+---
+
+## Acceptance Criteria
+
+- All 4 product mutation actions require `manager`/`admin`; `user` calls return `{error:"Forbidden"}`.
+- Both product read actions require authentication (any role).
+- All 3 account-product mutation actions require account write scope.
+- `get-account-products` and `get-invoices-by-accountId` require account read scope.
+- New tests cover unauth/user/manager/admin per action.
+
+## Out of E1 scope
+
+- **E2:** campaigns + templates (separate decision-point on user can-send/schedule)
+- **E3:** documents
+- **E4:** projects (boards/sections/tasks)
+- Per-row invoice list scoping inside an accessible account — the current pattern returns all invoices in scope-allowed accounts; further per-row filtering (e.g., user-role can only see invoices they created within their accounts) would be a follow-up tightening
+- Product visibility per role (some products marked private to manager+) — feature creep

--- a/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e2.md
+++ b/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e2.md
@@ -1,0 +1,201 @@
+# Permission-Driven Authorization — Phase E2 (Campaigns + Templates) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Close the campaign-action audit findings: all 8 campaign actions are currently unguarded (or only have a nullable session check). Add `requireAuthenticated` + role-aware send/schedule gating + creator-or-manager-or-admin mutation rules.
+
+**Campaign delivery policy decision (spec §15.3):** This plan applies the spec's recommended default — **send/schedule operations are manager/admin only** (they trigger external email delivery and consume quota). Users can create/update/delete their own draft campaigns and templates. If the product owner wants users to send their own campaigns, swap the role check on `schedule-campaign.ts` and `send-campaign-now.ts` for ownership-only gating.
+
+**Architecture:**
+1. New helpers in `lib/authz/scopes/crm.ts`: `campaignReadScopeWhere`, `campaignTemplateReadScopeWhere`, `assertCanReadCampaign`, `assertCanWriteCampaign`, `assertCanReadTemplate`, `assertCanWriteTemplate`. All use the same shape as target-list (creator-only for users; bare for manager/admin).
+2. Reads (`get-campaign`, `get-campaigns`, `get-template`, `get-templates`) → scope by role.
+3. Mutations (`create/update/delete/pause-campaign`, template create/update/delete, `generate-template`) → ownership-or-privileged.
+4. Send/schedule (`schedule-campaign`, `send-campaign-now`) → manager/admin only.
+5. **Critical fix:** `create-campaign.ts` currently sets `created_by: session?.user?.id ?? null` — **fail-closed** so unauthenticated calls reject and `created_by` is never null.
+
+**Spec source:** §6.9 (Campaigns), §8.11, §12 Phase 5.
+**Audit source:** "Critical: Campaign Actions Without Session Checks", "Critical: Unauthenticated Campaign Creation".
+
+**Depends on:** D-phase merged.
+
+---
+
+## File Structure
+
+**New tests:** one per action (~14 files) under `actions/campaigns/__tests__/` and `actions/campaigns/templates/__tests__/`.
+
+**Modified:**
+- `lib/authz/scopes/crm.ts` — 6 new helpers
+- `lib/authz/index.ts`
+- `actions/campaigns/{create,update,delete,pause,schedule,send-campaign-now,get-campaign,get-campaigns}-campaign*.ts`
+- `actions/campaigns/templates/{create,update,delete,generate,get-template,get-templates}.ts`
+
+---
+
+## Task 1: Campaign + template scope helpers
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts`
+- Create: `lib/authz/__tests__/scopes-crm-campaign-read.test.ts`
+
+```ts
+// crm_campaigns has soft-delete via status="deleted" (not deletedAt). Use status filter.
+export function campaignReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { status: { not: "deleted" } };
+  }
+  return { status: { not: "deleted" }, created_by: user.id };
+}
+
+// crm_campaign_templates has deletedAt soft-delete.
+export function campaignTemplateReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return { deletedAt: null, created_by: user.id };
+}
+
+export async function assertCanReadCampaign(user: AuthzUser, id: string) {
+  const row = await prismadb.crm_campaigns.findFirst({
+    where: { id, ...campaignReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteCampaign(user: AuthzUser, id: string) {
+  // Same as read for now — campaigns aren't shared cross-user.
+  // Manager/admin override applies in helpers.
+  return assertCanReadCampaign(user, id);
+}
+
+export async function assertCanReadTemplate(user: AuthzUser, id: string) {
+  const row = await prismadb.crm_campaign_templates.findFirst({
+    where: { id, ...campaignTemplateReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteTemplate(user: AuthzUser, id: string) {
+  return assertCanReadTemplate(user, id);
+}
+```
+
+- [ ] Test (admin/manager/user shape per helper, 200/404 on each assert), implement, barrel export, commit:
+
+```bash
+git commit -m "feat(authz): add campaign and template read/write scope helpers"
+```
+
+---
+
+## Task 2: Campaign read actions
+
+**Files:** `actions/campaigns/get-campaign.ts`, `get-campaigns.ts`.
+
+- [ ] Test files (`actions/campaigns/__tests__/`): 4 cases per file (401, out-of-scope, in-scope user, manager).
+- [ ] Patch:
+  - `get-campaigns.ts`: `requireAuthenticated` + spread `campaignReadScopeWhere(user)` into existing where (replace existing `status: { not: "deleted" }` since the helper includes it).
+  - `get-campaign.ts`: `requireAuthenticated` + `assertCanReadCampaign(user, id)` → existing detail query.
+- [ ] Commit: `fix(campaigns): scope campaign reads by role`
+
+---
+
+## Task 3: Campaign mutation actions (creator-or-privileged)
+
+**Files:** `create-campaign.ts`, `update-campaign.ts`, `delete-campaign.ts`, `pause-campaign.ts`.
+
+For `create-campaign.ts`:
+- **Critical:** require auth, fail-closed. `created_by: user.id` (never null).
+- Validate `target_list_ids` and `template_id` are readable by the user (use `assertCanReadTemplate` + a bulk filter on target lists — could use `targetListReadScopeWhere` + `findMany` to check).
+
+For `update/delete/pause-campaign.ts`:
+- `requireAuthenticated` + `assertCanWriteCampaign(user, id)` → existing mutation.
+
+- [ ] Test files (4 per action), patch, commit:
+
+```bash
+git commit -m "fix(campaigns): require auth + ownership on create/update/delete/pause"
+```
+
+---
+
+## Task 4: Schedule + send-now (manager/admin only)
+
+**Files:** `schedule-campaign.ts`, `send-campaign-now.ts`.
+
+These trigger external email delivery → manager/admin only per spec §15.3 default. After role check, also verify the campaign is readable (defense in depth) and not already in a terminal state (existing logic).
+
+- [ ] Test files: 4 cases (401, user → forbidden, manager → success, admin → success).
+- [ ] Patch:
+  ```ts
+  let user;
+  try { user = await requireRole(["manager", "admin"]); }
+  catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  try { await assertCanReadCampaign(user, id); }
+  catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+  // existing schedule/send logic
+  ```
+- [ ] Commit: `fix(campaigns): require manager/admin role on schedule and send-now`
+
+---
+
+## Task 5: Template actions
+
+**Files:**
+- Reads: `get-template.ts`, `get-templates.ts` — same pattern as Task 2 with `campaignTemplateReadScopeWhere` / `assertCanReadTemplate`.
+- Mutations: `create-template.ts` (fail-closed auth + `created_by = user.id`), `update-template.ts` + `delete-template.ts` (`assertCanWriteTemplate`).
+- `generate-template.ts` (AI generation, also a write op): `requireAuthenticated` (any role can generate templates for themselves; `created_by = user.id`).
+
+- [ ] Test files (4 per action), patch, commit:
+
+```bash
+git commit -m "fix(campaign-templates): scope template reads/mutations by role and ownership"
+```
+
+---
+
+## Task 6: Verification + PR
+
+- [ ] **Step 1**: Full suite + grep:
+  ```bash
+  grep -rn "session?.user?.id ?? null\|created_by: null" actions/campaigns/ --include="*.ts" | head
+  ```
+  Expected: empty.
+
+- [ ] **Step 2**: Manual checklist:
+  - As `bob` (user), `sendCampaignNow(<id>)` → forbidden
+  - As `bob`, `createCampaign` → succeeds with `created_by = bob.id`, never null
+  - As `bob`, `updateCampaign(<alice-campaign>)` → not-found
+  - As `manager`, all the above → succeed
+  - As `bob`, `getCampaigns()` → only `bob`'s campaigns
+
+- [ ] **Step 3**: Push + PR:
+  ```bash
+  gh pr create --base dev --head feat/authz-phase-e2 --title "fix(security): scope campaigns + templates (Phase E2)"
+  ```
+
+---
+
+## Acceptance Criteria
+
+- No campaign or template action accepts an unauthenticated session.
+- `created_by` is never null for newly created campaigns or templates.
+- `schedule-campaign` and `send-campaign-now` reject `user` role with 403.
+- `update/delete/pause-campaign` reject non-creator non-manager-non-admin attempts.
+- Read actions filter by ownership for users; bare for manager/admin.
+
+## Out of E2 scope
+
+- **E3**: documents
+- **E4**: projects
+- Inngest worker hardening (workers still trust `triggeredBy` from event payload — separate pass)
+- Campaign-target-list scope validation on create-campaign — basic check covered (target lists must be readable), but composite restrictions (e.g., user can only attach lists they own) should be re-confirmed in B1's bulk-id filter pattern. Plan default: assert `targetListReadScopeWhere` against the input list IDs.

--- a/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e3.md
+++ b/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e3.md
@@ -1,0 +1,187 @@
+# Permission-Driven Authorization — Phase E3 (Documents) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Close the document-action audit findings: global document listing, no ownership checks on delete/bulk operations, no account-write check on linking. Apply role + visibility-based scope across reads, plus per-document ownership on writes and bulk filter on multi-id operations.
+
+**Architecture:** Documents have multi-faceted ownership (`created_by_user`, `assigned_user`, `visibility` enum, plus link junctions to accounts/leads/contacts/opportunities/tasks). The user-scope rule is: a user can read a document if they created it OR are assigned to it OR a linked entity is in their scope. Manager/admin: bare read. Phase E3 implements:
+
+1. New `documentReadScopeWhere(user)` that captures the full ownership matrix.
+2. New `assertCanReadDocument`, `assertCanWriteDocument`, `filterAuthorizedDocumentIds` helpers.
+3. Patch all 12 document actions (reads + writes + bulk).
+
+**Visibility model decision:** The existing `Documents.visibility` field is enforced as: user-role users see public docs OR docs they directly own/are assigned to OR docs linked to in-scope entities. Manager/admin: see all. Plan applies the most conservative interpretation — `visibility = "public"` is the only sharing mechanism that overrides ownership; the field's exact enum values should be confirmed during T1 implementation.
+
+**Spec source:** §6.10 (Documents), §8.12, §12 Phase 5.
+**Audit source:** "Medium-High: Global Document Listing".
+
+**Depends on:** D-phase merged (account/lead/contact/opportunity scope helpers).
+
+---
+
+## File Structure
+
+**New tests:** ~12 (one per modified action) under `actions/documents/__tests__/`, plus one helper test in `lib/authz/__tests__/`.
+
+**Modified:**
+- `lib/authz/scopes/crm.ts` — new `documentReadScopeWhere`, asserts, filter
+- `lib/authz/index.ts`
+- `actions/documents/*.ts` — all 12 files
+
+---
+
+## Task 1: Document scope helpers
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts` (despite the name, this is the central authz module — keeps everything in one place)
+- Create: `lib/authz/__tests__/scopes-crm-document-read.test.ts`
+
+```ts
+// User scope: created OR assigned OR linked entity in scope OR public visibility.
+// "public" assumed; confirm the enum value during implementation.
+export function documentReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { created_by_user: user.id },
+      { createdBy: user.id }, // legacy duplicate
+      { assigned_user: user.id },
+      { visibility: "public" },
+      // Linked-entity scope (any of the junction tables resolves to an entity in user scope).
+      // Only the most common are included; expand if other junctions matter:
+      { accounts: { some: { account: { OR: accountUserScopeOR(user.id) } } } },
+      { leads:    { some: { lead: { OR: [{ assigned_to: user.id }, { createdBy: user.id }] } } } },
+      { contacts: { some: { contact: { OR: [
+        { assigned_to: user.id }, { created_by: user.id }, { createdBy: user.id }
+      ] } } } },
+      { opportunities: { some: { opportunity: { OR: [
+        { assigned_to: user.id }, { created_by: user.id }, { createdBy: user.id }
+      ] } } } },
+    ],
+  };
+}
+
+export async function assertCanReadDocument(user: AuthzUser, documentId: string) {
+  const row = await prismadb.documents.findFirst({
+    where: { id: documentId, ...documentReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteDocument(user: AuthzUser, documentId: string) {
+  // Write scope: same as read for now; Phase F may diverge.
+  return assertCanReadDocument(user, documentId);
+}
+
+export async function filterAuthorizedDocumentIds(
+  user: AuthzUser,
+  documentIds: string[],
+): Promise<string[]> {
+  if (documentIds.length === 0) return [];
+  const rows = await prismadb.documents.findMany({
+    where: { id: { in: documentIds }, ...documentReadScopeWhere(user) },
+    select: { id: true },
+  });
+  return rows.map((r: { id: string }) => r.id);
+}
+```
+
+**Confirm during implementation:**
+- Exact Prisma model name: `Documents` vs `documents` (the schema may use lowercase plural).
+- Junction relation names (`accounts`, `leads`, `contacts`, `opportunities`) and inner relation field names (`account`, `lead`, etc.).
+- `visibility` enum value for "public" — likely `Document_Visibility.PUBLIC` or similar.
+
+- [ ] Test → implement → barrel → commit:
+```bash
+git commit -m "feat(authz): add document read/write scope helpers (linked-entity aware)"
+```
+
+---
+
+## Task 2: Document read actions
+
+**Files:** `get-documents.ts`, `search-documents.ts`, `get-document-versions.ts`, `check-duplicate.ts`.
+
+- `get-documents.ts` — list root documents. Spread `documentReadScopeWhere(user)` into existing where (currently `parent_document_id: null`).
+- `search-documents.ts` — keyword + vector. Same pattern. Vector search uses raw SQL — apply post-filter with `filterAuthorizedDocumentIds`.
+- `get-document-versions.ts` — fetch versions. Versions inherit parent permissions: assert read on parent first, then list versions.
+- `check-duplicate.ts` — likely checks if a hash matches existing docs. Apply scope so users don't enumerate other people's documents via duplicate check.
+
+- [ ] Test files (4 cases per file: 401, out-of-scope-empty, in-scope, manager).
+- [ ] Patch, commit: `fix(documents): scope document reads by role and linked-entity access`
+
+---
+
+## Task 3: Document mutations (single-doc)
+
+**Files:** `create-document.ts`, `delete-document.ts`, `unlink-from-account.ts`, `retry-enrichment.ts`, `create-document-version.ts`.
+
+- `create-document.ts` — `requireAuthenticated`. If `accountId` provided, `assertCanWriteAccount(user, accountId)` before creating. `createdBy = user.id, assigned_user = user.id`.
+- `delete-document.ts` — `requireAuthenticated` + `assertCanWriteDocument` → existing hard delete + MinIO cleanup.
+- `unlink-from-account.ts` — `assertCanWriteDocument(user, document_id)` AND `assertCanWriteAccount(user, account_id)` (need both endpoints of the link).
+- `retry-enrichment.ts` — `assertCanWriteDocument`.
+- `create-document-version.ts` — `assertCanWriteDocument` on parent.
+
+- [ ] Tests + patches + single combined commit:
+```bash
+git commit -m "fix(documents): require ownership/account scope on document mutations"
+```
+
+---
+
+## Task 4: Bulk document operations
+
+**Files:** `bulk-delete-documents.ts`, `bulk-link-to-account.ts`, `bulk-change-type.ts`.
+
+Fail-closed pattern (per B1 bulk-enrichment precedent):
+
+- `bulk-delete-documents.ts` — call `filterAuthorizedDocumentIds(user, documentIds)`. If any id missing from the result, return 403 (or `{error: "Forbidden"}`). Otherwise proceed with bulk delete.
+- `bulk-link-to-account.ts` — `assertCanWriteAccount(user, account_id)` AND `filterAuthorizedDocumentIds(user, document_ids)` length-check.
+- `bulk-change-type.ts` — `filterAuthorizedDocumentIds` length-check.
+
+- [ ] Tests + patches + commit:
+```bash
+git commit -m "fix(documents): filter bulk document operations by user scope (fail-closed)"
+```
+
+---
+
+## Task 5: Verification + PR
+
+- [ ] Full suite + grep for residual unscoped document reads:
+  ```bash
+  grep -rn "prismadb\.documents\." actions/ --include="*.ts" | grep -v "__tests__\|scopes/crm" | head
+  ```
+
+- [ ] Manual checklist:
+  - As `bob`, list documents → only `bob`'s + linked-entity-accessible docs
+  - As `bob`, `deleteDocument(<alice-doc-id>)` → forbidden
+  - As `bob`, `bulkDeleteDocuments([alice, bob])` → 403, no deletion (fail-closed)
+  - As `bob`, `bulkLinkToAccount({account: <alice-account>, ...})` → forbidden
+  - As `manager`, all the above → succeed
+
+- [ ] Push + PR:
+  ```bash
+  gh pr create --base dev --head feat/authz-phase-e3 --title "fix(security): scope documents + bulk ops (Phase E3)"
+  ```
+
+---
+
+## Acceptance Criteria
+
+- All document read actions apply role-aware scope (creator/assigned/visibility/linked-entity).
+- All single-doc mutations require write scope on the document.
+- Account-link/unlink mutations require write scope on BOTH endpoints.
+- All 3 bulk operations fail-closed on any unauthorized id.
+- New tests cover unauth/user/manager/admin per action.
+
+## Out of E3 scope
+
+- **E4**: projects (boards/sections/tasks) and assign-document-to-task (handled in E4)
+- Document versions tree pagination — keep current behavior, only add the parent-read assertion
+- The exact visibility enum semantics for non-`public` values — Phase F could add per-role visibility rules
+- Tag-based access control — feature creep

--- a/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e4.md
+++ b/docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e4.md
@@ -1,0 +1,246 @@
+# Permission-Driven Authorization — Phase E4 (Projects: Boards + Sections + Tasks) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Add role + ownership scoping to the projects subsystem (boards, sections, tasks, comments, document assignments). After E4, a `user` only sees boards they own, are shared with, watch, or that are public; sections/tasks inherit their parent board's scope. Manager/admin: bare reads. Send/email side-effects respect existing patterns.
+
+**Architecture:**
+1. New helpers: `boardReadScopeWhere(user)`, `boardWriteScopeWhere(user)`, `assertCanReadBoard`, `assertCanWriteBoard`, `assertCanReadTask` (resolves through task→section→board), `assertCanWriteTask` (board write OR task assignee).
+2. Reads on boards/sections/tasks → role-scoped.
+3. Mutations on board/section → require board write scope.
+4. Task mutations → require board write scope OR (assignee for status-only changes per spec §6.12 special rule).
+5. Watch/unwatch operations require board read scope (you can watch any board you can see).
+6. Document-to-task assignment requires both `assertCanWriteTask` AND `assertCanReadDocument` (E3 helper).
+
+**Spec source:** §6.12 (Projects), §8.14, §12 Phase 5.
+**Audit source:** Implicit — boards/tasks weren't on the original audit, but spec §6.12 details the scope rules.
+
+**Depends on:** D-phase + E3 (for `assertCanReadDocument` used in `assignDocumentToTask`). If E3 not yet merged, the document-link task can fall back to `requireAuthenticated` only and TODO the document scope.
+
+---
+
+## File Structure
+
+**New tests:** ~16 (one per action) under `actions/projects/__tests__/`, plus helper tests in `lib/authz/__tests__/`.
+
+**Modified:**
+- `lib/authz/scopes/crm.ts` — new board/task helpers
+- `lib/authz/index.ts`
+- `actions/projects/*.ts` — all 16 files
+
+---
+
+## Task 1: Board + task scope helpers
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts`
+- Create: `lib/authz/__tests__/scopes-projects.test.ts`
+
+```ts
+// Board read: owner OR shared OR watcher OR visibility=public.
+// Note: confirm `Boards.visibility` enum (likely "public"|"private") and `sharedWith` shape.
+export function boardReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { user: user.id },                                  // owner
+      { sharedWith: { has: user.id } },                   // sharedWith is uuid[]
+      { visibility: "public" },                            // public board
+      { watchers: { some: { user_id: user.id } } },        // watcher junction
+    ],
+  };
+}
+
+// Board write: owner OR manager/admin (not watchers, not sharedWith for writes).
+export function boardWriteScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return { deletedAt: null, user: user.id };
+}
+
+export async function assertCanReadBoard(user: AuthzUser, boardId: string) {
+  const row = await prismadb.boards.findFirst({
+    where: { id: boardId, ...boardReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteBoard(user: AuthzUser, boardId: string) {
+  const row = await prismadb.boards.findFirst({
+    where: { id: boardId, ...boardWriteScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+// Task read: parent board read access.
+export async function assertCanReadTask(user: AuthzUser, taskId: string) {
+  const task = await prismadb.tasks.findUnique({
+    where: { id: taskId },
+    select: { assigned_section: { select: { board_relation: { select: { id: true } } } } },
+  });
+  if (!task?.assigned_section?.board_relation?.id) throw new AuthorizationError();
+  return assertCanReadBoard(user, task.assigned_section.board_relation.id);
+}
+
+// Task write: parent board write OR (user is task assignee — for status-only changes).
+// The plan exposes a strict version (board write) and the action layer can use a softer
+// check for status-only changes if needed (mark-task-done, kanban position).
+export async function assertCanWriteTask(user: AuthzUser, taskId: string) {
+  const task = await prismadb.tasks.findUnique({
+    where: { id: taskId },
+    select: {
+      user: true,
+      assigned_section: { select: { board_relation: { select: { id: true } } } },
+    },
+  });
+  if (!task?.assigned_section?.board_relation?.id) throw new AuthorizationError();
+  // Manager/admin always pass via boardWriteScopeWhere.
+  // User: must be board owner OR task assignee.
+  if (user.role === "user" && task.user === user.id) return;
+  return assertCanWriteBoard(user, task.assigned_section.board_relation.id);
+}
+```
+
+**Confirm during implementation:**
+- Schema name `boards` vs `Boards` (lowercase per Prisma typically; explore showed `Boards`).
+- `sharedWith` Prisma type — `String[]` with `has` operator, OR scalar list with `hasSome`.
+- Watcher junction model name (likely `BoardWatchers` per spec §6.12).
+- `visibility` enum exact value for public.
+
+- [ ] Test (admin/manager/user shapes for both helpers + assert paths), implement, barrel, commit:
+```bash
+git commit -m "feat(authz): add board and task read/write scope helpers"
+```
+
+---
+
+## Task 2: Project read actions
+
+**Files (~10):** `get-boards.ts`, `get-board.ts`, `get-board-sections.ts`, `get-sections.ts`, `get-kanban-data.ts`, `get-task.ts`, `get-task-comments.ts`, `get-task-documents.ts`, `get-tasks.ts`, `get-tasks-past-due.ts`, `get-user-tasks.ts`.
+
+Apply pattern per file:
+- `get-boards.ts` — spread `boardReadScopeWhere(user)`. The existing query already filters by `user OR sharedWith OR public OR watcher` — REPLACE the manual OR with the helper to avoid drift.
+- `get-board.ts` — `assertCanReadBoard` → existing detail query.
+- `get-board-sections.ts` / `get-sections.ts` — `assertCanReadBoard(user, boardId)` first → existing list (sections are 1:n with board, no separate scope).
+- `get-kanban-data.ts` — `assertCanReadBoard` → existing query (board + sections + tasks).
+- `get-task.ts` — `assertCanReadTask`.
+- `get-task-comments.ts` / `get-task-documents.ts` — `assertCanReadTask` first.
+- `get-tasks.ts` — if it takes `boardId`, gate via `assertCanReadBoard`. If it lists tasks across boards, scope by joining through board scope (use `assigned_section.board_relation: boardReadScopeWhere(user)` in nested where).
+- `get-tasks-past-due.ts`, `get-user-tasks.ts` — for `user` role, restrict to own tasks (`user: user.id`); manager/admin: bare. The "past-due" report likely should remain global for managers.
+
+- [ ] One test per file (4 cases each), patch, commit:
+```bash
+git commit -m "fix(projects): scope project read actions by board access"
+```
+
+---
+
+## Task 3: Board mutations
+
+**Files:** `create-project.ts`, `update-project.ts`, `delete-project.ts`, `watch-project.ts`, `unwatch-project.ts`.
+
+- `create-project.ts` — `requireAuthenticated`; existing logic creates board with `user = user.id`. No further scope needed (anyone can create their own board).
+- `update-project.ts` / `delete-project.ts` — `assertCanWriteBoard`.
+- `watch-project.ts` / `unwatch-project.ts` — `assertCanReadBoard` (you can watch boards you can see).
+
+- [ ] Tests + patches + commit:
+```bash
+git commit -m "fix(projects): require board write/read scope on board mutations"
+```
+
+---
+
+## Task 4: Section mutations
+
+**Files:** `create-section.ts`, `update-section-title.ts`, `delete-section.ts`.
+
+All require `assertCanWriteBoard(user, boardId)` on the parent board. For update/delete, load the section to find its `board` FK first.
+
+- [ ] Tests + patches + commit:
+```bash
+git commit -m "fix(projects): require parent board write scope on section mutations"
+```
+
+---
+
+## Task 5: Task mutations
+
+**Files:** `create-task.ts`, `create-task-in-board.ts`, `update-task.ts`, `delete-task.ts`, `mark-task-done.ts`, `update-kanban-position.ts`, `add-comment-to-task.ts`, `assign-document-to-task.ts`.
+
+Two tiers:
+- **Strict (board write required):** `create-task`, `create-task-in-board`, `update-task` (full edit), `delete-task`, `add-comment-to-task` (comments are content), `assign-document-to-task`.
+- **Soft (assignee allowed):** `mark-task-done`, `update-kanban-position` — these are status-only changes a user assigned to the task should be able to make. Use the soft `assertCanWriteTask` (which permits assignee).
+
+For `assign-document-to-task`:
+- `assertCanWriteTask(user, taskId)`
+- AND `assertCanReadDocument(user, documentId)` if E3 is merged (otherwise `requireAuthenticated` and TODO).
+
+For `create-task` / `create-task-in-board`:
+- `assertCanWriteBoard(user, boardId)`. Existing email-on-assignment-to-different-user logic stays.
+
+- [ ] Tests + patches + commit (split into 2 commits if it gets noisy: "task strict mutations" + "task soft mutations"):
+```bash
+git commit -m "fix(projects): require board/task scope on task mutations"
+```
+
+---
+
+## Task 6: Verification + PR
+
+- [ ] Full suite + grep for residual unscoped board/task reads:
+  ```bash
+  grep -rn "prismadb\.\(boards\|tasks\|sections\)\.\(findMany\|findFirst\|findUnique\)" actions/projects/ --include="*.ts" | grep -v "__tests__\|scopes/crm" | head
+  ```
+
+- [ ] Manual checklist:
+  - As `bob`, list boards → own + shared + public + watched
+  - As `bob`, navigate to private board owned by `alice` → 404
+  - As `bob`, `updateProject(<alice-private-board>)` → forbidden
+  - As `bob` (assignee on `alice`'s task): `markTaskDone` succeeds, `updateTask` (full edit) → forbidden
+  - As `manager`, all the above → succeed
+
+- [ ] Push + PR:
+  ```bash
+  gh pr create --base dev --head feat/authz-phase-e4 --title "fix(security): scope projects (boards/sections/tasks) (Phase E4)"
+  ```
+
+---
+
+## Acceptance Criteria
+
+- Boards reads/writes apply owner/sharedWith/watcher/visibility/role rules.
+- Sections inherit board scope (no independent ownership).
+- Task reads require parent board read; writes require board write OR assignee for status-only changes.
+- Watch/unwatch require board read access.
+- `assign-document-to-task` requires both task write and document read.
+- New tests cover unauth/user/manager/admin per action; helper tests cover role permutations.
+
+## Out of E4 scope
+
+- **Phase F**: cleanup (`is_admin`/`is_account_admin` removal, Prisma enum)
+- Section reordering across boards — current logic stays
+- Public-board listing UX — out of authz concern
+- Per-task visibility tags — feature creep
+- Project-level user-management (sharedWith add/remove) is not currently in `actions/projects/` — handled separately
+
+---
+
+## Phase E summary (across E1 + E2 + E3 + E4)
+
+After all four PRs merge:
+- Products (catalog reads any-role; mutations manager/admin only) — E1
+- Account-product assignments use account write scope — E1
+- Invoice list-by-account uses account read scope — E1
+- Campaigns + templates: creator-or-privileged scope; send/schedule manager/admin only — E2
+- Documents: ownership + visibility + linked-entity scope on reads, ownership on writes, fail-closed on bulk — E3
+- Projects: board owner/shared/watcher/public scope; task scope inherits board, soft-write for assignees — E4
+
+Total Phase E: ~52 actions hardened, ~12 new helpers in `lib/authz/scopes/crm.ts`, ~50 new tests.
+
+After Phase E, only **Phase F (cleanup)** remains: remove `Users.is_admin` / `is_account_admin` columns, switch `Users.role` to a Prisma enum, remove dual `created_by`/`createdBy` field redundancy where safe.


### PR DESCRIPTION
## Summary

Plans for the next four Phase E PRs splitting the remaining authorization work — products, campaigns, documents, projects, plus invoice list-scoping — into reviewable, independently shippable chunks. After E ships, only Phase F (cleanup) remains.

## What changed

- \`docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e1.md\` — Products + account-product assignments + invoice list-scoping
- \`docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e2.md\` — Campaigns + templates (with manager/admin gating on send/schedule per spec §15.3 default)
- \`docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e3.md\` — Documents (visibility + linked-entity scope + fail-closed bulk ops)
- \`docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e4.md\` — Projects (boards/sections/tasks with assignee soft-write for status-only changes)

## Open product decisions baked into the plans (override before starting if needed)

- **§15.2 (E1):** product mutations are manager/admin only (catalog data shared across accounts). User-owned products is the alternative if you want to swap.
- **§15.3 (E2):** campaign \`schedule\` and \`send-now\` are manager/admin only (external email + quota). Owner-only is the alternative.

## Dependency graph

E1, E2, E3 are independent (each can ship in any order after D merges). E4 depends on E3 if you want \`assign-document-to-task\` to use the document read scope; otherwise E4 can ship in parallel and TODO that one check.

## Volume estimate

| Plan | Actions | New helpers | Approx tasks |
|---|---|---|---|
| E1 | 11 | 0 (reuses D) | 6 |
| E2 | 14 | 6 | 6 |
| E3 | 12 | 4 | 5 |
| E4 | 16 | 5 | 6 |

Total Phase E: ~52 actions hardened, ~12 new helpers, ~50 new tests.

## Test plan

This is a docs-only PR. Smoke check: confirm the markdown renders; review acceptance criteria; flag scope/policy concerns before E1 implementation starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)