### PR TITLE
fix(security): scope documents + bulk ops (Phase E3)

### DIFF
--- a/actions/documents/__tests__/bulk-change-type-scope.test.ts
+++ b/actions/documents/__tests__/bulk-change-type-scope.test.ts
@@ -1,0 +1,66 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: { updateMany: jest.fn() },
+    Documents: { findMany: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { bulkChangeType } from "@/actions/documents/bulk-change-type";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("bulkChangeType auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws and does not updateMany", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(bulkChangeType(["d1"], "private" as any)).rejects.toThrow("Unauthenticated");
+    expect(prismadb.documents.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("403: partial unauthorized → fail-closed, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([{ id: "d1" }]);
+    await expect(bulkChangeType(["d1", "d2"], "private" as any)).rejects.toThrow("Forbidden");
+    expect(prismadb.documents.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("403: all unauthorized → fail-closed", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([]);
+    await expect(bulkChangeType(["d1", "d2"], "private" as any)).rejects.toThrow("Forbidden");
+    expect(prismadb.documents.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("200: all authorized → updateMany applies system type", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([
+      { id: "d1" },
+      { id: "d2" },
+    ]);
+    (prismadb.documents.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
+    await bulkChangeType(["d1", "d2"], "private" as any);
+    expect(prismadb.documents.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["d1", "d2"] } },
+      data: { document_system_type: "private" },
+    });
+  });
+
+  it("manager: bypasses OR scope and updates", async () => {
+    mockUser("manager", "m1");
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([{ id: "d1" }]);
+    (prismadb.documents.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    await bulkChangeType(["d1"], "private" as any);
+    const where = (prismadb.Documents.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+    expect(prismadb.documents.updateMany).toHaveBeenCalled();
+  });
+});

--- a/actions/documents/__tests__/bulk-delete-documents-scope.test.ts
+++ b/actions/documents/__tests__/bulk-delete-documents-scope.test.ts
@@ -1,0 +1,87 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: {
+      findMany: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    Documents: { findMany: jest.fn() },
+  },
+}));
+jest.mock("@/lib/minio", () => ({
+  minioClient: { send: jest.fn().mockResolvedValue(undefined) },
+  MINIO_BUCKET: "test-bucket",
+}));
+jest.mock("@aws-sdk/client-s3", () => ({
+  DeleteObjectCommand: jest.fn().mockImplementation((args) => args),
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { bulkDeleteDocuments } from "@/actions/documents/bulk-delete-documents";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("bulkDeleteDocuments auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws and does not delete", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(bulkDeleteDocuments(["d1", "d2"])).rejects.toThrow("Unauthenticated");
+    expect(prismadb.documents.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("403: partial unauthorized → fail-closed, nothing deleted", async () => {
+    mockUser("user", "u1");
+    // Filter returns only 1 of 2 ids → unauthorized.
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([{ id: "d1" }]);
+    await expect(bulkDeleteDocuments(["d1", "d2"])).rejects.toThrow("Forbidden");
+    expect(prismadb.documents.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("403: all unauthorized → fail-closed", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([]);
+    await expect(bulkDeleteDocuments(["d1", "d2"])).rejects.toThrow("Forbidden");
+    expect(prismadb.documents.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("200: all authorized → deletes all", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([
+      { id: "d1" },
+      { id: "d2" },
+    ]);
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([
+      { id: "d1", key: "k1" },
+      { id: "d2", key: null },
+    ]);
+    (prismadb.documents.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
+    await bulkDeleteDocuments(["d1", "d2"]);
+    expect(prismadb.documents.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["d1", "d2"] } },
+    });
+  });
+
+  it("manager: bypasses OR and deletes", async () => {
+    mockUser("manager", "m1");
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([
+      { id: "d1" },
+      { id: "d2" },
+    ]);
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([
+      { id: "d1", key: null },
+      { id: "d2", key: null },
+    ]);
+    (prismadb.documents.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
+    await bulkDeleteDocuments(["d1", "d2"]);
+    const where = (prismadb.Documents.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+    expect(prismadb.documents.deleteMany).toHaveBeenCalled();
+  });
+});

--- a/actions/documents/__tests__/bulk-link-to-account-scope.test.ts
+++ b/actions/documents/__tests__/bulk-link-to-account-scope.test.ts
@@ -1,0 +1,73 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documentsToAccounts: { createMany: jest.fn() },
+    Documents: { findMany: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { bulkLinkToAccount } from "@/actions/documents/bulk-link-to-account";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("bulkLinkToAccount auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws and does not createMany", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(bulkLinkToAccount(["d1"], "a1")).rejects.toThrow("Unauthenticated");
+    expect(prismadb.documentsToAccounts.createMany).not.toHaveBeenCalled();
+  });
+
+  it("403: account out-of-scope → fail-closed", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(bulkLinkToAccount(["d1"], "a1")).rejects.toThrow("Forbidden");
+    expect(prismadb.documentsToAccounts.createMany).not.toHaveBeenCalled();
+  });
+
+  it("403: account ok but partial unauthorized doc → fail-closed", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([{ id: "d1" }]);
+    await expect(bulkLinkToAccount(["d1", "d2"], "a1")).rejects.toThrow("Forbidden");
+    expect(prismadb.documentsToAccounts.createMany).not.toHaveBeenCalled();
+  });
+
+  it("200: all authorized → createMany junction rows", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([
+      { id: "d1" },
+      { id: "d2" },
+    ]);
+    (prismadb.documentsToAccounts.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+    await bulkLinkToAccount(["d1", "d2"], "a1");
+    expect(prismadb.documentsToAccounts.createMany).toHaveBeenCalledWith({
+      data: [
+        { document_id: "d1", account_id: "a1" },
+        { document_id: "d2", account_id: "a1" },
+      ],
+      skipDuplicates: true,
+    });
+  });
+
+  it("manager: bypasses OR scope and links", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([{ id: "d1" }]);
+    (prismadb.documentsToAccounts.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+    await bulkLinkToAccount(["d1"], "a1");
+    const acctWhere = (prismadb.crm_Accounts.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(acctWhere.OR).toBeUndefined();
+    expect(prismadb.documentsToAccounts.createMany).toHaveBeenCalled();
+  });
+});

--- a/actions/documents/__tests__/check-duplicate-scope.test.ts
+++ b/actions/documents/__tests__/check-duplicate-scope.test.ts
@@ -1,0 +1,71 @@
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  cache: <T extends (...a: unknown[]) => unknown>(fn: T) => fn,
+}));
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { checkDuplicate } from "@/actions/documents/check-duplicate";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("checkDuplicate scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns isDuplicate:false without query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await checkDuplicate("hash1");
+    expect(res).toEqual({ isDuplicate: false });
+    expect(prismadb.documents.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("user role: where includes content_hash + deletedAt:null + scope OR", async () => {
+    mockUser("user", "u1");
+    (prismadb.documents.findFirst as jest.Mock).mockResolvedValue(null);
+    await checkDuplicate("hash1");
+    const call = (prismadb.documents.findFirst as jest.Mock).mock.calls[0][0];
+    expect(call.where.content_hash).toBe("hash1");
+    expect(call.where.deletedAt).toBeNull();
+    expect(Array.isArray(call.where.OR)).toBe(true);
+  });
+
+  it("user role: out-of-scope returns isDuplicate:false (findFirst null)", async () => {
+    mockUser("user", "u1");
+    (prismadb.documents.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await checkDuplicate("hash1");
+    expect(res.isDuplicate).toBe(false);
+  });
+
+  it("user role: in-scope returns existing doc", async () => {
+    mockUser("user", "u1");
+    (prismadb.documents.findFirst as jest.Mock).mockResolvedValue({
+      id: "d1",
+      document_name: "n",
+      createdAt: null,
+      accounts: [],
+    });
+    const res = await checkDuplicate("hash1");
+    expect(res.isDuplicate).toBe(true);
+    expect(res.existingDocument?.id).toBe("d1");
+  });
+
+  it("manager: where = content_hash + deletedAt:null (no OR)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.documents.findFirst as jest.Mock).mockResolvedValue(null);
+    await checkDuplicate("hash1");
+    const call = (prismadb.documents.findFirst as jest.Mock).mock.calls[0][0];
+    expect(call.where.content_hash).toBe("hash1");
+    expect(call.where.deletedAt).toBeNull();
+    expect(call.where.OR).toBeUndefined();
+  });
+});

--- a/actions/documents/__tests__/create-document-scope.test.ts
+++ b/actions/documents/__tests__/create-document-scope.test.ts
@@ -1,0 +1,70 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: { create: jest.fn() },
+    Documents: { findFirst: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue(undefined) },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createDocument } from "@/actions/documents/create-document";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const baseInput = {
+  name: "f.pdf",
+  url: "https://example.com/f.pdf",
+  key: "k1",
+  size: 10,
+  mimeType: "application/pdf",
+};
+
+describe("createDocument auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws Unauthorized and does not write", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(createDocument(baseInput)).rejects.toThrow("Unauthorized");
+    expect(prismadb.documents.create).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope account: throws Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      createDocument({ ...baseInput, accountId: "a1" })
+    ).rejects.toThrow("Forbidden");
+    expect(prismadb.documents.create).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: creates with createdBy=user.id and assigned_user=user.id", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.documents.create as jest.Mock).mockResolvedValue({ id: "d1" });
+    await createDocument({ ...baseInput, accountId: "a1" });
+    const data = (prismadb.documents.create as jest.Mock).mock.calls[0][0].data;
+    expect(data.createdBy).toBe("u1");
+    expect(data.assigned_user).toBe("u1");
+  });
+
+  it("manager: bypasses account scope OR (assertCanWriteAccount admin/manager only checks id)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.documents.create as jest.Mock).mockResolvedValue({ id: "d1" });
+    await createDocument({ ...baseInput, accountId: "a1" });
+    const where = (prismadb.crm_Accounts.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.id).toBe("a1");
+    expect(where.OR).toBeUndefined();
+    expect(prismadb.documents.create).toHaveBeenCalled();
+  });
+});

--- a/actions/documents/__tests__/create-document-version-scope.test.ts
+++ b/actions/documents/__tests__/create-document-version-scope.test.ts
@@ -1,0 +1,84 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => {
+  const tx = jest.fn();
+  return {
+    prismadb: {
+      users: { findUnique: jest.fn() },
+      documents: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      Documents: { findFirst: jest.fn() },
+      $transaction: tx,
+    },
+  };
+});
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue(undefined) },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createDocumentVersion } from "@/actions/documents/create-document-version";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const baseInput = {
+  parentDocumentId: "p1",
+  url: "u",
+  key: "k",
+  size: 1,
+  mimeType: "application/pdf",
+};
+
+describe("createDocumentVersion auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws and does not create", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(createDocumentVersion(baseInput)).rejects.toThrow("Unauthorized");
+    expect(prismadb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope parent: throws Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(createDocumentVersion(baseInput)).rejects.toThrow("Forbidden");
+    expect(prismadb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: creates new version with createdBy=user.id", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "p1" });
+    (prismadb.documents.findUnique as jest.Mock).mockResolvedValue({
+      id: "p1",
+      document_name: "n",
+      version: 1,
+      accounts: [],
+    });
+    (prismadb.$transaction as jest.Mock).mockResolvedValue([{ id: "d2" }, {}]);
+    const res = await createDocumentVersion(baseInput);
+    expect(res).toEqual({ id: "d2" });
+    expect(prismadb.$transaction).toHaveBeenCalled();
+  });
+
+  it("manager: bypasses OR scope and creates new version", async () => {
+    mockUser("manager", "m1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "p1" });
+    (prismadb.documents.findUnique as jest.Mock).mockResolvedValue({
+      id: "p1",
+      document_name: "n",
+      version: 2,
+      accounts: [],
+    });
+    (prismadb.$transaction as jest.Mock).mockResolvedValue([{ id: "d3" }, {}]);
+    await createDocumentVersion(baseInput);
+    const where = (prismadb.Documents.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+  });
+});

--- a/actions/documents/__tests__/delete-document-scope.test.ts
+++ b/actions/documents/__tests__/delete-document-scope.test.ts
@@ -1,0 +1,69 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: {
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+    },
+    Documents: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("@/lib/minio", () => ({
+  minioClient: { send: jest.fn().mockResolvedValue(undefined) },
+  MINIO_BUCKET: "test-bucket",
+}));
+jest.mock("@aws-sdk/client-s3", () => ({
+  DeleteObjectCommand: jest.fn().mockImplementation((args) => args),
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { deleteDocument } from "@/actions/documents/delete-document";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("deleteDocument auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws Unauthenticated and does not delete", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(deleteDocument("d1")).rejects.toThrow("Unauthenticated");
+    expect(prismadb.documents.delete).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: throws Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(deleteDocument("d1")).rejects.toThrow("Forbidden");
+    expect(prismadb.documents.delete).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: deletes document and applies minio cleanup", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.documents.findUnique as jest.Mock).mockResolvedValue({
+      id: "d1",
+      key: "k1",
+    });
+    (prismadb.documents.delete as jest.Mock).mockResolvedValue({});
+    await deleteDocument("d1");
+    expect(prismadb.documents.delete).toHaveBeenCalledWith({ where: { id: "d1" } });
+  });
+
+  it("manager: bypasses OR scope and deletes", async () => {
+    mockUser("manager", "m1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.documents.findUnique as jest.Mock).mockResolvedValue({
+      id: "d1",
+      key: null,
+    });
+    (prismadb.documents.delete as jest.Mock).mockResolvedValue({});
+    await deleteDocument("d1");
+    const where = (prismadb.Documents.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+  });
+});

--- a/actions/documents/__tests__/get-document-versions-scope.test.ts
+++ b/actions/documents/__tests__/get-document-versions-scope.test.ts
@@ -1,0 +1,58 @@
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  cache: <T extends (...a: unknown[]) => unknown>(fn: T) => fn,
+}));
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: { findMany: jest.fn() },
+    Documents: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getDocumentVersions } from "@/actions/documents/get-document-versions";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getDocumentVersions scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] without query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getDocumentVersions("d1");
+    expect(res).toEqual([]);
+    expect(prismadb.documents.findMany).not.toHaveBeenCalled();
+  });
+
+  it("out-of-scope (assertCanReadDocument throws): returns []", async () => {
+    mockUser("user", "u1");
+    // assertCanReadDocument: parent lookup returns null → AuthorizationError
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getDocumentVersions("d1");
+    expect(res).toEqual([]);
+    expect(prismadb.documents.findMany).not.toHaveBeenCalled();
+  });
+
+  it("in-scope: returns version rows", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    const rows = [{ id: "d1", version: 2 }, { id: "v1", version: 1 }];
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue(rows);
+    const res = await getDocumentVersions("d1");
+    expect(res).toEqual(rows);
+  });
+
+  it("manager: assertCanReadDocument hits → returns versions", async () => {
+    mockUser("manager", "m1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([]);
+    const res = await getDocumentVersions("d1");
+    expect(res).toEqual([]);
+  });
+});

--- a/actions/documents/__tests__/get-documents-scope.test.ts
+++ b/actions/documents/__tests__/get-documents-scope.test.ts
@@ -1,0 +1,60 @@
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  cache: <T extends (...a: unknown[]) => unknown>(fn: T) => fn,
+}));
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getDocuments } from "@/actions/documents/get-documents";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getDocuments scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getDocuments();
+    expect(res).toEqual([]);
+    expect(prismadb.documents.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where contains parent_document_id:null + deletedAt:null + OR scope", async () => {
+    mockUser("user", "u1");
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([]);
+    await getDocuments();
+    const call = (prismadb.documents.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.parent_document_id).toBeNull();
+    expect(call.where.deletedAt).toBeNull();
+    expect(Array.isArray(call.where.OR)).toBe(true);
+    expect(call.where.OR.length).toBeGreaterThan(0);
+  });
+
+  it("user role: returns rows from findMany", async () => {
+    mockUser("user", "u1");
+    const rows = [{ id: "d1" }];
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue(rows);
+    const res = await getDocuments();
+    expect(res).toEqual(rows);
+  });
+
+  it("manager: where = parent_document_id:null + deletedAt:null (no OR)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([]);
+    await getDocuments();
+    const call = (prismadb.documents.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.parent_document_id).toBeNull();
+    expect(call.where.deletedAt).toBeNull();
+    expect(call.where.OR).toBeUndefined();
+  });
+});

--- a/actions/documents/__tests__/retry-enrichment-scope.test.ts
+++ b/actions/documents/__tests__/retry-enrichment-scope.test.ts
@@ -1,0 +1,58 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: { update: jest.fn() },
+    Documents: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue(undefined) },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { retryEnrichment } from "@/actions/documents/retry-enrichment";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("retryEnrichment auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws and does not update", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(retryEnrichment("d1")).rejects.toThrow("Unauthorized");
+    expect(prismadb.documents.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: throws Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(retryEnrichment("d1")).rejects.toThrow("Forbidden");
+    expect(prismadb.documents.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: triggers update", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.documents.update as jest.Mock).mockResolvedValue({});
+    await retryEnrichment("d1");
+    expect(prismadb.documents.update).toHaveBeenCalledWith({
+      where: { id: "d1" },
+      data: { processing_status: "PENDING", processing_error: null },
+    });
+  });
+
+  it("manager: bypasses OR and updates", async () => {
+    mockUser("manager", "m1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.documents.update as jest.Mock).mockResolvedValue({});
+    await retryEnrichment("d1");
+    const where = (prismadb.Documents.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+  });
+});

--- a/actions/documents/__tests__/search-documents-scope.test.ts
+++ b/actions/documents/__tests__/search-documents-scope.test.ts
@@ -1,0 +1,99 @@
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  cache: <T extends (...a: unknown[]) => unknown>(fn: T) => fn,
+}));
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documents: { findMany: jest.fn() },
+    Documents: { findMany: jest.fn() },
+    $queryRaw: jest.fn(),
+  },
+}));
+jest.mock("@/inngest/lib/embedding-utils", () => ({
+  generateEmbedding: jest.fn(async () => [0.1, 0.2]),
+  toVectorLiteral: jest.fn(() => "[0.1,0.2]"),
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { searchDocuments } from "@/actions/documents/search-documents";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("searchDocuments scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await searchDocuments("foo");
+    expect(res).toEqual([]);
+    expect(prismadb.documents.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: keyword findMany where includes parent_document_id:null + deletedAt:null + OR scope + search OR", async () => {
+    mockUser("user", "u1");
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.$queryRaw as jest.Mock).mockResolvedValue([]);
+    await searchDocuments("invoice");
+    const call = (prismadb.documents.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.parent_document_id).toBeNull();
+    expect(call.where.deletedAt).toBeNull();
+    expect(Array.isArray(call.where.OR)).toBe(true);
+    expect(call.where.AND).toBeDefined();
+    // search OR must be inside AND so it doesn't replace scope OR
+    const andClauses = call.where.AND as Array<{ OR?: unknown[] }>;
+    const searchClause = andClauses.find((c) =>
+      Array.isArray(c.OR) && c.OR.some((x: any) => x.document_name),
+    );
+    expect(searchClause).toBeDefined();
+  });
+
+  it("manager: keyword findMany where = parent_document_id:null + deletedAt:null + AND[search OR]", async () => {
+    mockUser("manager", "m1");
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.$queryRaw as jest.Mock).mockResolvedValue([]);
+    await searchDocuments("invoice");
+    const call = (prismadb.documents.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.parent_document_id).toBeNull();
+    expect(call.where.deletedAt).toBeNull();
+    expect(call.where.OR).toBeUndefined();
+  });
+
+  it("post-filters vector results via authorized id set", async () => {
+    mockUser("user", "u1");
+    // keyword: empty
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValueOnce([]);
+    // raw vector: 5 ids
+    (prismadb.$queryRaw as jest.Mock).mockResolvedValue([
+      { id: "v1", similarity: 0.9 },
+      { id: "v2", similarity: 0.85 },
+      { id: "v3", similarity: 0.83 },
+      { id: "v4", similarity: 0.81 },
+      { id: "v5", similarity: 0.75 },
+    ]);
+    // filterAuthorizedDocumentIds is implemented via prismadb.Documents.findMany — return only v1, v3
+    (prismadb.Documents.findMany as jest.Mock).mockResolvedValue([
+      { id: "v1" },
+      { id: "v3" },
+    ]);
+    // 2nd findMany call (extraDocs lookup by ids) returns those two
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValueOnce([
+      { id: "v1", document_name: "v1", summary: null, document_system_type: null, accounts: [] },
+      { id: "v3", document_name: "v3", summary: null, document_system_type: null, accounts: [] },
+    ]);
+
+    const res = await searchDocuments("foo");
+    const ids = res.map((r) => r.id);
+    expect(ids).toEqual(expect.arrayContaining(["v1", "v3"]));
+    expect(ids).not.toEqual(expect.arrayContaining(["v2", "v4", "v5"]));
+
+    // extraDocs query must use only the authorized ids
+    const extraCall = (prismadb.documents.findMany as jest.Mock).mock.calls[1][0];
+    expect(extraCall.where.id.in).toEqual(["v1", "v3"]);
+  });
+});

--- a/actions/documents/__tests__/unlink-from-account-scope.test.ts
+++ b/actions/documents/__tests__/unlink-from-account-scope.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    documentsToAccounts: { delete: jest.fn() },
+    Documents: { findFirst: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { unlinkFromAccount } from "@/actions/documents/unlink-from-account";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("unlinkFromAccount auth", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("401: unauthenticated throws and does not delete junction", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    await expect(unlinkFromAccount("d1", "a1")).rejects.toThrow("Unauthorized");
+    expect(prismadb.documentsToAccounts.delete).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope document: throws Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(unlinkFromAccount("d1", "a1")).rejects.toThrow("Forbidden");
+    expect(prismadb.documentsToAccounts.delete).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope account (doc passes, account fails): throws Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(unlinkFromAccount("d1", "a1")).rejects.toThrow("Forbidden");
+    expect(prismadb.documentsToAccounts.delete).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope owner: deletes junction", async () => {
+    mockUser("user", "u1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.documentsToAccounts.delete as jest.Mock).mockResolvedValue({});
+    await unlinkFromAccount("d1", "a1");
+    expect(prismadb.documentsToAccounts.delete).toHaveBeenCalled();
+  });
+
+  it("manager: bypasses OR scope and deletes", async () => {
+    mockUser("manager", "m1");
+    (prismadb.Documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({ id: "a1" });
+    (prismadb.documentsToAccounts.delete as jest.Mock).mockResolvedValue({});
+    await unlinkFromAccount("d1", "a1");
+    const acctWhere = (prismadb.crm_Accounts.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(acctWhere.OR).toBeUndefined();
+  });
+});

--- a/actions/documents/bulk-change-type.ts
+++ b/actions/documents/bulk-change-type.ts
@@ -1,12 +1,29 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  filterAuthorizedDocumentIds,
+  AuthenticationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import { DocumentSystemType } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 
 export async function bulkChangeType(documentIds: string[], systemType: DocumentSystemType) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthenticated");
+    throw e;
+  }
+
+  if (!documentIds || documentIds.length === 0) return;
+
+  // Fail-closed: every documentId must be authorized.
+  const allowed = await filterAuthorizedDocumentIds(user, documentIds);
+  if (allowed.length !== documentIds.length) {
+    throw new Error("Forbidden");
+  }
 
   await prismadb.documents.updateMany({
     where: { id: { in: documentIds } },

--- a/actions/documents/bulk-delete-documents.ts
+++ b/actions/documents/bulk-delete-documents.ts
@@ -1,13 +1,30 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  filterAuthorizedDocumentIds,
+  AuthenticationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { minioClient, MINIO_BUCKET } from "@/lib/minio";
 
 export async function bulkDeleteDocuments(documentIds: string[]) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthenticated");
+    throw e;
+  }
+
+  if (!documentIds || documentIds.length === 0) return;
+
+  // Fail-closed: if any id is not authorized, reject the whole request.
+  const allowed = await filterAuthorizedDocumentIds(user, documentIds);
+  if (allowed.length !== documentIds.length) {
+    throw new Error("Forbidden");
+  }
 
   const documents = await prismadb.documents.findMany({
     where: { id: { in: documentIds } },

--- a/actions/documents/bulk-link-to-account.ts
+++ b/actions/documents/bulk-link-to-account.ts
@@ -1,11 +1,39 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  filterAuthorizedDocumentIds,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 
 export async function bulkLinkToAccount(documentIds: string[], accountId: string) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthenticated");
+    throw e;
+  }
+
+  if (!accountId) throw new Error("Account ID is required");
+  if (!documentIds || documentIds.length === 0) return;
+
+  // Account must be writable by user (fail-closed).
+  try {
+    await assertCanWriteAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+
+  // Fail-closed: every documentId must be authorized.
+  const allowed = await filterAuthorizedDocumentIds(user, documentIds);
+  if (allowed.length !== documentIds.length) {
+    throw new Error("Forbidden");
+  }
 
   await prismadb.documentsToAccounts.createMany({
     data: documentIds.map((document_id) => ({ document_id, account_id: accountId })),

--- a/actions/documents/check-duplicate.ts
+++ b/actions/documents/check-duplicate.ts
@@ -1,5 +1,9 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  documentReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 
 interface DuplicateResult {
@@ -13,11 +17,19 @@ interface DuplicateResult {
 }
 
 export async function checkDuplicate(contentHash: string): Promise<DuplicateResult> {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { isDuplicate: false };
+    throw e;
+  }
 
   const existing = await prismadb.documents.findFirst({
-    where: { content_hash: contentHash },
+    where: {
+      content_hash: contentHash,
+      ...documentReadScopeWhere(user),
+    },
     select: {
       id: true,
       document_name: true,

--- a/actions/documents/create-document-version.ts
+++ b/actions/documents/create-document-version.ts
@@ -1,5 +1,10 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteDocument,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
@@ -14,8 +19,20 @@ interface CreateVersionInput {
 }
 
 export async function createDocumentVersion(input: CreateVersionInput) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
+
+  try {
+    await assertCanWriteDocument(user, input.parentDocumentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
 
   const parent = await prismadb.documents.findUnique({
     where: { id: input.parentDocumentId },
@@ -39,8 +56,8 @@ export async function createDocumentVersion(input: CreateVersionInput) {
         processing_status: "PENDING",
         version: newVersion,
         parent_document_id: input.parentDocumentId,
-        createdBy: session.user.id,
-        assigned_user: session.user.id,
+        createdBy: user.id,
+        assigned_user: user.id,
       },
     }),
     prismadb.documents.update({

--- a/actions/documents/create-document.ts
+++ b/actions/documents/create-document.ts
@@ -1,5 +1,10 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
@@ -15,8 +20,22 @@ interface CreateDocumentInput {
 }
 
 export async function createDocument(input: CreateDocumentInput) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
+
+  if (input.accountId) {
+    try {
+      await assertCanWriteAccount(user, input.accountId);
+    } catch (e) {
+      if (e instanceof AuthorizationError) throw new Error("Forbidden");
+      throw e;
+    }
+  }
 
   const document = await prismadb.documents.create({
     data: {
@@ -29,8 +48,8 @@ export async function createDocument(input: CreateDocumentInput) {
       document_file_mimeType: input.mimeType,
       content_hash: input.contentHash ?? null,
       processing_status: "PENDING",
-      createdBy: session.user.id,
-      assigned_user: session.user.id,
+      createdBy: user.id,
+      assigned_user: user.id,
       ...(input.accountId
         ? { accounts: { create: { account_id: input.accountId } } }
         : {}),

--- a/actions/documents/delete-document.ts
+++ b/actions/documents/delete-document.ts
@@ -1,15 +1,32 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteDocument,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 import { prismadb } from "@/lib/prisma";
 import { DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { minioClient, MINIO_BUCKET } from "@/lib/minio";
 
 export async function deleteDocument(documentId: string) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthenticated");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthenticated");
+    throw e;
+  }
 
   if (!documentId) throw new Error("Document ID is required");
+
+  try {
+    await assertCanWriteDocument(user, documentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
 
   const document = await prismadb.documents.findUnique({
     where: { id: documentId },

--- a/actions/documents/get-document-versions.ts
+++ b/actions/documents/get-document-versions.ts
@@ -1,10 +1,28 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanReadDocument,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 
 export async function getDocumentVersions(documentId: string) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
+  // Versions inherit parent permissions: assert read on parent first.
+  try {
+    await assertCanReadDocument(user, documentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
 
   const versions = await prismadb.documents.findMany({
     where: {

--- a/actions/documents/get-documents.ts
+++ b/actions/documents/get-documents.ts
@@ -1,14 +1,24 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  documentReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 
 export const getDocuments = async () => {
-  const session = await getSession();
-  if (!session) return [];
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
 
   const documents = await prismadb.documents.findMany({
     where: {
       parent_document_id: null, // Only show root documents, not old versions
+      ...documentReadScopeWhere(user),
     },
     orderBy: { date_created: "desc" },
     include: {

--- a/actions/documents/retry-enrichment.ts
+++ b/actions/documents/retry-enrichment.ts
@@ -1,12 +1,29 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteDocument,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import { inngest } from "@/inngest/client";
 import { revalidatePath } from "next/cache";
 
 export async function retryEnrichment(documentId: string) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
+
+  try {
+    await assertCanWriteDocument(user, documentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
 
   await prismadb.documents.update({
     where: { id: documentId },

--- a/actions/documents/search-documents.ts
+++ b/actions/documents/search-documents.ts
@@ -1,5 +1,10 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  documentReadScopeWhere,
+  filterAuthorizedDocumentIds,
+  AuthenticationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import {
   generateEmbedding,
@@ -17,17 +22,28 @@ export interface DocumentSearchResult {
 export async function searchDocuments(
   query: string
 ): Promise<DocumentSearchResult[]> {
-  const session = await getSession();
-  if (!session) return [];
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
   if (!query || query.trim().length < 2) return [];
 
-  // Keyword search
+  // Keyword search — scope OR (visibility/ownership) goes at top level;
+  // user-supplied search OR moves into AND so it cannot replace the scope OR.
   const kwResults = await prismadb.documents.findMany({
     where: {
       parent_document_id: null,
-      OR: [
-        { document_name: { contains: query, mode: "insensitive" } },
-        { summary: { contains: query, mode: "insensitive" } },
+      ...documentReadScopeWhere(user),
+      AND: [
+        {
+          OR: [
+            { document_name: { contains: query, mode: "insensitive" } },
+            { summary: { contains: query, mode: "insensitive" } },
+          ],
+        },
       ],
     },
     take: 5,
@@ -40,13 +56,15 @@ export async function searchDocuments(
     },
   });
 
-  // Semantic search
+  // Semantic search via raw pgvector. Apply post-filter for authz.
   let semResults: { id: string; similarity: number }[] = [];
   try {
     const embedding = await generateEmbedding(query.trim());
     const vec = toVectorLiteral(embedding);
 
-    semResults = await prismadb.$queryRaw<{ id: string; similarity: number }[]>`
+    const rawResults = await prismadb.$queryRaw<
+      { id: string; similarity: number }[]
+    >`
       SELECT d.id, 1 - (e.embedding <=> ${vec}::vector) AS similarity
       FROM "Documents" d
       LEFT JOIN "crm_Embeddings_Documents" e ON e.document_id = d.id
@@ -54,6 +72,14 @@ export async function searchDocuments(
         AND 1 - (e.embedding <=> ${vec}::vector) > 0.7
       ORDER BY e.embedding <=> ${vec}::vector
       LIMIT 5`;
+
+    const allowedIds = new Set(
+      await filterAuthorizedDocumentIds(
+        user,
+        rawResults.map((r) => r.id),
+      ),
+    );
+    semResults = rawResults.filter((r) => allowedIds.has(r.id));
   } catch {
     // Fall back to keyword-only
   }

--- a/actions/documents/unlink-from-account.ts
+++ b/actions/documents/unlink-from-account.ts
@@ -1,11 +1,36 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteDocument,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 
 export async function unlinkFromAccount(documentId: string, accountId: string) {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) throw new Error("Unauthorized");
+    throw e;
+  }
+
+  try {
+    await assertCanWriteDocument(user, documentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
+
+  try {
+    await assertCanWriteAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) throw new Error("Forbidden");
+    throw e;
+  }
 
   await prismadb.documentsToAccounts.delete({
     where: {

--- a/lib/authz/__tests__/scopes-document-read.test.ts
+++ b/lib/authz/__tests__/scopes-document-read.test.ts
@@ -1,0 +1,167 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    Documents: { findFirst: jest.fn(), findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  documentReadScopeWhere,
+  assertCanReadDocument,
+  assertCanWriteDocument,
+  filterAuthorizedDocumentIds,
+} from "../scopes/crm";
+
+const findDoc = prismadb.Documents.findFirst as jest.MockedFunction<
+  typeof prismadb.Documents.findFirst
+>;
+const findManyDoc = prismadb.Documents.findMany as jest.MockedFunction<
+  typeof prismadb.Documents.findMany
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+const linkedAccountOR = (uid: string) => ({
+  OR: expect.arrayContaining([
+    { assigned_to: uid },
+    { createdBy: uid },
+    { watchers: { some: { user_id: uid } } },
+  ]),
+});
+
+describe("documentReadScopeWhere", () => {
+  it("admin → only deletedAt:null", () => {
+    expect(documentReadScopeWhere({ id: "x", role: "admin" })).toEqual({
+      deletedAt: null,
+    });
+  });
+  it("manager → only deletedAt:null", () => {
+    expect(documentReadScopeWhere({ id: "x", role: "manager" })).toEqual({
+      deletedAt: null,
+    });
+  });
+  it("user → deletedAt + OR with all 8 branches", () => {
+    const w = documentReadScopeWhere({ id: "u1", role: "user" }) as any;
+    expect(w.deletedAt).toBeNull();
+    expect(w.OR).toEqual(
+      expect.arrayContaining([
+        { created_by_user: "u1" },
+        { createdBy: "u1" },
+        { assigned_user: "u1" },
+        { visibility: "public" },
+        { accounts: { some: { account: { OR: linkedAccountOR("u1").OR } } } },
+        {
+          leads: {
+            some: {
+              lead: { OR: [{ assigned_to: "u1" }, { createdBy: "u1" }] },
+            },
+          },
+        },
+        {
+          contacts: {
+            some: {
+              contact: {
+                OR: [
+                  { assigned_to: "u1" },
+                  { created_by: "u1" },
+                  { createdBy: "u1" },
+                ],
+              },
+            },
+          },
+        },
+        {
+          opportunities: {
+            some: {
+              opportunity: {
+                OR: [
+                  { assigned_to: "u1" },
+                  { created_by: "u1" },
+                  { createdBy: "u1" },
+                ],
+              },
+            },
+          },
+        },
+      ]),
+    );
+    expect(w.OR).toHaveLength(8);
+  });
+});
+
+describe("assertCanReadDocument", () => {
+  it("admin: 200 hit", async () => {
+    findDoc.mockResolvedValue({ id: "d1" } as any);
+    await assertCanReadDocument({ id: "x", role: "admin" }, "d1");
+    expect(findDoc).toHaveBeenCalledWith({
+      where: { id: "d1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+  it("user: scoped where (200 hit)", async () => {
+    findDoc.mockResolvedValue({ id: "d1" } as any);
+    await assertCanReadDocument({ id: "u1", role: "user" }, "d1");
+    const arg = findDoc.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({ id: "d1", deletedAt: null });
+    expect((arg.where as any).OR).toBeDefined();
+  });
+  it("throws AuthorizationError on miss (404)", async () => {
+    findDoc.mockResolvedValue(null);
+    await expect(
+      assertCanReadDocument({ id: "u1", role: "user" }, "d1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteDocument", () => {
+  it("delegates to read scope (200 hit)", async () => {
+    findDoc.mockResolvedValue({ id: "d1" } as any);
+    await assertCanWriteDocument({ id: "u1", role: "user" }, "d1");
+    expect(findDoc).toHaveBeenCalled();
+  });
+  it("throws on miss", async () => {
+    findDoc.mockResolvedValue(null);
+    await expect(
+      assertCanWriteDocument({ id: "u1", role: "user" }, "d1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("filterAuthorizedDocumentIds", () => {
+  it("empty list → returns [] without query", async () => {
+    const result = await filterAuthorizedDocumentIds(
+      { id: "u1", role: "user" },
+      [],
+    );
+    expect(result).toEqual([]);
+    expect(findManyDoc).not.toHaveBeenCalled();
+  });
+  it("admin: query uses deletedAt:null", async () => {
+    findManyDoc.mockResolvedValue([{ id: "d1" }, { id: "d2" }] as any);
+    const result = await filterAuthorizedDocumentIds(
+      { id: "x", role: "admin" },
+      ["d1", "d2", "d3"],
+    );
+    expect(findManyDoc).toHaveBeenCalledWith({
+      where: { id: { in: ["d1", "d2", "d3"] }, deletedAt: null },
+      select: { id: true },
+    });
+    expect(result).toEqual(["d1", "d2"]);
+  });
+  it("user: scoped where filters via OR", async () => {
+    findManyDoc.mockResolvedValue([{ id: "d1" }] as any);
+    const result = await filterAuthorizedDocumentIds(
+      { id: "u1", role: "user" },
+      ["d1", "d2"],
+    );
+    const arg = findManyDoc.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({
+      id: { in: ["d1", "d2"] },
+      deletedAt: null,
+    });
+    expect((arg.where as any).OR).toBeDefined();
+    expect(result).toEqual(["d1"]);
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -63,5 +63,11 @@ export {
   assertCanReadTemplate,
   assertCanWriteTemplate,
 } from "./scopes/crm";
+export {
+  documentReadScopeWhere,
+  assertCanReadDocument,
+  assertCanWriteDocument,
+  filterAuthorizedDocumentIds,
+} from "./scopes/crm";
 export type { ReportScope } from "./scopes/report-scope";
 export { getReportScope } from "./scopes/report-scope";

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -398,6 +398,94 @@ export async function assertCanReadTargetList(
 }
 
 // ---------------------------------------------------------------------------
+// E3.T1: Document read/write scope helpers (linked-entity aware).
+// Documents have multi-faceted ownership: created_by_user, createdBy (legacy),
+// assigned_user, visibility="public", plus link junctions to
+// accounts/leads/contacts/opportunities. User scope unions all of these;
+// manager/admin get bare deletedAt-only read.
+// ---------------------------------------------------------------------------
+
+export function documentReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { created_by_user: user.id },
+      { createdBy: user.id }, // legacy duplicate
+      { assigned_user: user.id },
+      { visibility: "public" },
+      // Linked-entity scope (junction relations)
+      { accounts: { some: { account: { OR: accountUserScopeOR(user.id) } } } },
+      {
+        leads: {
+          some: {
+            lead: { OR: [{ assigned_to: user.id }, { createdBy: user.id }] },
+          },
+        },
+      },
+      {
+        contacts: {
+          some: {
+            contact: {
+              OR: [
+                { assigned_to: user.id },
+                { created_by: user.id },
+                { createdBy: user.id },
+              ],
+            },
+          },
+        },
+      },
+      {
+        opportunities: {
+          some: {
+            opportunity: {
+              OR: [
+                { assigned_to: user.id },
+                { created_by: user.id },
+                { createdBy: user.id },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+export async function assertCanReadDocument(
+  user: AuthzUser,
+  documentId: string,
+): Promise<void> {
+  const row = await prismadb.Documents.findFirst({
+    where: { id: documentId, ...documentReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteDocument(
+  user: AuthzUser,
+  documentId: string,
+): Promise<void> {
+  return assertCanReadDocument(user, documentId);
+}
+
+export async function filterAuthorizedDocumentIds(
+  user: AuthzUser,
+  documentIds: string[],
+): Promise<string[]> {
+  if (documentIds.length === 0) return [];
+  const rows = await prismadb.Documents.findMany({
+    where: { id: { in: documentIds }, ...documentReadScopeWhere(user) },
+    select: { id: true },
+  });
+  return rows.map((r: { id: string }) => r.id);
+}
+
+// ---------------------------------------------------------------------------
 // D3.T3: Activity / audit dispatch helper.
 // Resolves an entityType string to the matching assertCanRead* helper.
 // Used by activity-feed (T4) and audit-log-by-entity (T5).


### PR DESCRIPTION
## Summary

Closes the document-action audit findings: global document listing, no ownership checks on delete/bulk operations, no account-write check on linking. Applies role + visibility-based scope across reads, per-document ownership on writes, and fail-closed bulk filters.

## What changed

**New helpers in \`lib/authz/scopes/crm.ts\`:**
- \`documentReadScopeWhere(user)\` — admin/manager: \`{deletedAt: null}\`; user: own + assigned + visibility="public" + linked-entity scope (accounts/leads/contacts/opportunities)
- \`assertCanReadDocument\`, \`assertCanWriteDocument\` (write delegates to read for now)
- \`filterAuthorizedDocumentIds(user, ids)\` — for bulk operations

**Document reads patched (4):**
- \`get-documents.ts\` — list root docs with scope filter
- \`search-documents.ts\` — keyword + raw SQL pgvector. Keyword query gets scope via \`AND/OR\` merge; vector results post-filtered through \`filterAuthorizedDocumentIds\`
- \`get-document-versions.ts\` — \`assertCanReadDocument\` on parent first
- \`check-duplicate.ts\` — scope applied to duplicate-hash query (no enumeration leak)

**Single-doc mutations patched (5):**
- \`create-document.ts\` — \`requireAuthenticated\` + \`assertCanWriteAccount\` if accountId provided
- \`delete-document.ts\` — \`assertCanWriteDocument\` before hard delete + MinIO cleanup
- \`unlink-from-account.ts\` — \`assertCanWriteDocument\` AND \`assertCanWriteAccount\` (both endpoints)
- \`retry-enrichment.ts\` — \`assertCanWriteDocument\`
- \`create-document-version.ts\` — \`assertCanWriteDocument\` on parent

**Bulk operations patched (3, all fail-closed):**
- \`bulk-delete-documents.ts\` — any unauthorized id → throw Forbidden, no MinIO/DB writes
- \`bulk-link-to-account.ts\` — \`assertCanWriteAccount\` on target + \`filterAuthorizedDocumentIds\` length-check
- \`bulk-change-type.ts\` — same fail-closed pattern

## Test status

- All 4 E3 tasks pass their new tests (~64 new tests)
- Same 6 pre-existing suite failures + 1 pre-existing test failure unchanged — no new regressions

## Test plan

- [ ] As \`bob\` (user, no doc ownership), list documents → only \`bob\`'s + linked-entity-accessible + public docs
- [ ] As \`bob\`, \`deleteDocument(<alice-doc-id>)\` → throws Forbidden, no MinIO/DB delete
- [ ] As \`bob\`, \`bulkDeleteDocuments([alice-doc, bob-doc])\` → throws Forbidden, no deletion (fail-closed)
- [ ] As \`bob\`, \`bulkLinkToAccount({account: <alice-account>, document_ids: [...]})\` → Forbidden
- [ ] As \`bob\`, search documents by query → results scoped + vector results post-filtered
- [ ] As \`manager\`, all the above → succeed

## Out of E3 scope

- **E4**: projects (boards/sections/tasks) and \`assign-document-to-task\` will use \`assertCanReadDocument\` from this PR
- Document versions tree pagination — current behavior preserved; only parent-read assert added
- Tag-based access control — feature creep
- Stricter visibility enum (e.g., per-role visibility levels) — Phase F could add

Plan: \`docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e3.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)