### PR TITLE
fix(security): scope products + account-products + invoice list (Phase E1)

### DIFF
--- a/actions/crm/account-products/__tests__/assign-product-scope.test.ts
+++ b/actions/crm/account-products/__tests__/assign-product-scope.test.ts
@@ -1,0 +1,81 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_AccountProducts: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+    crm_Products: { findUnique: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+jest.mock("@/lib/currency", () => ({
+  getSnapshotRate: jest.fn().mockResolvedValue(null),
+  getDefaultCurrency: jest.fn().mockResolvedValue("USD"),
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { assignProduct } from "../assign-product";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const accFind = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const apFindFirst = prismadb.crm_AccountProducts.findFirst as jest.MockedFunction<typeof prismadb.crm_AccountProducts.findFirst>;
+const apCreate = prismadb.crm_AccountProducts.create as jest.MockedFunction<typeof prismadb.crm_AccountProducts.create>;
+const prodFind = prismadb.crm_Products.findUnique as jest.MockedFunction<typeof prismadb.crm_Products.findUnique>;
+
+const validInput = {
+  accountId: "a1",
+  productId: "p1",
+  quantity: 1,
+  currency: "USD",
+  status: "ACTIVE" as const,
+  start_date: new Date("2026-01-01"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prodFind.mockResolvedValue({ id: "p1", deletedAt: null, status: "ACTIVE" } as any);
+  apFindFirst.mockResolvedValue(null);
+  apCreate.mockResolvedValue({ id: "ap1" } as any);
+});
+
+describe("assignProduct account write scope", () => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await assignProduct(validInput);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(apCreate).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when user out of account scope", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue(null);
+    const res = await assignProduct(validInput);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(apCreate).not.toHaveBeenCalled();
+  });
+
+  it("user in scope succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue({ id: "a1" } as any);
+    const res = await assignProduct(validInput);
+    expect(res).toMatchObject({ data: { id: "ap1" } });
+    expect(apCreate).toHaveBeenCalled();
+  });
+
+  it("manager succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    accFind.mockResolvedValue({ id: "a1" } as any);
+    const res = await assignProduct(validInput);
+    expect(res).toMatchObject({ data: { id: "ap1" } });
+    expect(apCreate).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/account-products/__tests__/get-account-products-scope.test.ts
+++ b/actions/crm/account-products/__tests__/get-account-products-scope.test.ts
@@ -1,0 +1,58 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_AccountProducts: { findMany: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getAccountProducts } from "../get-account-products";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const accFind = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const apFindMany = prismadb.crm_AccountProducts.findMany as jest.MockedFunction<typeof prismadb.crm_AccountProducts.findMany>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  apFindMany.mockResolvedValue([{ id: "ap1" }] as any);
+});
+
+describe("getAccountProducts account read scope", () => {
+  it("returns empty when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await getAccountProducts("a1");
+    expect(res).toEqual([]);
+    expect(apFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when user out of scope", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue(null);
+    const res = await getAccountProducts("a2");
+    expect(res).toEqual([]);
+    expect(apFindMany).not.toHaveBeenCalled();
+  });
+
+  it("user in scope returns assignments", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue({ id: "a3" } as any);
+    const res = await getAccountProducts("a3");
+    expect(res).toEqual([{ id: "ap1" }]);
+    expect(apFindMany).toHaveBeenCalled();
+  });
+
+  it("manager returns assignments", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    accFind.mockResolvedValue({ id: "a4" } as any);
+    const res = await getAccountProducts("a4");
+    expect(res).toEqual([{ id: "ap1" }]);
+    expect(apFindMany).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/account-products/__tests__/remove-assignment-scope.test.ts
+++ b/actions/crm/account-products/__tests__/remove-assignment-scope.test.ts
@@ -1,0 +1,64 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_AccountProducts: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { removeAssignment } from "../remove-assignment";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const accFind = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const apFindUnique = prismadb.crm_AccountProducts.findUnique as jest.MockedFunction<typeof prismadb.crm_AccountProducts.findUnique>;
+const apUpdate = prismadb.crm_AccountProducts.update as jest.MockedFunction<typeof prismadb.crm_AccountProducts.update>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  apFindUnique.mockResolvedValue({ id: "ap1", accountId: "a1" } as any);
+  apUpdate.mockResolvedValue({ id: "ap1" } as any);
+});
+
+describe("removeAssignment account write scope", () => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await removeAssignment("ap1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(apUpdate).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when user out of account scope", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue(null);
+    const res = await removeAssignment("ap1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(apUpdate).not.toHaveBeenCalled();
+  });
+
+  it("user in scope succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue({ id: "a1" } as any);
+    const res = await removeAssignment("ap1");
+    expect(res).toMatchObject({ data: { id: "ap1" } });
+    expect(apUpdate).toHaveBeenCalled();
+  });
+
+  it("manager succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    const res = await removeAssignment("ap1");
+    expect(res).toMatchObject({ data: { id: "ap1" } });
+    expect(apUpdate).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/account-products/__tests__/update-assignment-scope.test.ts
+++ b/actions/crm/account-products/__tests__/update-assignment-scope.test.ts
@@ -1,0 +1,69 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_AccountProducts: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({
+  writeAuditLog: jest.fn(),
+  diffObjects: jest.fn().mockReturnValue([]),
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { updateAssignment } from "../update-assignment";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const accFind = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const apFindUnique = prismadb.crm_AccountProducts.findUnique as jest.MockedFunction<typeof prismadb.crm_AccountProducts.findUnique>;
+const apUpdate = prismadb.crm_AccountProducts.update as jest.MockedFunction<typeof prismadb.crm_AccountProducts.update>;
+
+const validInput = { id: "ap1", quantity: 5 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  apFindUnique.mockResolvedValue({ id: "ap1", accountId: "a1", start_date: new Date("2026-01-01") } as any);
+  apUpdate.mockResolvedValue({ id: "ap1" } as any);
+});
+
+describe("updateAssignment account write scope", () => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await updateAssignment(validInput);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(apUpdate).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when user out of account scope", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue(null);
+    const res = await updateAssignment(validInput);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(apUpdate).not.toHaveBeenCalled();
+  });
+
+  it("user in scope succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    accFind.mockResolvedValue({ id: "a1" } as any);
+    const res = await updateAssignment(validInput);
+    expect(res).toMatchObject({ data: { id: "ap1" } });
+    expect(apUpdate).toHaveBeenCalled();
+  });
+
+  it("manager succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    const res = await updateAssignment(validInput);
+    expect(res).toMatchObject({ data: { id: "ap1" } });
+    expect(apUpdate).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/account-products/assign-product/index.ts
+++ b/actions/crm/account-products/assign-product/index.ts
@@ -1,6 +1,11 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { AssignProduct } from "./schema";
 import { InputType, ReturnType } from "./types";
 import { createSafeAction } from "@/lib/create-safe-action";
@@ -9,13 +14,24 @@ import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
 import { revalidatePath } from "next/cache";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  const { accountId, productId, quantity, custom_price, currency, status, start_date, end_date, renewal_date, notes } = data;
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
   }
 
-  const userId = session.user.id;
-  const { accountId, productId, quantity, custom_price, currency, status, start_date, end_date, renewal_date, notes } = data;
+  try {
+    await assertCanWriteAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  const userId = user.id;
 
   try {
     const product = await prismadb.crm_Products.findUnique({ where: { id: productId } });

--- a/actions/crm/account-products/get-account-products.ts
+++ b/actions/crm/account-products/get-account-products.ts
@@ -1,7 +1,27 @@
 import { cache } from "react";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getAccountProducts = cache(async (accountId: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+  try {
+    await assertCanReadAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
+
   const assignments = await prismadb.crm_AccountProducts.findMany({
     where: { accountId },
     include: {

--- a/actions/crm/account-products/remove-assignment/index.ts
+++ b/actions/crm/account-products/remove-assignment/index.ts
@@ -1,13 +1,36 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 
 export const removeAssignment = async (id: string) => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  const existing = await prismadb.crm_AccountProducts.findUnique({
+    where: { id },
+    select: { accountId: true },
+  });
+  if (!existing) {
+    return { error: "Not found" };
+  }
+
+  try {
+    await assertCanWriteAccount(user, existing.accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {
@@ -15,12 +38,12 @@ export const removeAssignment = async (id: string) => {
       where: { id },
       data: {
         status: "CANCELLED",
-        updatedBy: session.user.id,
+        updatedBy: user.id,
         v: { increment: 1 },
       },
     });
 
-    await writeAuditLog({ entityType: "account_product", entityId: id, action: "cancelled", changes: null, userId: session.user.id });
+    await writeAuditLog({ entityType: "account_product", entityId: id, action: "cancelled", changes: null, userId: user.id });
 
     revalidatePath("/[locale]/(routes)/crm/accounts/[accountId]", "page");
     revalidatePath("/[locale]/(routes)/crm/products/[productId]", "page");

--- a/actions/crm/account-products/update-assignment/index.ts
+++ b/actions/crm/account-products/update-assignment/index.ts
@@ -1,6 +1,11 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { UpdateAssignment } from "./schema";
 import { InputType, ReturnType } from "./types";
 import { createSafeAction } from "@/lib/create-safe-action";
@@ -8,19 +13,30 @@ import { writeAuditLog, diffObjects } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
   }
 
-  const userId = session.user.id;
+  const userId = user.id;
   const { id, ...updateData } = data;
 
+  const existing = await prismadb.crm_AccountProducts.findUnique({ where: { id } });
+  if (!existing) {
+    return { error: "Assignment not found" };
+  }
+
   try {
-    const existing = await prismadb.crm_AccountProducts.findUnique({ where: { id } });
-    if (!existing) {
-      return { error: "Assignment not found" };
-    }
+    await assertCanWriteAccount(user, existing.accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  try {
 
     const startDate = updateData.start_date ?? existing.start_date;
     if (updateData.end_date && updateData.end_date <= startDate) {

--- a/actions/crm/products/__tests__/create-product-scope.test.ts
+++ b/actions/crm/products/__tests__/create-product-scope.test.ts
@@ -1,0 +1,69 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Products: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { createProduct } from "../create-product";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const create = prismadb.crm_Products.create as jest.MockedFunction<typeof prismadb.crm_Products.create>;
+const findProd = prismadb.crm_Products.findUnique as jest.MockedFunction<typeof prismadb.crm_Products.findUnique>;
+
+const validInput = {
+  name: "Widget",
+  type: "PRODUCT" as const,
+  status: "DRAFT" as const,
+  unit_price: "10.00",
+  currency: "USD",
+  is_recurring: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findProd.mockResolvedValue(null as any);
+  create.mockResolvedValue({ id: "p1", name: "Widget" } as any);
+});
+
+describe("createProduct role gate", () => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await createProduct(validInput);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when user role", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const res = await createProduct(validInput);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("manager succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    const res = await createProduct(validInput);
+    expect(res).toMatchObject({ data: { id: "p1" } });
+    expect(create).toHaveBeenCalled();
+  });
+
+  it("admin succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "a" } } as any);
+    fu.mockResolvedValue({ id: "a", role: "admin" } as any);
+    const res = await createProduct(validInput);
+    expect(res).toMatchObject({ data: { id: "p1" } });
+    expect(create).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/products/__tests__/delete-product-scope.test.ts
+++ b/actions/crm/products/__tests__/delete-product-scope.test.ts
@@ -1,0 +1,55 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Products: { update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { deleteProduct } from "../delete-product";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const upd = prismadb.crm_Products.update as jest.MockedFunction<typeof prismadb.crm_Products.update>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  upd.mockResolvedValue({ id: "p1" } as any);
+});
+
+describe("deleteProduct role gate", () => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await deleteProduct("p1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when user role", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const res = await deleteProduct("p1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("manager succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    const res = await deleteProduct("p1");
+    expect(res).toMatchObject({ data: { id: "p1" } });
+    expect(upd).toHaveBeenCalled();
+  });
+
+  it("admin succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "a" } } as any);
+    fu.mockResolvedValue({ id: "a", role: "admin" } as any);
+    const res = await deleteProduct("p1");
+    expect(res).toMatchObject({ data: { id: "p1" } });
+    expect(upd).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/products/__tests__/get-product-scope.test.ts
+++ b/actions/crm/products/__tests__/get-product-scope.test.ts
@@ -1,0 +1,37 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Products: { findUnique: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getProduct } from "../get-product";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const findProd = prismadb.crm_Products.findUnique as jest.MockedFunction<typeof prismadb.crm_Products.findUnique>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("getProduct auth gate", () => {
+  it("returns null when unauthenticated", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await getProduct("p1");
+    expect(res).toBeNull();
+    expect(findProd).not.toHaveBeenCalled();
+  });
+
+  it("returns row when authenticated", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    findProd.mockResolvedValue({ id: "p1", name: "Widget" } as any);
+    const res = await getProduct("p1");
+    expect(res).toMatchObject({ id: "p1" });
+    expect(findProd).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/products/__tests__/get-products-scope.test.ts
+++ b/actions/crm/products/__tests__/get-products-scope.test.ts
@@ -1,0 +1,37 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Products: { findMany: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getProductsFull } from "../get-products";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const findMany = prismadb.crm_Products.findMany as jest.MockedFunction<typeof prismadb.crm_Products.findMany>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("getProductsFull auth gate", () => {
+  it("returns [] when unauthenticated", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await getProductsFull();
+    expect(res).toEqual([]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns array when authenticated", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    findMany.mockResolvedValue([{ id: "p1", name: "Widget" }] as any);
+    const res = await getProductsFull();
+    expect(res).toHaveLength(1);
+    expect(findMany).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/products/__tests__/import-products-scope.test.ts
+++ b/actions/crm/products/__tests__/import-products-scope.test.ts
@@ -1,0 +1,68 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_ProductCategories: { findMany: jest.fn().mockResolvedValue([]) },
+    currency: { findMany: jest.fn().mockResolvedValue([{ code: "USD" }]) },
+    crm_Products: {
+      findMany: jest.fn().mockResolvedValue([]),
+      createMany: jest.fn(),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { importProducts } from "../import-products";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const createMany = prismadb.crm_Products.createMany as jest.MockedFunction<typeof prismadb.crm_Products.createMany>;
+
+const csv = "name,type,unit_price,currency\nWidget,PRODUCT,10,USD\n";
+const makeForm = () => {
+  const fd = new FormData();
+  fd.set("file", new File([csv], "p.csv", { type: "text/csv" }));
+  return fd;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (prismadb.crm_ProductCategories.findMany as jest.Mock).mockResolvedValue([]);
+  (prismadb.currency.findMany as jest.Mock).mockResolvedValue([{ code: "USD" }]);
+  (prismadb.crm_Products.findMany as jest.Mock).mockResolvedValue([]);
+  createMany.mockResolvedValue({ count: 1 } as any);
+});
+
+describe("importProducts role gate", () => {
+  it("throws Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    await expect(importProducts(makeForm())).rejects.toThrow("Unauthorized");
+    expect(createMany).not.toHaveBeenCalled();
+  });
+
+  it("throws Forbidden when user role", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    await expect(importProducts(makeForm())).rejects.toThrow("Forbidden");
+    expect(createMany).not.toHaveBeenCalled();
+  });
+
+  it("manager succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    const res = await importProducts(makeForm());
+    expect(res.imported).toBe(1);
+    expect(createMany).toHaveBeenCalled();
+  });
+
+  it("admin succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "a" } } as any);
+    fu.mockResolvedValue({ id: "a", role: "admin" } as any);
+    const res = await importProducts(makeForm());
+    expect(res.imported).toBe(1);
+    expect(createMany).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/products/__tests__/update-product-scope.test.ts
+++ b/actions/crm/products/__tests__/update-product-scope.test.ts
@@ -1,0 +1,65 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Products: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({
+  writeAuditLog: jest.fn(),
+  diffObjects: jest.fn().mockReturnValue([]),
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { updateProduct } from "../update-product";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const findProd = prismadb.crm_Products.findUnique as jest.MockedFunction<typeof prismadb.crm_Products.findUnique>;
+const upd = prismadb.crm_Products.update as jest.MockedFunction<typeof prismadb.crm_Products.update>;
+
+const validInput = { id: "p1", name: "Widget v2" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findProd.mockResolvedValue({ id: "p1", deletedAt: null, sku: null, is_recurring: false, billing_period: null } as any);
+  upd.mockResolvedValue({ id: "p1", name: "Widget v2" } as any);
+});
+
+describe("updateProduct role gate", () => {
+  it("Unauthorized when no session", async () => {
+    gs.mockResolvedValue(null as any);
+    const res = await updateProduct(validInput);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("Forbidden when user role", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    const res = await updateProduct(validInput);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("manager succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    const res = await updateProduct(validInput);
+    expect(res).toMatchObject({ data: { id: "p1" } });
+    expect(upd).toHaveBeenCalled();
+  });
+
+  it("admin succeeds", async () => {
+    gs.mockResolvedValue({ user: { id: "a" } } as any);
+    fu.mockResolvedValue({ id: "a", role: "admin" } as any);
+    const res = await updateProduct(validInput);
+    expect(res).toMatchObject({ data: { id: "p1" } });
+    expect(upd).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/products/create-product/index.ts
+++ b/actions/crm/products/create-product/index.ts
@@ -1,19 +1,23 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { CreateProduct } from "./schema";
 import { InputType, ReturnType } from "./types";
 import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let actor;
+  try {
+    actor = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
-  const userId = session.user.id;
+  const userId = actor.id;
   const {
     name, description, sku, type, status, unit_price, unit_cost,
     currency, tax_rate, unit, is_recurring, billing_period, categoryId,

--- a/actions/crm/products/delete-product/index.ts
+++ b/actions/crm/products/delete-product/index.ts
@@ -1,13 +1,17 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
 
 export const deleteProduct = async (id: string) => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let actor;
+  try {
+    actor = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {
@@ -15,7 +19,7 @@ export const deleteProduct = async (id: string) => {
       where: { id },
       data: {
         deletedAt: new Date(),
-        deletedBy: session.user.id,
+        deletedBy: actor.id,
       },
     });
 
@@ -24,7 +28,7 @@ export const deleteProduct = async (id: string) => {
       entityId: id,
       action: "deleted",
       changes: null,
-      userId: session.user.id,
+      userId: actor.id,
     });
 
     revalidatePath("/[locale]/(routes)/crm/products", "page");

--- a/actions/crm/products/get-product.ts
+++ b/actions/crm/products/get-product.ts
@@ -1,7 +1,14 @@
 import { cache } from "react";
 import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, AuthenticationError } from "@/lib/authz";
 
 export const getProduct = cache(async (id: string) => {
+  try {
+    await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
   const product = await prismadb.crm_Products.findUnique({
     where: { id },
     include: {

--- a/actions/crm/products/get-products.ts
+++ b/actions/crm/products/get-products.ts
@@ -1,7 +1,14 @@
 import { cache } from "react";
 import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, AuthenticationError } from "@/lib/authz";
 
 export const getProductsFull = cache(async () => {
+  try {
+    await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
   const products = await prismadb.crm_Products.findMany({
     where: { deletedAt: null },
     include: {

--- a/actions/crm/products/import-products.ts
+++ b/actions/crm/products/import-products.ts
@@ -1,9 +1,9 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import Papa from "papaparse";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
 
 const REQUIRED_FIELDS = ["name", "type", "unit_price", "currency"];
 const MAX_ROWS = 500;
@@ -11,10 +11,16 @@ const MAX_ROWS = 500;
 export async function importProducts(
   formData: FormData
 ): Promise<{ imported: number; skipped: number; errors: string[] }> {
-  const session = await getSession();
-  if (!session?.user?.id) throw new Error("Unauthorized");
+  let actor;
+  try {
+    actor = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
 
-  const userId = session.user.id;
+  const userId = actor.id;
   const file = formData.get("file") as File | null;
   if (!file) throw new Error("No file provided");
 

--- a/actions/crm/products/update-product/index.ts
+++ b/actions/crm/products/update-product/index.ts
@@ -1,19 +1,23 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { UpdateProduct } from "./schema";
 import { InputType, ReturnType } from "./types";
 import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog, diffObjects } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let actor;
+  try {
+    actor = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
-  const userId = session.user.id;
+  const userId = actor.id;
   const { id, ...updateData } = data;
 
   try {

--- a/actions/invoices/__tests__/get-invoices-by-accountId-scope.test.ts
+++ b/actions/invoices/__tests__/get-invoices-by-accountId-scope.test.ts
@@ -1,0 +1,59 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    invoices: { findMany: jest.fn() },
+  },
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { getInvoicesByAccountId } from "../get-invoices-by-accountId";
+
+const gs = getSession as jest.MockedFunction<typeof getSession>;
+const fu = prismadb.users.findUnique as jest.MockedFunction<typeof prismadb.users.findUnique>;
+const fa = prismadb.crm_Accounts.findFirst as jest.MockedFunction<typeof prismadb.crm_Accounts.findFirst>;
+const fm = prismadb.invoices.findMany as jest.MockedFunction<typeof prismadb.invoices.findMany>;
+
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("getInvoicesByAccountId scope", () => {
+  it("returns [] when unauthenticated", async () => {
+    gs.mockResolvedValue(null as any);
+    const r = await getInvoicesByAccountId(ACCOUNT_ID);
+    expect(r).toEqual([]);
+    expect(fm).not.toHaveBeenCalled();
+  });
+
+  it("returns [] for out-of-scope user", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue(null);
+    const r = await getInvoicesByAccountId(ACCOUNT_ID);
+    expect(r).toEqual([]);
+    expect(fm).not.toHaveBeenCalled();
+  });
+
+  it("returns list for in-scope user", async () => {
+    gs.mockResolvedValue({ user: { id: "u" } } as any);
+    fu.mockResolvedValue({ id: "u", role: "user" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID } as any);
+    fm.mockResolvedValue([{ id: "i1" }] as any);
+    const r = await getInvoicesByAccountId(ACCOUNT_ID);
+    expect(r).toEqual([{ id: "i1" }]);
+    expect(fm).toHaveBeenCalledTimes(1);
+  });
+
+  it("manager gets list", async () => {
+    gs.mockResolvedValue({ user: { id: "m" } } as any);
+    fu.mockResolvedValue({ id: "m", role: "manager" } as any);
+    fa.mockResolvedValue({ id: ACCOUNT_ID } as any);
+    fm.mockResolvedValue([{ id: "i1" }, { id: "i2" }] as any);
+    const r = await getInvoicesByAccountId(ACCOUNT_ID);
+    expect(r).toHaveLength(2);
+    expect(fm).toHaveBeenCalled();
+  });
+});

--- a/actions/invoices/get-invoices-by-accountId.ts
+++ b/actions/invoices/get-invoices-by-accountId.ts
@@ -1,6 +1,26 @@
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export async function getInvoicesByAccountId(accountId: string) {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+  try {
+    await assertCanReadAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
+
   return prismadb.invoices.findMany({
     where: { accountId },
     orderBy: { createdAt: "desc" },


### PR DESCRIPTION
## Summary

Adds role-based authorization to the products module, account-product assignments, and the last unscoped invoice read action (`get-invoices-by-accountId`). Bundles three small areas because they share account-scope helpers shipped in D1/D2/B2.

**Product policy applied (spec §15.2 default):** Products are catalog data shared across accounts → mutations are **manager/admin only**. Reads stay open to any authenticated role.

## What changed

**Product mutations (manager/admin only):**
- `actions/crm/products/{create,update,delete}-product/index.ts` — wrapped via `createSafeAction`; `requireRole(["manager", "admin"])` returns `{error}`
- `actions/crm/products/import-products.ts` — plain async; throws on auth/authz failure (preserves existing throw contract)

**Product reads (any authenticated role):**
- `actions/crm/products/get-product.ts` — `requireAuthenticated` inside `cache()` closure
- `actions/crm/products/get-products.ts` — same pattern; returns `[]` on unauth

**Account-product mutations (account write scope):**
- `assign-product/index.ts` — `assertCanWriteAccount(user, input.accountId)` before creating
- `update-assignment/index.ts` — load assignment first → `assertCanWriteAccount(user, existing.accountId)`
- `remove-assignment/index.ts` — same load-first pattern

**Account-product + invoice reads (account read scope):**
- `get-account-products.ts` — `requireAuthenticated` + `assertCanReadAccount(user, accountId)` inside `cache()`
- `actions/invoices/get-invoices-by-accountId.ts` — same pattern

## Test status

- 102/108 suites pass, 530/531 tests pass (D3 baseline: 91/97, 490/491)
- 40 new tests across 11 actions
- Same 6 pre-existing suite failures + 1 pre-existing test failure unchanged — no new regressions

## Test plan

- [ ] As `bob` (user), call `createProduct` → `{error: "Forbidden"}`
- [ ] As `bob`, list products → succeeds (catalog read)
- [ ] As `bob`, `getAccountProducts(<alice-account>)` → `[]` (no account access)
- [ ] As `bob`, `assignProduct({ accountId: <alice-account>, ... })` → `{error: "Forbidden"}`
- [ ] As `bob`, `getInvoicesByAccountId(<alice-account>)` → `[]`
- [ ] As `manager`, all the above → succeed

## Out of E1 scope

- **E2**: campaigns + templates (separate decision-point on user can-send/schedule per §15.3 default)
- **E3**: documents
- **E4**: projects (boards/sections/tasks)
- Per-row invoice list scoping inside an accessible account — current pattern returns all invoices in scope-allowed accounts; further per-row filtering is a follow-up

Plan: `docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)