### PR TITLE
fix(security): scope campaigns + templates (Phase E2)

### DIFF
--- a/actions/campaigns/__tests__/create-campaign-scope.test.ts
+++ b/actions/campaigns/__tests__/create-campaign-scope.test.ts
@@ -1,0 +1,72 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { create: jest.fn() },
+    crm_campaign_templates: { findFirst: jest.fn() },
+    crm_TargetLists: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createCampaign } from "@/actions/campaigns/create-campaign";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const baseInput = {
+  name: "C1",
+  target_list_ids: [] as string[],
+  steps: [] as any[],
+};
+
+describe("createCampaign scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized error and never writes", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await createCampaign({ ...baseInput });
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaigns.create).not.toHaveBeenCalled();
+  });
+
+  it("user creates campaign with created_by = user.id", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.create as jest.Mock).mockResolvedValue({ id: "c1" });
+    await createCampaign({ ...baseInput });
+    expect(prismadb.crm_campaigns.create).toHaveBeenCalledTimes(1);
+    const call = (prismadb.crm_campaigns.create as jest.Mock).mock.calls[0][0];
+    expect(call.data.created_by).toBe("u1");
+    expect(call.data.created_by).not.toBeNull();
+  });
+
+  it("manager creates campaign successfully", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.create as jest.Mock).mockResolvedValue({ id: "c2" });
+    await createCampaign({ ...baseInput });
+    const call = (prismadb.crm_campaigns.create as jest.Mock).mock.calls[0][0];
+    expect(call.data.created_by).toBe("m1");
+  });
+
+  it("user references unreadable template_id returns Forbidden, no write", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await createCampaign({ ...baseInput, template_id: "t1" });
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.crm_campaigns.create).not.toHaveBeenCalled();
+  });
+
+  it("user references unreadable target_list_ids returns Forbidden, no write", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_TargetLists.findMany as jest.Mock).mockResolvedValue([{ id: "tl1" }]);
+    const res = await createCampaign({
+      ...baseInput,
+      target_list_ids: ["tl1", "tl2"],
+    });
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.crm_campaigns.create).not.toHaveBeenCalled();
+  });
+});

--- a/actions/campaigns/__tests__/delete-campaign-scope.test.ts
+++ b/actions/campaigns/__tests__/delete-campaign-scope.test.ts
@@ -1,0 +1,52 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { deleteCampaign } from "@/actions/campaigns/delete-campaign";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("deleteCampaign scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized, no update", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await deleteCampaign("c1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns Not found, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await deleteCampaign("c1");
+    expect(res).toEqual({ error: "Not found" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: soft-deletes", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await deleteCampaign("c1");
+    const call = (prismadb.crm_campaigns.update as jest.Mock).mock.calls[0][0];
+    expect(call.data.status).toBe("deleted");
+  });
+
+  it("manager: soft-deletes", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await deleteCampaign("c1");
+    expect(prismadb.crm_campaigns.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/campaigns/__tests__/get-campaign-scope.test.ts
+++ b/actions/campaigns/__tests__/get-campaign-scope.test.ts
@@ -1,0 +1,62 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { findFirst: jest.fn(), findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getCampaign } from "@/actions/campaigns/get-campaign";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getCampaign scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns null and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getCampaign("c1");
+    expect(res).toBeNull();
+    expect(prismadb.crm_campaigns.findFirst).not.toHaveBeenCalled();
+    expect(prismadb.crm_campaigns.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns null (assert miss)", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getCampaign("c1");
+    expect(res).toBeNull();
+    expect(prismadb.crm_campaigns.findFirst).toHaveBeenCalledTimes(1);
+    expect(prismadb.crm_campaigns.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope: assert passes, returns detail", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    const detail = { id: "c1", name: "Spring blast" };
+    (prismadb.crm_campaigns.findUnique as jest.Mock).mockResolvedValue(detail);
+    const res = await getCampaign("c1");
+    expect(res).toEqual(detail);
+    const assertCall = (prismadb.crm_campaigns.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.id).toBe("c1");
+    expect(assertCall.where.created_by).toBe("u1");
+    expect(assertCall.where.status).toEqual({ not: "deleted" });
+  });
+
+  it("manager: assert where has no created_by, detail returned", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    const detail = { id: "c1" };
+    (prismadb.crm_campaigns.findUnique as jest.Mock).mockResolvedValue(detail);
+    const res = await getCampaign("c1");
+    expect(res).toEqual(detail);
+    const assertCall = (prismadb.crm_campaigns.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.created_by).toBeUndefined();
+    expect(assertCall.where.status).toEqual({ not: "deleted" });
+  });
+});

--- a/actions/campaigns/__tests__/get-campaigns-scope.test.ts
+++ b/actions/campaigns/__tests__/get-campaigns-scope.test.ts
@@ -1,0 +1,53 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getCampaigns } from "@/actions/campaigns/get-campaigns";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getCampaigns scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getCampaigns();
+    expect(res).toEqual([]);
+    expect(prismadb.crm_campaigns.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where scoped by created_by and status not deleted", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findMany as jest.Mock).mockResolvedValue([]);
+    await getCampaigns();
+    const call = (prismadb.crm_campaigns.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.created_by).toBe("u1");
+    expect(call.where.status).toEqual({ not: "deleted" });
+  });
+
+  it("manager: where = { status: { not: 'deleted' } } (no created_by)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.findMany as jest.Mock).mockResolvedValue([]);
+    await getCampaigns();
+    const call = (prismadb.crm_campaigns.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ status: { not: "deleted" } });
+    expect(call.where.created_by).toBeUndefined();
+  });
+
+  it("returns rows from findMany", async () => {
+    mockUser("user", "u1");
+    const rows = [{ id: "c1" }];
+    (prismadb.crm_campaigns.findMany as jest.Mock).mockResolvedValue(rows);
+    const res = await getCampaigns();
+    expect(res).toEqual(rows);
+  });
+});

--- a/actions/campaigns/__tests__/pause-campaign-scope.test.ts
+++ b/actions/campaigns/__tests__/pause-campaign-scope.test.ts
@@ -1,0 +1,52 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { pauseCampaign } from "@/actions/campaigns/pause-campaign";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("pauseCampaign scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized, no update", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await pauseCampaign("c1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns Not found, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await pauseCampaign("c1");
+    expect(res).toEqual({ error: "Not found" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: pauses", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await pauseCampaign("c1");
+    const call = (prismadb.crm_campaigns.update as jest.Mock).mock.calls[0][0];
+    expect(call.data.status).toBe("paused");
+  });
+
+  it("manager: pauses", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await pauseCampaign("c1");
+    expect(prismadb.crm_campaigns.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/campaigns/__tests__/schedule-campaign-scope.test.ts
+++ b/actions/campaigns/__tests__/schedule-campaign-scope.test.ts
@@ -1,0 +1,66 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({}) },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { inngest } from "@/inngest/client";
+import { scheduleCampaign } from "@/actions/campaigns/schedule-campaign";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("scheduleCampaign scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const when = new Date("2026-06-01T00:00:00Z");
+
+  it("unauthenticated returns Unauthorized, no update / no inngest", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await scheduleCampaign("c1", when);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+    expect(inngest.send).not.toHaveBeenCalled();
+  });
+
+  it("user role returns Forbidden, no update / no inngest", async () => {
+    mockUser("user", "u1");
+    const res = await scheduleCampaign("c1", when);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+    expect(inngest.send).not.toHaveBeenCalled();
+  });
+
+  it("manager: schedules and emits inngest event", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await scheduleCampaign("c1", when);
+    expect(prismadb.crm_campaigns.findFirst).toHaveBeenCalled();
+    const call = (prismadb.crm_campaigns.update as jest.Mock).mock.calls[0][0];
+    expect(call.data.status).toBe("scheduled");
+    expect(call.data.scheduled_at).toBe(when);
+    expect(inngest.send).toHaveBeenCalledWith({
+      name: "campaigns/schedule",
+      data: { campaignId: "c1", scheduledAt: when.toISOString() },
+    });
+  });
+
+  it("admin: schedules and emits inngest event", async () => {
+    mockUser("admin", "a1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await scheduleCampaign("c1", when);
+    expect(prismadb.crm_campaigns.update).toHaveBeenCalledTimes(1);
+    expect(inngest.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/campaigns/__tests__/send-campaign-now-scope.test.ts
+++ b/actions/campaigns/__tests__/send-campaign-now-scope.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({}) },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { inngest } from "@/inngest/client";
+import { sendCampaignNow } from "@/actions/campaigns/send-campaign-now";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("sendCampaignNow scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized, no update / no inngest", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await sendCampaignNow("c1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+    expect(inngest.send).not.toHaveBeenCalled();
+  });
+
+  it("user role returns Forbidden, no update / no inngest", async () => {
+    mockUser("user", "u1");
+    const res = await sendCampaignNow("c1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+    expect(inngest.send).not.toHaveBeenCalled();
+  });
+
+  it("manager: sends and emits inngest event", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await sendCampaignNow("c1");
+    expect(prismadb.crm_campaigns.findFirst).toHaveBeenCalled();
+    const call = (prismadb.crm_campaigns.update as jest.Mock).mock.calls[0][0];
+    expect(call.data.status).toBe("sending");
+    expect(inngest.send).toHaveBeenCalledWith({
+      name: "campaigns/send-now",
+      data: { campaignId: "c1" },
+    });
+  });
+
+  it("admin: sends and emits inngest event", async () => {
+    mockUser("admin", "a1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await sendCampaignNow("c1");
+    expect(prismadb.crm_campaigns.update).toHaveBeenCalledTimes(1);
+    expect(inngest.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/campaigns/__tests__/update-campaign-scope.test.ts
+++ b/actions/campaigns/__tests__/update-campaign-scope.test.ts
@@ -1,0 +1,51 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaigns: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { updateCampaign } from "@/actions/campaigns/update-campaign";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("updateCampaign scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized, no update", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await updateCampaign("c1", { name: "x" });
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns Not found, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await updateCampaign("c1", { name: "x" });
+    expect(res).toEqual({ error: "Not found" });
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: updates", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await updateCampaign("c1", { name: "x" });
+    expect(prismadb.crm_campaigns.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("manager: updates", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await updateCampaign("c1", { name: "x" });
+    expect(prismadb.crm_campaigns.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/campaigns/create-campaign.ts
+++ b/actions/campaigns/create-campaign.ts
@@ -1,6 +1,12 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadTemplate,
+  targetListReadScopeWhere,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 type StepInput = {
   order: number;
@@ -20,7 +26,36 @@ export const createCampaign = async (data: {
   steps: StepInput[];
   scheduled_at?: Date;
 }) => {
-  const session = await getSession();
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  if (data.template_id) {
+    try {
+      await assertCanReadTemplate(user, data.template_id);
+    } catch (e) {
+      if (e instanceof AuthorizationError) return { error: "Forbidden" };
+      throw e;
+    }
+  }
+
+  if (data.target_list_ids?.length) {
+    const accessible = await prismadb.crm_TargetLists.findMany({
+      where: {
+        id: { in: data.target_list_ids },
+        ...targetListReadScopeWhere(user),
+      },
+      select: { id: true },
+    });
+    if (accessible.length !== data.target_list_ids.length) {
+      return { error: "Forbidden" };
+    }
+  }
+
   const { target_list_ids, steps, ...campaignData } = data;
 
   return prismadb.crm_campaigns.create({
@@ -28,7 +63,7 @@ export const createCampaign = async (data: {
       ...campaignData,
       v: 0,
       status: data.scheduled_at ? "scheduled" : "draft",
-      created_by: session?.user?.id ?? null,
+      created_by: user.id,
       target_lists: {
         create: target_list_ids.map((id) => ({ target_list_id: id })),
       },

--- a/actions/campaigns/delete-campaign.ts
+++ b/actions/campaigns/delete-campaign.ts
@@ -1,6 +1,27 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteCampaign,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteCampaign = async (id: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  try {
+    await assertCanWriteCampaign(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+
   return prismadb.crm_campaigns.update({ where: { id }, data: { status: "deleted" } });
 };

--- a/actions/campaigns/get-campaign.ts
+++ b/actions/campaigns/get-campaign.ts
@@ -1,7 +1,28 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadCampaign,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getCampaign = async (id: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
+
+  try {
+    await assertCanReadCampaign(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+
   return prismadb.crm_campaigns.findUnique({
     where: { id },
     include: {

--- a/actions/campaigns/get-campaigns.ts
+++ b/actions/campaigns/get-campaigns.ts
@@ -1,10 +1,23 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  campaignReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getCampaigns = async (filters?: { status?: string; search?: string }) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
   return prismadb.crm_campaigns.findMany({
     where: {
-      status: { not: "deleted" },
+      ...campaignReadScopeWhere(user),
       ...(filters?.status ? { status: filters.status } : {}),
       ...(filters?.search ? { name: { contains: filters.search, mode: "insensitive" } } : {}),
     },

--- a/actions/campaigns/pause-campaign.ts
+++ b/actions/campaigns/pause-campaign.ts
@@ -1,7 +1,28 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteCampaign,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const pauseCampaign = async (id: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  try {
+    await assertCanWriteCampaign(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+
   return prismadb.crm_campaigns.update({
     where: { id },
     data: { status: "paused" },

--- a/actions/campaigns/schedule-campaign.ts
+++ b/actions/campaigns/schedule-campaign.ts
@@ -1,8 +1,30 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
 import { inngest } from "@/inngest/client";
+import {
+  requireRole,
+  assertCanReadCampaign,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const scheduleCampaign = async (id: string, scheduledAt: Date) => {
+  let user;
+  try {
+    user = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  try {
+    await assertCanReadCampaign(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+
   const campaign = await prismadb.crm_campaigns.update({
     where: { id },
     data: {

--- a/actions/campaigns/send-campaign-now.ts
+++ b/actions/campaigns/send-campaign-now.ts
@@ -1,8 +1,30 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
 import { inngest } from "@/inngest/client";
+import {
+  requireRole,
+  assertCanReadCampaign,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const sendCampaignNow = async (id: string) => {
+  let user;
+  try {
+    user = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  try {
+    await assertCanReadCampaign(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+
   const now = new Date();
   await prismadb.crm_campaigns.update({
     where: { id },

--- a/actions/campaigns/templates/__tests__/create-template-scope.test.ts
+++ b/actions/campaigns/templates/__tests__/create-template-scope.test.ts
@@ -1,0 +1,60 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaign_templates: { create: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createTemplate } from "@/actions/campaigns/templates/create-template";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const baseInput = {
+  name: "T1",
+  content_html: "<p>x</p>",
+  content_json: {},
+};
+
+describe("createTemplate scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized error and never writes", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await createTemplate({ ...baseInput });
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaign_templates.create).not.toHaveBeenCalled();
+  });
+
+  it("user creates template with created_by = user.id", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.create as jest.Mock).mockResolvedValue({ id: "t1" });
+    await createTemplate({ ...baseInput });
+    const call = (prismadb.crm_campaign_templates.create as jest.Mock).mock.calls[0][0];
+    expect(call.data.created_by).toBe("u1");
+    expect(call.data.created_by).not.toBeNull();
+  });
+
+  it("manager creates template successfully with created_by set", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaign_templates.create as jest.Mock).mockResolvedValue({ id: "t2" });
+    await createTemplate({ ...baseInput });
+    const call = (prismadb.crm_campaign_templates.create as jest.Mock).mock.calls[0][0];
+    expect(call.data.created_by).toBe("m1");
+    expect(call.data.created_by).not.toBeNull();
+  });
+
+  it("created_by is never null when authenticated", async () => {
+    mockUser("admin", "a1");
+    (prismadb.crm_campaign_templates.create as jest.Mock).mockResolvedValue({ id: "t3" });
+    await createTemplate({ ...baseInput });
+    const call = (prismadb.crm_campaign_templates.create as jest.Mock).mock.calls[0][0];
+    expect(call.data.created_by).toBe("a1");
+    expect(call.data.created_by).not.toBeNull();
+  });
+});

--- a/actions/campaigns/templates/__tests__/delete-template-scope.test.ts
+++ b/actions/campaigns/templates/__tests__/delete-template-scope.test.ts
@@ -1,0 +1,54 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaign_templates: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { deleteTemplate } from "@/actions/campaigns/templates/delete-template";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("deleteTemplate scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized, no update", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await deleteTemplate("t1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaign_templates.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns Not found, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await deleteTemplate("t1");
+    expect(res).toEqual({ error: "Not found" });
+    expect(prismadb.crm_campaign_templates.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: soft-deletes with deletedBy = user.id", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.crm_campaign_templates.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    await deleteTemplate("t1");
+    const call = (prismadb.crm_campaign_templates.update as jest.Mock).mock.calls[0][0];
+    expect(call.data.deletedBy).toBe("u1");
+    expect(call.data.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it("manager: soft-deletes", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.crm_campaign_templates.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    await deleteTemplate("t1");
+    const call = (prismadb.crm_campaign_templates.update as jest.Mock).mock.calls[0][0];
+    expect(call.data.deletedBy).toBe("m1");
+  });
+});

--- a/actions/campaigns/templates/__tests__/generate-template-scope.test.ts
+++ b/actions/campaigns/templates/__tests__/generate-template-scope.test.ts
@@ -1,0 +1,65 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+  },
+}));
+jest.mock("@/lib/api-keys", () => ({ getApiKey: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getApiKey } from "@/lib/api-keys";
+import { generateTemplate } from "@/actions/campaigns/templates/generate-template";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const mockFetchOk = () => {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content: JSON.stringify({ subject: "S", html: "<p>H</p>" }) } }],
+    }),
+  });
+};
+
+describe("generateTemplate scope", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getApiKey as jest.Mock).mockResolvedValue("sk-test");
+  });
+
+  it("unauthenticated throws Unauthorized and never calls fetch", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    (global as any).fetch = jest.fn();
+    await expect(generateTemplate("p")).rejects.toThrow();
+    expect((global as any).fetch).not.toHaveBeenCalled();
+  });
+
+  it("user generates template; getApiKey called with user.id", async () => {
+    mockUser("user", "u1");
+    mockFetchOk();
+    const res = await generateTemplate("write a welcome");
+    expect(res.subject).toBe("S");
+    expect(res.html).toBe("<p>H</p>");
+    expect(getApiKey).toHaveBeenCalledWith("OPENAI", "u1");
+  });
+
+  it("manager generates template", async () => {
+    mockUser("manager", "m1");
+    mockFetchOk();
+    const res = await generateTemplate("p");
+    expect(res.subject).toBe("S");
+    expect(getApiKey).toHaveBeenCalledWith("OPENAI", "m1");
+  });
+
+  it("admin generates template", async () => {
+    mockUser("admin", "a1");
+    mockFetchOk();
+    const res = await generateTemplate("p");
+    expect(res.subject).toBe("S");
+    expect(getApiKey).toHaveBeenCalledWith("OPENAI", "a1");
+  });
+});

--- a/actions/campaigns/templates/__tests__/get-template-scope.test.ts
+++ b/actions/campaigns/templates/__tests__/get-template-scope.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaign_templates: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTemplate } from "@/actions/campaigns/templates/get-template";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTemplate scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns null and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTemplate("t1");
+    expect(res).toBeNull();
+    expect(prismadb.crm_campaign_templates.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns null (assert miss)", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getTemplate("t1");
+    expect(res).toBeNull();
+  });
+
+  it("user in-scope owner: returns detail", async () => {
+    mockUser("user", "u1");
+    const detail = { id: "t1", name: "Welcome" };
+    // First call = assert (scoped where), second call = detail
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock)
+      .mockResolvedValueOnce({ id: "t1" })
+      .mockResolvedValueOnce(detail);
+    const res = await getTemplate("t1");
+    expect(res).toEqual(detail);
+    const assertCall = (prismadb.crm_campaign_templates.findFirst as jest.Mock)
+      .mock.calls[0][0];
+    expect(assertCall.where.id).toBe("t1");
+    expect(assertCall.where.created_by).toBe("u1");
+    expect(assertCall.where.deletedAt).toBeNull();
+  });
+
+  it("manager: assert where has no created_by, returns detail", async () => {
+    mockUser("manager", "m1");
+    const detail = { id: "t1" };
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock)
+      .mockResolvedValueOnce({ id: "t1" })
+      .mockResolvedValueOnce(detail);
+    const res = await getTemplate("t1");
+    expect(res).toEqual(detail);
+    const assertCall = (prismadb.crm_campaign_templates.findFirst as jest.Mock)
+      .mock.calls[0][0];
+    expect(assertCall.where.created_by).toBeUndefined();
+  });
+});

--- a/actions/campaigns/templates/__tests__/get-templates-scope.test.ts
+++ b/actions/campaigns/templates/__tests__/get-templates-scope.test.ts
@@ -1,0 +1,53 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaign_templates: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTemplates } from "@/actions/campaigns/templates/get-templates";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTemplates scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTemplates();
+    expect(res).toEqual([]);
+    expect(prismadb.crm_campaign_templates.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where scoped by created_by and deletedAt null", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.findMany as jest.Mock).mockResolvedValue([]);
+    await getTemplates();
+    const call = (prismadb.crm_campaign_templates.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.created_by).toBe("u1");
+    expect(call.where.deletedAt).toBeNull();
+  });
+
+  it("manager: where has no created_by", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaign_templates.findMany as jest.Mock).mockResolvedValue([]);
+    await getTemplates();
+    const call = (prismadb.crm_campaign_templates.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.created_by).toBeUndefined();
+    expect(call.where.deletedAt).toBeNull();
+  });
+
+  it("returns rows from findMany", async () => {
+    mockUser("user", "u1");
+    const rows = [{ id: "t1" }];
+    (prismadb.crm_campaign_templates.findMany as jest.Mock).mockResolvedValue(rows);
+    const res = await getTemplates();
+    expect(res).toEqual(rows);
+  });
+});

--- a/actions/campaigns/templates/__tests__/update-template-scope.test.ts
+++ b/actions/campaigns/templates/__tests__/update-template-scope.test.ts
@@ -1,0 +1,51 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_campaign_templates: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { updateTemplate } from "@/actions/campaigns/templates/update-template";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("updateTemplate scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized, no update", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await updateTemplate("t1", { name: "x" });
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.crm_campaign_templates.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns Not found, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await updateTemplate("t1", { name: "x" });
+    expect(res).toEqual({ error: "Not found" });
+    expect(prismadb.crm_campaign_templates.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: updates", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.crm_campaign_templates.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    await updateTemplate("t1", { name: "x" });
+    expect(prismadb.crm_campaign_templates.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("manager: updates", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.crm_campaign_templates.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    await updateTemplate("t1", { name: "x" });
+    expect(prismadb.crm_campaign_templates.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/actions/campaigns/templates/create-template.ts
+++ b/actions/campaigns/templates/create-template.ts
@@ -1,6 +1,6 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, AuthenticationError } from "@/lib/authz";
 
 export const createTemplate = async (data: {
   name: string;
@@ -9,8 +9,15 @@ export const createTemplate = async (data: {
   content_html: string;
   content_json: object;
 }) => {
-  const session = await getSession();
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   return prismadb.crm_campaign_templates.create({
-    data: { ...data, created_by: session?.user?.id ?? null },
+    data: { ...data, created_by: user.id },
   });
 };

--- a/actions/campaigns/templates/delete-template.ts
+++ b/actions/campaigns/templates/delete-template.ts
@@ -1,11 +1,30 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteTemplate,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteTemplate = async (id: string) => {
-  const session = await getSession();
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  try {
+    await assertCanWriteTemplate(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+
   return prismadb.crm_campaign_templates.update({
     where: { id },
-    data: { deletedAt: new Date(), deletedBy: session?.user.id },
+    data: { deletedAt: new Date(), deletedBy: user.id },
   });
 };

--- a/actions/campaigns/templates/generate-template.ts
+++ b/actions/campaigns/templates/generate-template.ts
@@ -1,6 +1,6 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { getApiKey } from "@/lib/api-keys";
+import { requireAuthenticated, AuthenticationError } from "@/lib/authz";
 
 export const generateTemplate = async (
   prompt: string
@@ -9,10 +9,15 @@ export const generateTemplate = async (
   json: object;
   subject: string;
 }> => {
-  const session = await getSession();
-  if (!session?.user?.id) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
 
-  const apiKey = await getApiKey("OPENAI", session.user.id);
+  const apiKey = await getApiKey("OPENAI", user.id);
   if (!apiKey)
     throw new Error(
       "No OpenAI API key configured. Add one in Profile → LLMs."

--- a/actions/campaigns/templates/get-template.ts
+++ b/actions/campaigns/templates/get-template.ts
@@ -1,7 +1,28 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadTemplate,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getTemplate = async (id: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
+
+  try {
+    await assertCanReadTemplate(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+
   return prismadb.crm_campaign_templates.findFirst({
     where: { id, deletedAt: null },
     include: { created_by_user: { select: { name: true } } },

--- a/actions/campaigns/templates/get-templates.ts
+++ b/actions/campaigns/templates/get-templates.ts
@@ -1,9 +1,22 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  campaignTemplateReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getTemplates = async () => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
   return prismadb.crm_campaign_templates.findMany({
-    where: { deletedAt: null },
+    where: campaignTemplateReadScopeWhere(user),
     orderBy: { created_on: "desc" },
     include: { created_by_user: { select: { name: true } } },
   });

--- a/actions/campaigns/templates/update-template.ts
+++ b/actions/campaigns/templates/update-template.ts
@@ -1,5 +1,11 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteTemplate,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateTemplate = async (
   id: string,
@@ -11,8 +17,20 @@ export const updateTemplate = async (
     content_json: object;
   }>
 ) => {
-  // Only update non-deleted templates
-  const existing = await prismadb.crm_campaign_templates.findFirst({ where: { id, deletedAt: null } });
-  if (!existing) return null;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  try {
+    await assertCanWriteTemplate(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+
   return prismadb.crm_campaign_templates.update({ where: { id }, data });
 };

--- a/actions/campaigns/update-campaign.ts
+++ b/actions/campaigns/update-campaign.ts
@@ -1,5 +1,11 @@
 "use server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteCampaign,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateCampaign = async (
   id: string,
@@ -12,5 +18,20 @@ export const updateCampaign = async (
     scheduled_at: Date;
   }>
 ) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  try {
+    await assertCanWriteCampaign(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Not found" };
+    throw e;
+  }
+
   return prismadb.crm_campaigns.update({ where: { id }, data });
 };

--- a/lib/authz/__tests__/scopes-crm-campaign-read.test.ts
+++ b/lib/authz/__tests__/scopes-crm-campaign-read.test.ts
@@ -1,0 +1,146 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_campaigns: { findFirst: jest.fn() },
+    crm_campaign_templates: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  campaignReadScopeWhere,
+  campaignTemplateReadScopeWhere,
+  assertCanReadCampaign,
+  assertCanWriteCampaign,
+  assertCanReadTemplate,
+  assertCanWriteTemplate,
+} from "../scopes/crm";
+
+const findCampaign = prismadb.crm_campaigns.findFirst as jest.MockedFunction<
+  typeof prismadb.crm_campaigns.findFirst
+>;
+const findTemplate = prismadb.crm_campaign_templates
+  .findFirst as jest.MockedFunction<
+  typeof prismadb.crm_campaign_templates.findFirst
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("campaignReadScopeWhere", () => {
+  it("admin/manager → { status: { not: 'deleted' } }", () => {
+    expect(campaignReadScopeWhere({ id: "x", role: "admin" })).toEqual({
+      status: { not: "deleted" },
+    });
+    expect(campaignReadScopeWhere({ id: "x", role: "manager" })).toEqual({
+      status: { not: "deleted" },
+    });
+  });
+  it("user → { status: { not: 'deleted' }, created_by: user.id }", () => {
+    expect(campaignReadScopeWhere({ id: "u1", role: "user" })).toEqual({
+      status: { not: "deleted" },
+      created_by: "u1",
+    });
+  });
+});
+
+describe("campaignTemplateReadScopeWhere", () => {
+  it("admin/manager → { deletedAt: null }", () => {
+    expect(
+      campaignTemplateReadScopeWhere({ id: "x", role: "admin" }),
+    ).toEqual({ deletedAt: null });
+    expect(
+      campaignTemplateReadScopeWhere({ id: "x", role: "manager" }),
+    ).toEqual({ deletedAt: null });
+  });
+  it("user → { deletedAt: null, created_by: user.id }", () => {
+    expect(campaignTemplateReadScopeWhere({ id: "u1", role: "user" })).toEqual({
+      deletedAt: null,
+      created_by: "u1",
+    });
+  });
+});
+
+describe("assertCanReadCampaign", () => {
+  it("admin: where { id, status:{not:'deleted'} } (200)", async () => {
+    findCampaign.mockResolvedValue({ id: "c1" } as any);
+    await assertCanReadCampaign({ id: "x", role: "admin" }, "c1");
+    expect(findCampaign).toHaveBeenCalledWith({
+      where: { id: "c1", status: { not: "deleted" } },
+      select: { id: true },
+    });
+  });
+  it("user: where merges created_by scope (200 hit)", async () => {
+    findCampaign.mockResolvedValue({ id: "c1" } as any);
+    await assertCanReadCampaign({ id: "u1", role: "user" }, "c1");
+    expect(findCampaign).toHaveBeenCalledWith({
+      where: { id: "c1", status: { not: "deleted" }, created_by: "u1" },
+      select: { id: true },
+    });
+  });
+  it("throws AuthorizationError on miss (404)", async () => {
+    findCampaign.mockResolvedValue(null);
+    await expect(
+      assertCanReadCampaign({ id: "u1", role: "user" }, "c1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteCampaign", () => {
+  it("delegates to read scope (200)", async () => {
+    findCampaign.mockResolvedValue({ id: "c1" } as any);
+    await assertCanWriteCampaign({ id: "u1", role: "user" }, "c1");
+    expect(findCampaign).toHaveBeenCalledWith({
+      where: { id: "c1", status: { not: "deleted" }, created_by: "u1" },
+      select: { id: true },
+    });
+  });
+  it("throws on miss (404)", async () => {
+    findCampaign.mockResolvedValue(null);
+    await expect(
+      assertCanWriteCampaign({ id: "u1", role: "user" }, "c1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanReadTemplate", () => {
+  it("admin: where { id, deletedAt:null } (200)", async () => {
+    findTemplate.mockResolvedValue({ id: "t1" } as any);
+    await assertCanReadTemplate({ id: "x", role: "admin" }, "t1");
+    expect(findTemplate).toHaveBeenCalledWith({
+      where: { id: "t1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+  it("user: where merges created_by scope (200 hit)", async () => {
+    findTemplate.mockResolvedValue({ id: "t1" } as any);
+    await assertCanReadTemplate({ id: "u1", role: "user" }, "t1");
+    expect(findTemplate).toHaveBeenCalledWith({
+      where: { id: "t1", deletedAt: null, created_by: "u1" },
+      select: { id: true },
+    });
+  });
+  it("throws AuthorizationError on miss (404)", async () => {
+    findTemplate.mockResolvedValue(null);
+    await expect(
+      assertCanReadTemplate({ id: "u1", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteTemplate", () => {
+  it("delegates to read scope (200)", async () => {
+    findTemplate.mockResolvedValue({ id: "t1" } as any);
+    await assertCanWriteTemplate({ id: "u1", role: "user" }, "t1");
+    expect(findTemplate).toHaveBeenCalledWith({
+      where: { id: "t1", deletedAt: null, created_by: "u1" },
+      select: { id: true },
+    });
+  });
+  it("throws on miss (404)", async () => {
+    findTemplate.mockResolvedValue(null);
+    await expect(
+      assertCanWriteTemplate({ id: "u1", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -55,5 +55,13 @@ export {
   assertCanReadTargetList,
 } from "./scopes/crm";
 export { assertCanReadActivityForEntity } from "./scopes/crm";
+export {
+  campaignReadScopeWhere,
+  campaignTemplateReadScopeWhere,
+  assertCanReadCampaign,
+  assertCanWriteCampaign,
+  assertCanReadTemplate,
+  assertCanWriteTemplate,
+} from "./scopes/crm";
 export type { ReportScope } from "./scopes/report-scope";
 export { getReportScope } from "./scopes/report-scope";

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -429,3 +429,60 @@ export async function assertCanReadActivityForEntity(
       return;
   }
 }
+
+// ---------------------------------------------------------------------------
+// E2.T1: Campaign + campaign-template read/write scope helpers.
+// crm_campaigns soft-deletes via `status: "deleted"` (string field).
+// crm_campaign_templates uses `deletedAt: null` like other CRM entities.
+// Write helpers delegate to read for now; can split later if needed.
+// ---------------------------------------------------------------------------
+
+export function campaignReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { status: { not: "deleted" } };
+  }
+  return { status: { not: "deleted" }, created_by: user.id };
+}
+
+export function campaignTemplateReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return { deletedAt: null, created_by: user.id };
+}
+
+export async function assertCanReadCampaign(
+  user: AuthzUser,
+  id: string,
+): Promise<void> {
+  const row = await prismadb.crm_campaigns.findFirst({
+    where: { id, ...campaignReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteCampaign(
+  user: AuthzUser,
+  id: string,
+): Promise<void> {
+  return assertCanReadCampaign(user, id);
+}
+
+export async function assertCanReadTemplate(
+  user: AuthzUser,
+  id: string,
+): Promise<void> {
+  const row = await prismadb.crm_campaign_templates.findFirst({
+    where: { id, ...campaignTemplateReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteTemplate(
+  user: AuthzUser,
+  id: string,
+): Promise<void> {
+  return assertCanReadTemplate(user, id);
+}


### PR DESCRIPTION
## Summary

Closes the campaign-action audit findings: every campaign and template action now requires authentication, and creator/manager/admin scope is enforced. Critical fix: \`createCampaign\` no longer accepts unauthenticated callers and \`created_by\` is never null.

**Campaign delivery policy applied (spec §15.3 default):** \`schedule-campaign\` and \`send-campaign-now\` require **manager or admin** (external email + quota cost). User role can create/update/delete/pause their own campaigns and templates.

## What changed

**New helpers in \`lib/authz/scopes/crm.ts\`:**
- \`campaignReadScopeWhere(user)\` — uses \`status: { not: "deleted" }\` (campaigns soft-delete via status field)
- \`campaignTemplateReadScopeWhere(user)\` — uses \`deletedAt: null\` (templates have deletedAt)
- \`assertCanReadCampaign\`, \`assertCanWriteCampaign\` (write delegates to read for now; can diverge later)
- \`assertCanReadTemplate\`, \`assertCanWriteTemplate\`

**Campaign actions patched:**
- Reads (2): \`get-campaign\`, \`get-campaigns\` — scope filter applied
- Mutations (4): \`create-campaign\` (fail-closed; validates referenced template + target lists are readable), \`update-campaign\`, \`delete-campaign\`, \`pause-campaign\`
- Send/schedule (2): \`schedule-campaign\`, \`send-campaign-now\` — manager/admin only

**Template actions patched (6):**
- Reads: \`get-template\`, \`get-templates\` — scope filter
- Mutations: \`create-template\` (fail-closed), \`update-template\`, \`delete-template\`, \`generate-template\` (fail-closed)

## Test status

- 117/123 suites pass, 601/602 tests pass (E1 baseline: 102/108, 530/531)
- 71 new tests across 14 actions
- Same 6 pre-existing suite failures + 1 pre-existing test failure unchanged — no new regressions

## Test plan

- [ ] As unauthenticated client, \`createCampaign\` → \`{error: "Unauthorized"}\`, no DB write, no \`created_by: null\` row
- [ ] As \`bob\` (user), \`sendCampaignNow(<id>)\` → \`{error: "Forbidden"}\`
- [ ] As \`bob\`, \`scheduleCampaign(<id>)\` → \`{error: "Forbidden"}\`
- [ ] As \`bob\`, \`createCampaign({ template_id: <alice-template> })\` → \`{error: "Forbidden"}\` (unreadable template)
- [ ] As \`bob\`, \`createCampaign({ target_list_ids: [<alice-list>] })\` → \`{error: "Forbidden"}\` (any unreadable list rejects whole call)
- [ ] As \`bob\`, \`updateCampaign(<alice-campaign>)\` → \`{error: "Not found"}\`
- [ ] As \`bob\`, \`getCampaigns()\` → only \`bob\`'s campaigns
- [ ] As \`manager\`, all the above → succeed

## Out of E2 scope

- **E3**: documents
- **E4**: projects (boards/sections/tasks)
- Inngest worker re-validation for campaign-send events (workers still trust event payload)
- Stricter "owner-only edit" policy on campaigns — current shape allows manager/admin to edit any user's draft campaign. If product wants strict creator-only, the \`assertCanWriteCampaign\` helper is the single point to update.

Plan: \`docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e2.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)