### PR TITLE
fix(security): scope projects (boards/sections/tasks) (Phase E4)

### DIFF
--- a/actions/documents/__tests__/bulk-change-type-scope.test.ts
+++ b/actions/documents/__tests__/bulk-change-type-scope.test.ts
@@ -2,8 +2,7 @@ jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findUnique: jest.fn() },
-    documents: { updateMany: jest.fn() },
-    Documents: { findMany: jest.fn() },
+    documents: { updateMany: jest.fn(), findMany: jest.fn() },
   },
 }));
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));

--- a/actions/documents/__tests__/bulk-delete-documents-scope.test.ts
+++ b/actions/documents/__tests__/bulk-delete-documents-scope.test.ts
@@ -6,7 +6,6 @@ jest.mock("@/lib/prisma", () => ({
       findMany: jest.fn(),
       deleteMany: jest.fn(),
     },
-    Documents: { findMany: jest.fn() },
   },
 }));
 jest.mock("@/lib/minio", () => ({

--- a/actions/documents/__tests__/bulk-link-to-account-scope.test.ts
+++ b/actions/documents/__tests__/bulk-link-to-account-scope.test.ts
@@ -3,7 +3,7 @@ jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findUnique: jest.fn() },
     documentsToAccounts: { createMany: jest.fn() },
-    Documents: { findMany: jest.fn() },
+    documents: { findMany: jest.fn() },
     crm_Accounts: { findFirst: jest.fn() },
   },
 }));

--- a/actions/documents/__tests__/create-document-scope.test.ts
+++ b/actions/documents/__tests__/create-document-scope.test.ts
@@ -2,8 +2,7 @@ jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findUnique: jest.fn() },
-    documents: { create: jest.fn() },
-    Documents: { findFirst: jest.fn() },
+    documents: { create: jest.fn(), findFirst: jest.fn() },
     crm_Accounts: { findFirst: jest.fn() },
   },
 }));

--- a/actions/documents/__tests__/create-document-version-scope.test.ts
+++ b/actions/documents/__tests__/create-document-version-scope.test.ts
@@ -8,8 +8,8 @@ jest.mock("@/lib/prisma", () => {
         findUnique: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
+        findFirst: jest.fn(),
       },
-      Documents: { findFirst: jest.fn() },
       $transaction: tx,
     },
   };

--- a/actions/documents/__tests__/delete-document-scope.test.ts
+++ b/actions/documents/__tests__/delete-document-scope.test.ts
@@ -5,8 +5,8 @@ jest.mock("@/lib/prisma", () => ({
     documents: {
       findUnique: jest.fn(),
       delete: jest.fn(),
+      findFirst: jest.fn(),
     },
-    Documents: { findFirst: jest.fn() },
   },
 }));
 jest.mock("@/lib/minio", () => ({

--- a/actions/documents/__tests__/get-document-versions-scope.test.ts
+++ b/actions/documents/__tests__/get-document-versions-scope.test.ts
@@ -6,8 +6,7 @@ jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findUnique: jest.fn() },
-    documents: { findMany: jest.fn() },
-    Documents: { findFirst: jest.fn() },
+    documents: { findMany: jest.fn(), findFirst: jest.fn() },
   },
 }));
 

--- a/actions/documents/__tests__/retry-enrichment-scope.test.ts
+++ b/actions/documents/__tests__/retry-enrichment-scope.test.ts
@@ -2,8 +2,7 @@ jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findUnique: jest.fn() },
-    documents: { update: jest.fn() },
-    Documents: { findFirst: jest.fn() },
+    documents: { update: jest.fn(), findFirst: jest.fn() },
   },
 }));
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));

--- a/actions/documents/__tests__/search-documents-scope.test.ts
+++ b/actions/documents/__tests__/search-documents-scope.test.ts
@@ -7,7 +7,6 @@ jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findUnique: jest.fn() },
     documents: { findMany: jest.fn() },
-    Documents: { findMany: jest.fn() },
     $queryRaw: jest.fn(),
   },
 }));

--- a/actions/documents/__tests__/unlink-from-account-scope.test.ts
+++ b/actions/documents/__tests__/unlink-from-account-scope.test.ts
@@ -3,7 +3,7 @@ jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findUnique: jest.fn() },
     documentsToAccounts: { delete: jest.fn() },
-    Documents: { findFirst: jest.fn() },
+    documents: { findFirst: jest.fn() },
     crm_Accounts: { findFirst: jest.fn() },
   },
 }));

--- a/actions/projects/__tests__/add-comment-to-task-scope.test.ts
+++ b/actions/projects/__tests__/add-comment-to-task-scope.test.ts
@@ -1,0 +1,88 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), update: jest.fn() },
+    boardWatchers: { findMany: jest.fn(async () => []) },
+    sections: { findUnique: jest.fn() },
+    tasks: { findUnique: jest.fn() },
+    tasksComments: { create: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/junction-helpers", () => ({
+  junctionTableHelpers: { addWatcher: jest.fn(() => ({})) },
+}));
+jest.mock("@/lib/resend", () => ({ __esModule: true, default: jest.fn(async () => null) }));
+jest.mock("@/emails/NewTaskComment", () => ({ __esModule: true, default: () => null }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { addCommentToTask } from "@/actions/projects/add-comment-to-task";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = { taskId: "t1", comment: "hi" };
+
+describe("addCommentToTask scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await addCommentToTask(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.tasksComments.create).not.toHaveBeenCalled();
+  });
+
+  it("task's board out-of-scope returns Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      id: "t1",
+      section: "s1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await addCommentToTask(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.tasksComments.create).not.toHaveBeenCalled();
+  });
+
+  it("in-scope board owner adds comment", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      id: "t1",
+      title: "Task",
+      section: "s1",
+      createdBy: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({});
+    (prismadb.tasksComments.create as jest.Mock).mockResolvedValue({ id: "c1" });
+    const res = await addCommentToTask(args);
+    expect(res).toEqual({ data: { id: "c1" } });
+  });
+
+  it("manager bare scope adds comment", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      id: "t1",
+      title: "Task",
+      section: "s1",
+      createdBy: "m1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({});
+    (prismadb.tasksComments.create as jest.Mock).mockResolvedValue({ id: "c1" });
+    const res = await addCommentToTask(args);
+    expect(res).toEqual({ data: { id: "c1" } });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/assign-document-to-task-scope.test.ts
+++ b/actions/projects/__tests__/assign-document-to-task-scope.test.ts
@@ -1,0 +1,85 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    documents: { findFirst: jest.fn() },
+    documentsToTasks: { create: jest.fn() },
+    tasks: { findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { assignDocumentToTask } from "@/actions/projects/assign-document-to-task";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = { documentId: "d1", taskId: "t1" };
+
+describe("assignDocumentToTask scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await assignDocumentToTask(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.documentsToTasks.create).not.toHaveBeenCalled();
+  });
+
+  it("task out-of-scope (non-assignee, board denied): Forbidden", async () => {
+    mockUser("user", "u2");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await assignDocumentToTask(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.documentsToTasks.create).not.toHaveBeenCalled();
+  });
+
+  it("task ok but document unreadable: Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.documents.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await assignDocumentToTask(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.documentsToTasks.create).not.toHaveBeenCalled();
+  });
+
+  it("assignee + readable document succeeds (assignee bypass)", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.documentsToTasks.create as jest.Mock).mockResolvedValue({});
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({});
+    const res = await assignDocumentToTask(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.documentsToTasks.create).toHaveBeenCalled();
+  });
+
+  it("manager bare scope succeeds", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.documents.findFirst as jest.Mock).mockResolvedValue({ id: "d1" });
+    (prismadb.documentsToTasks.create as jest.Mock).mockResolvedValue({});
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({});
+    const res = await assignDocumentToTask(args);
+    expect(res).toEqual({ success: true });
+  });
+});

--- a/actions/projects/__tests__/create-project-scope.test.ts
+++ b/actions/projects/__tests__/create-project-scope.test.ts
@@ -1,0 +1,42 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { count: jest.fn(), create: jest.fn() },
+    sections: { create: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createProject } from "@/actions/projects/create-project";
+
+const mockUser = (id = "u1", role: "user" | "manager" | "admin" = "user") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("createProject scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await createProject({ title: "t", description: "d", visibility: "private" });
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.boards.create).not.toHaveBeenCalled();
+  });
+
+  it("authenticated user creates board with createdBy = user.id", async () => {
+    mockUser("u1");
+    (prismadb.boards.count as jest.Mock).mockResolvedValue(0);
+    (prismadb.boards.create as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.create as jest.Mock).mockResolvedValue({ id: "s1" });
+    const res = await createProject({ title: "t", description: "d", visibility: "private" });
+    expect(res).toEqual({ data: { id: "b1" } });
+    const args = (prismadb.boards.create as jest.Mock).mock.calls[0][0];
+    expect(args.data.user).toBe("u1");
+    expect(args.data.createdBy).toBe("u1");
+    expect(args.data.sharedWith).toEqual(["u1"]);
+  });
+});

--- a/actions/projects/__tests__/create-section-scope.test.ts
+++ b/actions/projects/__tests__/create-section-scope.test.ts
@@ -1,0 +1,60 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    sections: { count: jest.fn(), create: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createSection } from "@/actions/projects/create-section";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = { boardId: "b1", title: "Section A" };
+
+describe("createSection scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await createSection(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.sections.create).not.toHaveBeenCalled();
+  });
+
+  it("board out-of-scope returns Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await createSection(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.sections.create).not.toHaveBeenCalled();
+  });
+
+  it("in-scope owner creates section", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.count as jest.Mock).mockResolvedValue(0);
+    (prismadb.sections.create as jest.Mock).mockResolvedValue({ id: "s1" });
+    const res = await createSection(args);
+    expect(res).toEqual({ data: { id: "s1" } });
+    expect(prismadb.sections.create).toHaveBeenCalled();
+  });
+
+  it("manager bare write scope creates section", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.count as jest.Mock).mockResolvedValue(2);
+    (prismadb.sections.create as jest.Mock).mockResolvedValue({ id: "s2" });
+    const res = await createSection(args);
+    expect(res).toEqual({ data: { id: "s2" } });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/create-task-in-board-scope.test.ts
+++ b/actions/projects/__tests__/create-task-in-board-scope.test.ts
@@ -1,0 +1,71 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+    tasks: { count: jest.fn(), create: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/resend", () => ({ __esModule: true, default: jest.fn(async () => null) }));
+jest.mock("@/emails/NewTaskFromProject", () => ({ __esModule: true, default: () => null }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createTaskInBoard } from "@/actions/projects/create-task-in-board";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = {
+  boardId: "b1",
+  section: "s1",
+  title: "T",
+  priority: "normal",
+  content: "C",
+  user: "u1",
+};
+
+describe("createTaskInBoard scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await createTaskInBoard(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.tasks.create).not.toHaveBeenCalled();
+  });
+
+  it("board out-of-scope returns Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await createTaskInBoard(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.tasks.create).not.toHaveBeenCalled();
+  });
+
+  it("in-scope owner creates task", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.count as jest.Mock).mockResolvedValue(0);
+    (prismadb.tasks.create as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({});
+    const res = await createTaskInBoard(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.tasks.create).toHaveBeenCalled();
+  });
+
+  it("manager bare scope creates task (quick-add path)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.count as jest.Mock).mockResolvedValue(0);
+    (prismadb.tasks.create as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({});
+    const res = await createTaskInBoard({ boardId: "b1", section: "s1" });
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/create-task-scope.test.ts
+++ b/actions/projects/__tests__/create-task-scope.test.ts
@@ -1,0 +1,73 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+    sections: { findFirst: jest.fn() },
+    tasks: { count: jest.fn(), create: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/resend", () => ({ __esModule: true, default: jest.fn(async () => null) }));
+jest.mock("@/emails/NewTaskFromProject", () => ({ __esModule: true, default: () => null }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { createTask } from "@/actions/projects/create-task";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = {
+  title: "T",
+  user: "u1",
+  board: "b1",
+  priority: "normal",
+  content: "C",
+};
+
+describe("createTask scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await createTask(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.tasks.create).not.toHaveBeenCalled();
+  });
+
+  it("board out-of-scope returns Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await createTask(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.tasks.create).not.toHaveBeenCalled();
+  });
+
+  it("in-scope owner creates task", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.findFirst as jest.Mock).mockResolvedValue({ id: "s1" });
+    (prismadb.tasks.count as jest.Mock).mockResolvedValue(0);
+    (prismadb.tasks.create as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({});
+    const res = await createTask(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.tasks.create).toHaveBeenCalled();
+  });
+
+  it("manager bare scope creates task", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.findFirst as jest.Mock).mockResolvedValue({ id: "s1" });
+    (prismadb.tasks.count as jest.Mock).mockResolvedValue(0);
+    (prismadb.tasks.create as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({});
+    const res = await createTask({ ...args, user: "m1" });
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/delete-project-scope.test.ts
+++ b/actions/projects/__tests__/delete-project-scope.test.ts
@@ -1,0 +1,56 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { deleteProject } from "@/actions/projects/delete-project";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("deleteProject scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await deleteProject("b1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns error, no delete", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await deleteProject("b1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user owner: soft-deletes board", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await deleteProject("b1");
+    expect(res).toEqual({ success: true });
+    const updArgs = (prismadb.boards.update as jest.Mock).mock.calls[0][0];
+    expect(updArgs.data.deletedBy).toBe("u1");
+  });
+
+  it("manager: bare write scope", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await deleteProject("b1");
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/delete-section-scope.test.ts
+++ b/actions/projects/__tests__/delete-section-scope.test.ts
@@ -1,0 +1,64 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    sections: { findUnique: jest.fn(), delete: jest.fn() },
+    tasks: { deleteMany: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { deleteSection } from "@/actions/projects/delete-section";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("deleteSection scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await deleteSection("s1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.sections.delete).not.toHaveBeenCalled();
+  });
+
+  it("section's board out-of-scope returns Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await deleteSection("s1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.sections.delete).not.toHaveBeenCalled();
+    expect(prismadb.tasks.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("in-scope owner deletes section and its tasks", async () => {
+    mockUser("user", "u1");
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
+    (prismadb.sections.delete as jest.Mock).mockResolvedValue({ id: "s1" });
+    const res = await deleteSection("s1");
+    expect(res).toEqual({ success: true });
+    expect(prismadb.tasks.deleteMany).toHaveBeenCalledWith({ where: { section: "s1" } });
+    expect(prismadb.sections.delete).toHaveBeenCalledWith({ where: { id: "s1" } });
+  });
+
+  it("manager bare write scope deletes section", async () => {
+    mockUser("manager", "m1");
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+    (prismadb.sections.delete as jest.Mock).mockResolvedValue({ id: "s1" });
+    const res = await deleteSection("s1");
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/delete-task-scope.test.ts
+++ b/actions/projects/__tests__/delete-task-scope.test.ts
@@ -1,0 +1,76 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    tasks: { findUnique: jest.fn(), findMany: jest.fn(), update: jest.fn(), delete: jest.fn() },
+    tasksComments: { deleteMany: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { deleteTask } from "@/actions/projects/delete-task";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = { id: "t1" };
+
+describe("deleteTask scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await deleteTask(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.tasks.delete).not.toHaveBeenCalled();
+  });
+
+  it("task's board out-of-scope returns Forbidden (assignee not allowed for delete)", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await deleteTask(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.tasks.delete).not.toHaveBeenCalled();
+  });
+
+  it("in-scope board owner deletes task", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      id: "t1",
+      section: "s1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasksComments.deleteMany as jest.Mock).mockResolvedValue({});
+    (prismadb.tasks.delete as jest.Mock).mockResolvedValue({});
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+    const res = await deleteTask(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.tasks.delete).toHaveBeenCalled();
+  });
+
+  it("manager bare scope deletes task", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      id: "t1",
+      section: "s1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasksComments.deleteMany as jest.Mock).mockResolvedValue({});
+    (prismadb.tasks.delete as jest.Mock).mockResolvedValue({});
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+    const res = await deleteTask(args);
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/get-board-scope.test.ts
+++ b/actions/projects/__tests__/get-board-scope.test.ts
@@ -1,0 +1,62 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    sections: { findMany: jest.fn() },
+  },
+}));
+jest.mock("@/lib/junction-helpers", () => ({
+  junctionTableHelpers: { includeWatchersWithUsers: () => ({}) },
+  extractWatcherUsers: () => [],
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getBoard } from "@/actions/projects/get-board";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getBoard scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns null and does not query board", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getBoard("b1");
+    expect(res).toBeNull();
+    expect(prismadb.boards.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns null (assert miss)", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValueOnce(null);
+    const res = await getBoard("b1");
+    expect(res).toBeNull();
+    expect(prismadb.sections.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope: assert passes, returns board+sections", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock)
+      .mockResolvedValueOnce({ id: "b1" }) // assert
+      .mockResolvedValueOnce({ id: "b1", title: "X" }); // detail
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([]);
+    const res = await getBoard("b1");
+    expect(res).toEqual({ board: { id: "b1", title: "X" }, sections: [] });
+  });
+
+  it("manager: assert where has no OR (bare scope)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock)
+      .mockResolvedValueOnce({ id: "b1" })
+      .mockResolvedValueOnce({ id: "b1" });
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([]);
+    await getBoard("b1");
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+    expect(assertCall.where.deletedAt).toBeNull();
+  });
+});

--- a/actions/projects/__tests__/get-board-sections-scope.test.ts
+++ b/actions/projects/__tests__/get-board-sections-scope.test.ts
@@ -1,0 +1,53 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    sections: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getBoardSections } from "@/actions/projects/get-board-sections";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getBoardSections scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns []", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getBoardSections("b1");
+    expect(res).toEqual([]);
+    expect(prismadb.sections.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns []", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getBoardSections("b1");
+    expect(res).toEqual([]);
+    expect(prismadb.sections.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope: returns sections", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([{ id: "s1" }]);
+    const res = await getBoardSections("b1");
+    expect(res).toEqual([{ id: "s1" }]);
+  });
+
+  it("manager: assert bare scope, returns sections", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([]);
+    await getBoardSections("b1");
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/get-boards-scope.test.ts
+++ b/actions/projects/__tests__/get-boards-scope.test.ts
@@ -1,0 +1,60 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findMany: jest.fn() },
+  },
+}));
+jest.mock("@/lib/junction-helpers", () => ({
+  junctionTableHelpers: {
+    watchedByUser: () => ({ watchers: { some: { user_id: "x" } } }),
+    includeWatchersWithUsers: () => ({}),
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getBoards } from "@/actions/projects/get-boards";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getBoards scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns [] and does not query", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getBoards();
+    expect(res).toEqual([]);
+    expect(prismadb.boards.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where uses board read scope OR with deletedAt:null", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findMany as jest.Mock).mockResolvedValue([]);
+    await getBoards();
+    const call = (prismadb.boards.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.deletedAt).toBeNull();
+    expect(Array.isArray(call.where.OR)).toBe(true);
+    expect(call.where.OR.length).toBeGreaterThan(0);
+  });
+
+  it("user role: returns rows from findMany", async () => {
+    mockUser("user", "u1");
+    const rows = [{ id: "b1" }];
+    (prismadb.boards.findMany as jest.Mock).mockResolvedValue(rows);
+    const res = await getBoards();
+    expect(res).toEqual(rows);
+  });
+
+  it("manager: where = deletedAt:null only (no OR)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findMany as jest.Mock).mockResolvedValue([]);
+    await getBoards();
+    const call = (prismadb.boards.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.deletedAt).toBeNull();
+    expect(call.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/get-kanban-data-scope.test.ts
+++ b/actions/projects/__tests__/get-kanban-data-scope.test.ts
@@ -1,0 +1,55 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), findUnique: jest.fn() },
+    sections: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getKanbanData } from "@/actions/projects/get-kanban-data";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getKanbanData scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns empty shape", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getKanbanData("b1");
+    expect(res).toEqual({ board: null, sections: [] });
+    expect(prismadb.boards.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns empty shape", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getKanbanData("b1");
+    expect(res).toEqual({ board: null, sections: [] });
+    expect(prismadb.boards.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope: returns board + sections", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.findUnique as jest.Mock).mockResolvedValue({ id: "b1", title: "X" });
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([{ id: "s1" }]);
+    const res = await getKanbanData("b1");
+    expect(res).toEqual({ board: { id: "b1", title: "X" }, sections: [{ id: "s1" }] });
+  });
+
+  it("manager: assert bare, returns data", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.findUnique as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([]);
+    await getKanbanData("b1");
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/get-sections-scope.test.ts
+++ b/actions/projects/__tests__/get-sections-scope.test.ts
@@ -1,0 +1,52 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    sections: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getSections } from "@/actions/projects/get-sections";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getSections scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns []", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getSections();
+    expect(res).toEqual([]);
+    expect(prismadb.sections.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where joins through board_relation read scope", async () => {
+    mockUser("user", "u1");
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([]);
+    await getSections();
+    const call = (prismadb.sections.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.board_relation).toBeDefined();
+    expect(Array.isArray(call.where.board_relation.OR)).toBe(true);
+  });
+
+  it("user role: returns rows", async () => {
+    mockUser("user", "u1");
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([{ id: "s1" }]);
+    const res = await getSections();
+    expect(res).toEqual([{ id: "s1" }]);
+  });
+
+  it("manager: where uses bare board_relation (no OR)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.sections.findMany as jest.Mock).mockResolvedValue([]);
+    await getSections();
+    const call = (prismadb.sections.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.board_relation.OR).toBeUndefined();
+    expect(call.where.board_relation.deletedAt).toBeNull();
+  });
+});

--- a/actions/projects/__tests__/get-task-comments-scope.test.ts
+++ b/actions/projects/__tests__/get-task-comments-scope.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    tasks: { findUnique: jest.fn() },
+    tasksComments: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTaskComments } from "@/actions/projects/get-task-comments";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTaskComments scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns []", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTaskComments("t1");
+    expect(res).toEqual([]);
+    expect(prismadb.tasksComments.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns []", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getTaskComments("t1");
+    expect(res).toEqual([]);
+    expect(prismadb.tasksComments.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope: returns comments", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasksComments.findMany as jest.Mock).mockResolvedValue([{ id: "c1" }]);
+    const res = await getTaskComments("t1");
+    expect(res).toEqual([{ id: "c1" }]);
+  });
+
+  it("manager: bare scope, returns comments", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasksComments.findMany as jest.Mock).mockResolvedValue([]);
+    await getTaskComments("t1");
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/get-task-documents-scope.test.ts
+++ b/actions/projects/__tests__/get-task-documents-scope.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    tasks: { findUnique: jest.fn() },
+    documents: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTaskDocuments } from "@/actions/projects/get-task-documents";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTaskDocuments scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns []", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTaskDocuments("t1");
+    expect(res).toEqual([]);
+    expect(prismadb.documents.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns []", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getTaskDocuments("t1");
+    expect(res).toEqual([]);
+    expect(prismadb.documents.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope: returns docs", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([{ id: "d1" }]);
+    const res = await getTaskDocuments("t1");
+    expect(res).toEqual([{ id: "d1" }]);
+  });
+
+  it("manager: bare scope, returns docs", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.documents.findMany as jest.Mock).mockResolvedValue([]);
+    await getTaskDocuments("t1");
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/get-task-scope.test.ts
+++ b/actions/projects/__tests__/get-task-scope.test.ts
@@ -1,0 +1,63 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    tasks: { findUnique: jest.fn(), findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTask } from "@/actions/projects/get-task";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTask scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns null", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTask("t1");
+    expect(res).toBeNull();
+    expect(prismadb.tasks.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope (board read denied): returns null", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getTask("t1");
+    expect(res).toBeNull();
+    expect(prismadb.tasks.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope: returns task", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    const detail = { id: "t1", content: "X" };
+    (prismadb.tasks.findFirst as jest.Mock).mockResolvedValue(detail);
+    const res = await getTask("t1");
+    expect(res).toEqual(detail);
+  });
+
+  it("manager: bare scope, returns task", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.findFirst as jest.Mock).mockResolvedValue({ id: "t1" });
+    await getTask("t1");
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/get-tasks-past-due-scope.test.ts
+++ b/actions/projects/__tests__/get-tasks-past-due-scope.test.ts
@@ -1,0 +1,55 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    tasks: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTasksPastDue } from "@/actions/projects/get-tasks-past-due";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTasksPastDue scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns undefined", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTasksPastDue();
+    expect(res).toBeUndefined();
+    expect(prismadb.tasks.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: AND includes user-scope filter", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+    await getTasksPastDue();
+    const call = (prismadb.tasks.findMany as jest.Mock).mock.calls[0][0];
+    const hasUserClause = call.where.AND.some((c: { user?: string }) => c.user === "u1");
+    expect(hasUserClause).toBe(true);
+  });
+
+  it("user role: returns object shape", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([{ id: "t1" }]);
+    const res = await getTasksPastDue();
+    expect(res).toEqual({
+      getTaskPastDue: [{ id: "t1" }],
+      getTaskPastDueInSevenDays: [{ id: "t1" }],
+    });
+  });
+
+  it("manager: AND has no user filter (global)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+    await getTasksPastDue();
+    const call = (prismadb.tasks.findMany as jest.Mock).mock.calls[0][0];
+    const hasUserClause = call.where.AND.some((c: { user?: string }) => "user" in c);
+    expect(hasUserClause).toBe(false);
+  });
+});

--- a/actions/projects/__tests__/get-tasks-scope.test.ts
+++ b/actions/projects/__tests__/get-tasks-scope.test.ts
@@ -1,0 +1,52 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    tasks: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getTasks } from "@/actions/projects/get-tasks";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getTasks scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns []", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getTasks();
+    expect(res).toEqual([]);
+    expect(prismadb.tasks.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user role: where joins through assigned_section.board_relation OR scope", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+    await getTasks();
+    const call = (prismadb.tasks.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.assigned_section.board_relation).toBeDefined();
+    expect(Array.isArray(call.where.assigned_section.board_relation.OR)).toBe(true);
+  });
+
+  it("user role: returns tasks", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([{ id: "t1" }]);
+    const res = await getTasks();
+    expect(res).toEqual([{ id: "t1" }]);
+  });
+
+  it("manager: where uses bare board_relation (no OR)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+    await getTasks();
+    const call = (prismadb.tasks.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.assigned_section.board_relation.OR).toBeUndefined();
+    expect(call.where.assigned_section.board_relation.deletedAt).toBeNull();
+  });
+});

--- a/actions/projects/__tests__/get-user-tasks-scope.test.ts
+++ b/actions/projects/__tests__/get-user-tasks-scope.test.ts
@@ -1,0 +1,48 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    tasks: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getUserTasks } from "@/actions/projects/get-user-tasks";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getUserTasks scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns []", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await getUserTasks("u1");
+    expect(res).toEqual([]);
+    expect(prismadb.tasks.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user requesting another user's tasks: returns []", async () => {
+    mockUser("user", "u1");
+    const res = await getUserTasks("u2");
+    expect(res).toEqual([]);
+    expect(prismadb.tasks.findMany).not.toHaveBeenCalled();
+  });
+
+  it("user requesting own tasks: returns rows", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([{ id: "t1" }]);
+    const res = await getUserTasks("u1");
+    expect(res).toEqual([{ id: "t1" }]);
+  });
+
+  it("manager requesting another user's tasks: returns rows", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([{ id: "t9" }]);
+    const res = await getUserTasks("u2");
+    expect(res).toEqual([{ id: "t9" }]);
+  });
+});

--- a/actions/projects/__tests__/mark-task-done-scope.test.ts
+++ b/actions/projects/__tests__/mark-task-done-scope.test.ts
@@ -1,0 +1,81 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    tasks: { findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { markTaskDone } from "@/actions/projects/mark-task-done";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("markTaskDone scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await markTaskDone("t1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+
+  it("assignee can mark done even when board is out-of-scope", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    const res = await markTaskDone("t1");
+    expect(res).toEqual({ success: true });
+    // assignee bypass: no board lookup needed
+    expect(prismadb.boards.findFirst).not.toHaveBeenCalled();
+    expect(prismadb.tasks.update).toHaveBeenCalled();
+  });
+
+  it("non-assignee user with board out-of-scope: Forbidden", async () => {
+    mockUser("user", "u2");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await markTaskDone("t1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+
+  it("board owner (non-assignee) can mark done", async () => {
+    mockUser("user", "u2");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    const res = await markTaskDone("t1");
+    expect(res).toEqual({ success: true });
+  });
+
+  it("manager bare scope marks done", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    const res = await markTaskDone("t1");
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/update-kanban-position-scope.test.ts
+++ b/actions/projects/__tests__/update-kanban-position-scope.test.ts
@@ -1,0 +1,88 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    sections: { findUnique: jest.fn() },
+    tasks: { findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { updateKanbanPosition } from "@/actions/projects/update-kanban-position";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = {
+  resourceList: [{ id: "t1" }],
+  destinationList: [{ id: "t2" }],
+  resourceSectionId: "s1",
+  destinationSectionId: "s2",
+};
+
+describe("updateKanbanPosition scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await updateKanbanPosition(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+
+  it("assignee on every task can reorder even with out-of-scope board", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({});
+    const res = await updateKanbanPosition(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.boards.findFirst).not.toHaveBeenCalled();
+    expect(prismadb.tasks.update).toHaveBeenCalled();
+  });
+
+  it("non-assignee user with board out-of-scope: Forbidden", async () => {
+    mockUser("user", "u2");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await updateKanbanPosition(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+
+  it("board owner reorders", async () => {
+    mockUser("user", "u2");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({});
+    const res = await updateKanbanPosition(args);
+    expect(res).toEqual({ success: true });
+  });
+
+  it("manager bare scope reorders", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({});
+    const res = await updateKanbanPosition(args);
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/update-project-scope.test.ts
+++ b/actions/projects/__tests__/update-project-scope.test.ts
@@ -1,0 +1,57 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { updateProject } from "@/actions/projects/update-project";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = { id: "b1", title: "t", description: "d", visibility: "private" };
+
+describe("updateProject scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await updateProject(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns error, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await updateProject(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user owner: assert passes, updates board", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await updateProject(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.boards.update).toHaveBeenCalled();
+  });
+
+  it("manager: bare write scope", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await updateProject(args);
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/update-section-title-scope.test.ts
+++ b/actions/projects/__tests__/update-section-title-scope.test.ts
@@ -1,0 +1,61 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn() },
+    sections: { findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { updateSectionTitle } from "@/actions/projects/update-section-title";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = { sectionId: "s1", newTitle: "New Title" };
+
+describe("updateSectionTitle scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await updateSectionTitle(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.sections.update).not.toHaveBeenCalled();
+  });
+
+  it("section's board out-of-scope returns Forbidden", async () => {
+    mockUser("user", "u1");
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await updateSectionTitle(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.sections.update).not.toHaveBeenCalled();
+  });
+
+  it("in-scope owner updates section title", async () => {
+    mockUser("user", "u1");
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.update as jest.Mock).mockResolvedValue({ id: "s1" });
+    const res = await updateSectionTitle(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.sections.update).toHaveBeenCalled();
+  });
+
+  it("manager bare write scope updates section title", async () => {
+    mockUser("manager", "m1");
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ board: "b1" });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.sections.update as jest.Mock).mockResolvedValue({ id: "s1" });
+    const res = await updateSectionTitle(args);
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/update-task-scope.test.ts
+++ b/actions/projects/__tests__/update-task-scope.test.ts
@@ -1,0 +1,75 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+    tasks: { findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/resend", () => ({ __esModule: true, default: jest.fn(async () => null) }));
+jest.mock("@/emails/UpdatedTaskFromProject", () => ({ __esModule: true, default: () => null }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { updateTask } from "@/actions/projects/update-task";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+const args = {
+  taskId: "t1",
+  title: "T",
+  user: "u1",
+  priority: "normal",
+  content: "C",
+};
+
+describe("updateTask scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await updateTask(args);
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+
+  it("task's board out-of-scope returns Forbidden (assignee not allowed for full update)", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await updateTask(args);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+
+  it("in-scope board owner updates task", async () => {
+    mockUser("user", "u1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    const res = await updateTask(args);
+    expect(res).toEqual({ success: true });
+    expect(prismadb.tasks.update).toHaveBeenCalled();
+  });
+
+  it("manager bare scope updates task", async () => {
+    mockUser("manager", "m1");
+    (prismadb.tasks.findUnique as jest.Mock).mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    });
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({ id: "t1" });
+    const res = await updateTask(args);
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/__tests__/watch-project-scope.test.ts
+++ b/actions/projects/__tests__/watch-project-scope.test.ts
@@ -1,0 +1,99 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    boards: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("@/lib/junction-helpers", () => ({
+  junctionTableHelpers: {
+    addWatcher: jest.fn(() => ({ create: { user_id: "x" } })),
+    removeBoardWatcher: jest.fn(() => ({ delete: { id: "x" } })),
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { watchProject, unwatchProject } from "@/actions/projects/watch-project";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("watchProject scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await watchProject("b1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns error, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await watchProject("b1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope (read): adds watcher", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await watchProject("b1");
+    expect(res).toEqual({ success: true });
+    expect(prismadb.boards.update).toHaveBeenCalled();
+  });
+
+  it("manager: bare read scope", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await watchProject("b1");
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});
+
+describe("unwatchProject scope", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unauthenticated returns Unauthorized", async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const res = await unwatchProject("b1");
+    expect(res).toEqual({ error: "Unauthorized" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user out-of-scope: returns error, no update", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await unwatchProject("b1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("user in-scope (read): removes watcher", async () => {
+    mockUser("user", "u1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await unwatchProject("b1");
+    expect(res).toEqual({ success: true });
+    expect(prismadb.boards.update).toHaveBeenCalled();
+  });
+
+  it("manager: bare read scope", async () => {
+    mockUser("manager", "m1");
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b1" });
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b1" });
+    const res = await unwatchProject("b1");
+    expect(res).toEqual({ success: true });
+    const assertCall = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(assertCall.where.OR).toBeUndefined();
+  });
+});

--- a/actions/projects/add-comment-to-task.ts
+++ b/actions/projects/add-comment-to-task.ts
@@ -5,17 +5,49 @@ import { junctionTableHelpers } from "@/lib/junction-helpers";
 import { revalidatePath } from "next/cache";
 import NewTaskCommentEmail from "@/emails/NewTaskComment";
 import resendHelper from "@/lib/resend";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const addCommentToTask = async (data: {
   taskId: string;
   comment: string;
 }) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
   const { taskId, comment } = data;
   if (!taskId) return { error: "Missing task ID" };
   if (!comment) return { error: "Missing comment" };
+
+  // Resolve parent board (if any) via assigned_section relation for scope check.
+  const taskBoardLookup = await prismadb.tasks.findUnique({
+    where: { id: taskId },
+    select: {
+      assigned_section: { select: { board_relation: { select: { id: true } } } },
+    },
+  });
+  const parentBoardId =
+    taskBoardLookup?.assigned_section?.board_relation?.id;
+  if (parentBoardId) {
+    try {
+      await assertCanWriteBoard(authzUser, parentBoardId);
+    } catch (e) {
+      if (e instanceof AuthorizationError) return { error: "Forbidden" };
+      throw e;
+    }
+  }
 
   try {
     const task = await prismadb.tasks.findUnique({

--- a/actions/projects/assign-document-to-task.ts
+++ b/actions/projects/assign-document-to-task.ts
@@ -2,17 +2,45 @@
 import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTask,
+  assertCanReadDocument,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const assignDocumentToTask = async (data: {
   documentId: string;
   taskId: string;
 }) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
   const { documentId, taskId } = data;
   if (!documentId) return { error: "Missing document ID" };
   if (!taskId) return { error: "Missing task ID" };
+
+  try {
+    await assertCanWriteTask(authzUser, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  try {
+    await assertCanReadDocument(authzUser, documentId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const task = await prismadb.tasks.findUnique({

--- a/actions/projects/create-project.ts
+++ b/actions/projects/create-project.ts
@@ -1,15 +1,20 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import { requireAuthenticated, AuthenticationError } from "@/lib/authz";
 
 export const createProject = async (data: {
   title: string;
   description: string;
   visibility: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   const { title, description, visibility } = data;
   if (!title) return { error: "Missing project name" };
@@ -21,13 +26,13 @@ export const createProject = async (data: {
     const newBoard = await prismadb.boards.create({
       data: {
         v: 0,
-        user: session.user.id,
+        user: user.id,
         title,
         description,
         position: boardsCount > 0 ? boardsCount : 0,
         visibility,
-        sharedWith: [session.user.id],
-        createdBy: session.user.id,
+        sharedWith: [user.id],
+        createdBy: user.id,
       },
     });
 

--- a/actions/projects/create-section.ts
+++ b/actions/projects/create-section.ts
@@ -1,18 +1,35 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const createSection = async (data: {
   boardId: string;
   title: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   const { boardId, title } = data;
   if (!title) return { error: "Missing section title" };
   if (!boardId) return { error: "Missing board ID" };
+
+  try {
+    await assertCanWriteBoard(user, boardId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const sectionPosition = await prismadb.sections.count({

--- a/actions/projects/create-task-in-board.ts
+++ b/actions/projects/create-task-in-board.ts
@@ -4,6 +4,12 @@ import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import NewTaskFromProject from "@/emails/NewTaskFromProject";
 import resendHelper from "@/lib/resend";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const createTaskInBoard = async (data: {
   boardId: string;
@@ -14,12 +20,27 @@ export const createTaskInBoard = async (data: {
   user?: string;
   dueDateAt?: Date;
 }) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
   const { boardId, section, title, priority, content, user, dueDateAt } = data;
 
   if (!section) return { error: "Missing section ID" };
+
+  try {
+    await assertCanWriteBoard(authzUser, boardId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   // Quick-add path: no title/user/priority/content - create a blank task
   if (!title || !user || !priority || !content) {

--- a/actions/projects/create-task.ts
+++ b/actions/projects/create-task.ts
@@ -4,6 +4,12 @@ import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import NewTaskFromProject from "@/emails/NewTaskFromProject";
 import resendHelper from "@/lib/resend";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const createTask = async (data: {
   title: string;
@@ -14,6 +20,14 @@ export const createTask = async (data: {
   dueDateAt?: Date;
   account?: string;
 }) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
@@ -21,6 +35,13 @@ export const createTask = async (data: {
 
   if (!title || !user || !board || !priority || !content) {
     return { error: "Missing one of the task data" };
+  }
+
+  try {
+    await assertCanWriteBoard(authzUser, board);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {

--- a/actions/projects/delete-project.ts
+++ b/actions/projects/delete-project.ts
@@ -1,18 +1,35 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteProject = async (projectId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   if (!projectId) return { error: "Missing project ID" };
 
   try {
+    await assertCanWriteBoard(user, projectId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  try {
     await prismadb.boards.update({
       where: { id: projectId },
-      data: { deletedAt: new Date(), deletedBy: session.user.id },
+      data: { deletedAt: new Date(), deletedBy: user.id },
     });
 
     revalidatePath("/[locale]/(routes)/projects", "page");

--- a/actions/projects/delete-section.ts
+++ b/actions/projects/delete-section.ts
@@ -1,13 +1,36 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteSection = async (sectionId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   if (!sectionId) return { error: "Missing section ID" };
+
+  const existing = await prismadb.sections.findUnique({
+    where: { id: sectionId },
+    select: { board: true },
+  });
+  if (!existing) return { error: "Not found" };
+
+  try {
+    await assertCanWriteBoard(user, existing.board);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.tasks.deleteMany({

--- a/actions/projects/delete-task.ts
+++ b/actions/projects/delete-task.ts
@@ -2,13 +2,45 @@
 import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteTask = async (data: { id: string; section?: string }) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
   const { id } = data;
   if (!id) return { error: "Missing task ID" };
+
+  const existing = await prismadb.tasks.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      section: true,
+      assigned_section: { select: { board_relation: { select: { id: true } } } },
+    },
+  });
+  const parentBoardId = existing?.assigned_section?.board_relation?.id;
+  if (!parentBoardId) return { error: "Not found" };
+
+  try {
+    await assertCanWriteBoard(authzUser, parentBoardId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const currentTask = await prismadb.tasks.findUnique({

--- a/actions/projects/get-board-sections.ts
+++ b/actions/projects/get-board-sections.ts
@@ -1,6 +1,27 @@
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getBoardSections = async (boadId: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
+  try {
+    await assertCanReadBoard(user, boadId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
+
   const data = await prismadb.sections.findMany({
     where: {
       board: boadId,

--- a/actions/projects/get-board.ts
+++ b/actions/projects/get-board.ts
@@ -1,7 +1,28 @@
 import { prismadb } from "@/lib/prisma";
 import { junctionTableHelpers, extractWatcherUsers } from "@/lib/junction-helpers";
+import {
+  requireAuthenticated,
+  assertCanReadBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getBoard = async (id: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
+
+  try {
+    await assertCanReadBoard(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+
   const board = await prismadb.boards.findFirst({
     where: {
       id: id,

--- a/actions/projects/get-boards.ts
+++ b/actions/projects/get-boards.ts
@@ -1,24 +1,21 @@
 import { prismadb } from "@/lib/prisma";
 import { junctionTableHelpers } from "@/lib/junction-helpers";
+import {
+  requireAuthenticated,
+  boardReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
-export const getBoards = async (userId: string) => {
-  if (!userId) {
-    return null;
+export const getBoards = async (_userId?: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
   }
   const data = await prismadb.boards.findMany({
-    where: {
-      deletedAt: null,
-      OR: [
-        {
-          user: userId,
-        },
-        {
-          visibility: "public",
-        },
-        // Find boards where user is a watcher using BoardWatchers junction table
-        junctionTableHelpers.watchedByUser(userId),
-      ],
-    },
+    where: boardReadScopeWhere(user),
     include: {
       assigned_user: {
         select: {

--- a/actions/projects/get-kanban-data.ts
+++ b/actions/projects/get-kanban-data.ts
@@ -1,12 +1,32 @@
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getKanbanData = async (boardId: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { board: null, sections: [] };
+    throw e;
+  }
+
+  try {
+    await assertCanReadBoard(user, boardId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { board: null, sections: [] };
+    throw e;
+  }
+
   const board = await prismadb.boards.findUnique({
     where: {
       id: boardId,
     },
   });
-  //console.log(board, "getBoard - board");
 
   //Select sections from board with boardId, tasks are included
   let sections = await prismadb.sections.findMany({

--- a/actions/projects/get-sections.ts
+++ b/actions/projects/get-sections.ts
@@ -1,7 +1,24 @@
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  boardReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getSections = async () => {
-  const data = await prismadb.sections.findMany({});
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
+  const data = await prismadb.sections.findMany({
+    where: {
+      board_relation: boardReadScopeWhere(user),
+    },
+  });
 
   return data;
 };

--- a/actions/projects/get-task-comments.ts
+++ b/actions/projects/get-task-comments.ts
@@ -1,4 +1,10 @@
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 /**
  * Fetch comments for a Projects task (`Tasks` model).
@@ -8,6 +14,21 @@ import { prismadb } from "@/lib/prisma";
  * through this function.
  */
 export const getTaskComments = async (taskId: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
+  try {
+    await assertCanReadTask(user, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
+
   const data = await prismadb.tasksComments.findMany({
     where: {
       task: taskId,

--- a/actions/projects/get-task-documents.ts
+++ b/actions/projects/get-task-documents.ts
@@ -1,6 +1,27 @@
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanReadTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getTaskDocuments = async (taskId: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
+  try {
+    await assertCanReadTask(user, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return [];
+    throw e;
+  }
+
   // Query documents through DocumentsToTasks junction table
   const data = await prismadb.documents.findMany({
     where: {

--- a/actions/projects/get-task.ts
+++ b/actions/projects/get-task.ts
@@ -1,7 +1,28 @@
 import { prismadb } from "@/lib/prisma";
 import { junctionTableHelpers } from "@/lib/junction-helpers";
+import {
+  requireAuthenticated,
+  assertCanReadTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const getTask = async (taskId: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return null;
+    throw e;
+  }
+
+  try {
+    await assertCanReadTask(user, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+
   const data = await prismadb.tasks.findFirst({
     where: {
       id: taskId,

--- a/actions/projects/get-tasks-past-due.ts
+++ b/actions/projects/get-tasks-past-due.ts
@@ -1,97 +1,103 @@
 import { prismadb } from "@/lib/prisma";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  AuthenticationError,
+} from "@/lib/authz";
 import dayjs from "dayjs";
 
 export const getTasksPastDue = async () => {
-  const session = await getSession();
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return undefined;
+    throw e;
+  }
   const today = dayjs().startOf("day");
   const nextWeek = dayjs().add(7, "day").startOf("day");
-  if (session) {
-    const getTaskPastDue = await prismadb.tasks.findMany({
-      where: {
-        AND: [
-          {
-            user: session.user.id,
-          },
-          {
-            dueDateAt: {
-              lte: new Date(),
-            },
-          },
-          {
-            taskStatus: {
-              not: "COMPLETE",
-            },
-          },
-        ],
-      },
-      include: {
-        comments: {
-          select: {
-            id: true,
-            comment: true,
-            createdAt: true,
-            assigned_user: {
-              select: {
-                id: true,
-                name: true,
-                avatar: true,
-              },
-            },
-          },
-          orderBy: {
-            createdAt: "desc",
+  // user role: restrict to own tasks. manager/admin: global.
+  const userScope =
+    user.role === "user" ? [{ user: user.id }] : [];
+
+  const getTaskPastDue = await prismadb.tasks.findMany({
+    where: {
+      AND: [
+        ...userScope,
+        {
+          dueDateAt: {
+            lte: new Date(),
           },
         },
-      },
-    });
-
-    const getTaskPastDueInSevenDays = await prismadb.tasks.findMany({
-      where: {
-        AND: [
-          {
-            user: session.user.id,
-          },
-          {
-            dueDateAt: {
-              //lte: dayjs().add(7, "day").toDate(),
-              gt: today.toDate(), // Due date is greater than or equal to today
-              lt: nextWeek.toDate(), // Due date is less than next week (not including today)
-            },
-          },
-          {
-            taskStatus: {
-              not: "COMPLETE",
-            },
-          },
-        ],
-      },
-      include: {
-        comments: {
-          select: {
-            id: true,
-            comment: true,
-            createdAt: true,
-            assigned_user: {
-              select: {
-                id: true,
-                name: true,
-                avatar: true,
-              },
-            },
-          },
-          orderBy: {
-            createdAt: "desc",
+        {
+          taskStatus: {
+            not: "COMPLETE",
           },
         },
+      ],
+    },
+    include: {
+      comments: {
+        select: {
+          id: true,
+          comment: true,
+          createdAt: true,
+          assigned_user: {
+            select: {
+              id: true,
+              name: true,
+              avatar: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
       },
-    });
+    },
+  });
 
-    const data = {
-      getTaskPastDue,
-      getTaskPastDueInSevenDays,
-    };
+  const getTaskPastDueInSevenDays = await prismadb.tasks.findMany({
+    where: {
+      AND: [
+        ...userScope,
+        {
+          dueDateAt: {
+            gt: today.toDate(),
+            lt: nextWeek.toDate(),
+          },
+        },
+        {
+          taskStatus: {
+            not: "COMPLETE",
+          },
+        },
+      ],
+    },
+    include: {
+      comments: {
+        select: {
+          id: true,
+          comment: true,
+          createdAt: true,
+          assigned_user: {
+            select: {
+              id: true,
+              name: true,
+              avatar: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      },
+    },
+  });
 
-    return data;
-  }
+  const data = {
+    getTaskPastDue,
+    getTaskPastDueInSevenDays,
+  };
+
+  return data;
 };

--- a/actions/projects/get-tasks.ts
+++ b/actions/projects/get-tasks.ts
@@ -1,54 +1,24 @@
 import { prismadb } from "@/lib/prisma";
-import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  boardReadScopeWhere,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getTasks = async () => {
-  const session = await getSession();
-  const userId = session?.user?.id;
-
-  const boards = await prismadb.boards.findMany({
-    where: {
-      OR: [
-        {
-          user: userId,
-        },
-        {
-          visibility: "public",
-        },
-      ],
-    },
-    include: {
-      assigned_user: {
-        select: {
-          name: true,
-        },
-      },
-    },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
-
-  if (!boards) return null;
-  if (!userId) return null;
-
-  //Filtering tasks by section and board
-  const sections = await prismadb.sections.findMany({
-    where: {
-      OR: boards.map((board: any) => {
-        return {
-          board: board.id,
-        };
-      }),
-    },
-  });
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
 
   const data = await prismadb.tasks.findMany({
     where: {
-      OR: sections.map((section: any) => {
-        return {
-          section: section.id,
-        };
-      }),
+      assigned_section: {
+        board_relation: boardReadScopeWhere(user),
+      },
     },
     include: {
       assigned_user: {

--- a/actions/projects/get-user-tasks.ts
+++ b/actions/projects/get-user-tasks.ts
@@ -1,6 +1,23 @@
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const getUserTasks = async (userId: string) => {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return [];
+    throw e;
+  }
+
+  // user role: only allowed to read own tasks.
+  if (user.role === "user" && userId !== user.id) {
+    return [];
+  }
+
   const data = await prismadb.tasks.findMany({
     where: {
       user: userId,

--- a/actions/projects/mark-task-done.ts
+++ b/actions/projects/mark-task-done.ts
@@ -2,12 +2,33 @@
 import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const markTaskDone = async (taskId: string) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
   if (!taskId) return { error: "Missing task ID" };
+
+  try {
+    await assertCanWriteTask(authzUser, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.tasks.update({

--- a/actions/projects/update-kanban-position.ts
+++ b/actions/projects/update-kanban-position.ts
@@ -2,6 +2,12 @@
 import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateKanbanPosition = async (data: {
   resourceList: { id: string }[];
@@ -9,6 +15,14 @@ export const updateKanbanPosition = async (data: {
   resourceSectionId: string;
   destinationSectionId: string;
 }) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
@@ -18,6 +32,21 @@ export const updateKanbanPosition = async (data: {
     resourceSectionId,
     destinationSectionId,
   } = data;
+
+  // Soft scope: each affected task must be writable by current user
+  // (board write OR assignee bypass for status-only changes).
+  const allTaskIds = [
+    ...resourceList.map((t) => t.id),
+    ...destinationList.map((t) => t.id),
+  ];
+  for (const id of allTaskIds) {
+    try {
+      await assertCanWriteTask(authzUser, id);
+    } catch (e) {
+      if (e instanceof AuthorizationError) return { error: "Forbidden" };
+      throw e;
+    }
+  }
 
   try {
     const resourceListReverse = [...resourceList].reverse();

--- a/actions/projects/update-project.ts
+++ b/actions/projects/update-project.ts
@@ -1,7 +1,12 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateProject = async (data: {
   id: string;
@@ -9,12 +14,24 @@ export const updateProject = async (data: {
   description: string;
   visibility: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   const { id, title, description, visibility } = data;
   if (!title) return { error: "Missing project name" };
   if (!description) return { error: "Missing project description" };
+
+  try {
+    await assertCanWriteBoard(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.boards.update({
@@ -23,7 +40,7 @@ export const updateProject = async (data: {
         title,
         description,
         visibility,
-        updatedBy: session.user.id,
+        updatedBy: user.id,
         updatedAt: new Date(),
       },
     });

--- a/actions/projects/update-section-title.ts
+++ b/actions/projects/update-section-title.ts
@@ -1,17 +1,40 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateSectionTitle = async (data: {
   sectionId: string;
   newTitle: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   const { sectionId, newTitle } = data;
   if (!sectionId) return { error: "Missing section ID" };
+
+  const existing = await prismadb.sections.findUnique({
+    where: { id: sectionId },
+    select: { board: true },
+  });
+  if (!existing) return { error: "Not found" };
+
+  try {
+    await assertCanWriteBoard(user, existing.board);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.sections.update({

--- a/actions/projects/update-task.ts
+++ b/actions/projects/update-task.ts
@@ -4,6 +4,12 @@ import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import UpdatedTaskFromProject from "@/emails/UpdatedTaskFromProject";
 import resendHelper from "@/lib/resend";
+import {
+  requireAuthenticated,
+  assertCanWriteBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateTask = async (data: {
   taskId: string;
@@ -15,6 +21,14 @@ export const updateTask = async (data: {
   content: string;
   dueDateAt?: Date;
 }) => {
+  let authzUser;
+  try {
+    authzUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
@@ -24,6 +38,22 @@ export const updateTask = async (data: {
   if (!taskId) return { error: "Missing task ID" };
   if (!title || !user || !priority || !content) {
     return { error: "Missing one of the task data" };
+  }
+
+  const existing = await prismadb.tasks.findUnique({
+    where: { id: taskId },
+    select: {
+      assigned_section: { select: { board_relation: { select: { id: true } } } },
+    },
+  });
+  const parentBoardId = existing?.assigned_section?.board_relation?.id;
+  if (!parentBoardId) return { error: "Not found" };
+
+  try {
+    await assertCanWriteBoard(authzUser, parentBoardId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {

--- a/actions/projects/watch-project.ts
+++ b/actions/projects/watch-project.ts
@@ -1,20 +1,37 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { junctionTableHelpers } from "@/lib/junction-helpers";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanReadBoard,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const watchProject = async (projectId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   if (!projectId) return { error: "Missing project ID" };
+
+  try {
+    await assertCanReadBoard(user, projectId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.boards.update({
       where: { id: projectId },
       data: {
-        watchers: junctionTableHelpers.addWatcher(session.user.id),
+        watchers: junctionTableHelpers.addWatcher(user.id),
       },
     });
 
@@ -27,10 +44,22 @@ export const watchProject = async (projectId: string) => {
 };
 
 export const unwatchProject = async (projectId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   if (!projectId) return { error: "Missing project ID" };
+
+  try {
+    await assertCanReadBoard(user, projectId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.boards.update({
@@ -38,7 +67,7 @@ export const unwatchProject = async (projectId: string) => {
       data: {
         watchers: junctionTableHelpers.removeBoardWatcher(
           projectId,
-          session.user.id
+          user.id
         ),
       },
     });

--- a/lib/authz/__tests__/scopes-document-read.test.ts
+++ b/lib/authz/__tests__/scopes-document-read.test.ts
@@ -2,7 +2,7 @@ import { AuthorizationError } from "../errors";
 
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
-    Documents: { findFirst: jest.fn(), findMany: jest.fn() },
+    documents: { findFirst: jest.fn(), findMany: jest.fn() },
   },
 }));
 

--- a/lib/authz/__tests__/scopes-projects.test.ts
+++ b/lib/authz/__tests__/scopes-projects.test.ts
@@ -1,0 +1,207 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    boards: { findFirst: jest.fn() },
+    tasks: { findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  boardReadScopeWhere,
+  boardWriteScopeWhere,
+  assertCanReadBoard,
+  assertCanWriteBoard,
+  assertCanReadTask,
+  assertCanWriteTask,
+} from "../scopes/crm";
+
+const findBoard = prismadb.boards.findFirst as jest.MockedFunction<
+  typeof prismadb.boards.findFirst
+>;
+const findTask = prismadb.tasks.findUnique as jest.MockedFunction<
+  typeof prismadb.tasks.findUnique
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("boardReadScopeWhere", () => {
+  it("admin → only deletedAt:null", () => {
+    expect(boardReadScopeWhere({ id: "x", role: "admin" })).toEqual({
+      deletedAt: null,
+    });
+  });
+  it("manager → only deletedAt:null", () => {
+    expect(boardReadScopeWhere({ id: "x", role: "manager" })).toEqual({
+      deletedAt: null,
+    });
+  });
+  it("user → deletedAt + OR with 4 branches (owner / shared / public / watcher)", () => {
+    const w = boardReadScopeWhere({ id: "u1", role: "user" }) as {
+      deletedAt: null;
+      OR: unknown[];
+    };
+    expect(w.deletedAt).toBeNull();
+    expect(w.OR).toEqual(
+      expect.arrayContaining([
+        { user: "u1" },
+        { sharedWith: { has: "u1" } },
+        { visibility: "public" },
+        { watchers: { some: { user_id: "u1" } } },
+      ]),
+    );
+    expect(w.OR).toHaveLength(4);
+  });
+});
+
+describe("boardWriteScopeWhere", () => {
+  it("admin → only deletedAt:null", () => {
+    expect(boardWriteScopeWhere({ id: "x", role: "admin" })).toEqual({
+      deletedAt: null,
+    });
+  });
+  it("manager → only deletedAt:null", () => {
+    expect(boardWriteScopeWhere({ id: "x", role: "manager" })).toEqual({
+      deletedAt: null,
+    });
+  });
+  it("user → owner only", () => {
+    expect(boardWriteScopeWhere({ id: "u1", role: "user" })).toEqual({
+      deletedAt: null,
+      user: "u1",
+    });
+  });
+});
+
+describe("assertCanReadBoard", () => {
+  it("admin: hit resolves", async () => {
+    findBoard.mockResolvedValue({ id: "b1" } as never);
+    await assertCanReadBoard({ id: "x", role: "admin" }, "b1");
+    expect(findBoard).toHaveBeenCalledWith({
+      where: { id: "b1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+  it("user: scoped where with OR", async () => {
+    findBoard.mockResolvedValue({ id: "b1" } as never);
+    await assertCanReadBoard({ id: "u1", role: "user" }, "b1");
+    const arg = findBoard.mock.calls[0][0]!;
+    expect(arg.where).toMatchObject({ id: "b1", deletedAt: null });
+    expect((arg.where as { OR?: unknown[] }).OR).toBeDefined();
+  });
+  it("throws on miss", async () => {
+    findBoard.mockResolvedValue(null);
+    await expect(
+      assertCanReadBoard({ id: "u1", role: "user" }, "b1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteBoard", () => {
+  it("user: where uses owner-only filter", async () => {
+    findBoard.mockResolvedValue({ id: "b1" } as never);
+    await assertCanWriteBoard({ id: "u1", role: "user" }, "b1");
+    expect(findBoard).toHaveBeenCalledWith({
+      where: { id: "b1", deletedAt: null, user: "u1" },
+      select: { id: true },
+    });
+  });
+  it("throws on miss", async () => {
+    findBoard.mockResolvedValue(null);
+    await expect(
+      assertCanWriteBoard({ id: "u1", role: "user" }, "b1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanReadTask", () => {
+  it("traverses task → section → board, delegates to board read", async () => {
+    findTask.mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    } as never);
+    findBoard.mockResolvedValue({ id: "b1" } as never);
+    await assertCanReadTask({ id: "u1", role: "user" }, "t1");
+    expect(findTask).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      select: {
+        assigned_section: {
+          select: { board_relation: { select: { id: true } } },
+        },
+      },
+    });
+    expect(findBoard).toHaveBeenCalled();
+  });
+  it("throws when task missing", async () => {
+    findTask.mockResolvedValue(null);
+    await expect(
+      assertCanReadTask({ id: "u1", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+  it("throws when section/board missing", async () => {
+    findTask.mockResolvedValue({ assigned_section: null } as never);
+    await expect(
+      assertCanReadTask({ id: "u1", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+  it("throws when board read denied", async () => {
+    findTask.mockResolvedValue({
+      assigned_section: { board_relation: { id: "b1" } },
+    } as never);
+    findBoard.mockResolvedValue(null);
+    await expect(
+      assertCanReadTask({ id: "u1", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteTask", () => {
+  it("user assignee bypass: resolves without board check", async () => {
+    findTask.mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    } as never);
+    await assertCanWriteTask({ id: "u1", role: "user" }, "t1");
+    expect(findBoard).not.toHaveBeenCalled();
+  });
+  it("user non-assignee: delegates to board write", async () => {
+    findTask.mockResolvedValue({
+      user: "other",
+      assigned_section: { board_relation: { id: "b1" } },
+    } as never);
+    findBoard.mockResolvedValue({ id: "b1" } as never);
+    await assertCanWriteTask({ id: "u1", role: "user" }, "t1");
+    expect(findBoard).toHaveBeenCalledWith({
+      where: { id: "b1", deletedAt: null, user: "u1" },
+      select: { id: true },
+    });
+  });
+  it("admin: skips assignee bypass, delegates to board write (deletedAt only)", async () => {
+    findTask.mockResolvedValue({
+      user: "u1",
+      assigned_section: { board_relation: { id: "b1" } },
+    } as never);
+    findBoard.mockResolvedValue({ id: "b1" } as never);
+    await assertCanWriteTask({ id: "admin1", role: "admin" }, "t1");
+    expect(findBoard).toHaveBeenCalledWith({
+      where: { id: "b1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+  it("throws when task missing", async () => {
+    findTask.mockResolvedValue(null);
+    await expect(
+      assertCanWriteTask({ id: "u1", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+  it("throws when board denies", async () => {
+    findTask.mockResolvedValue({
+      user: "other",
+      assigned_section: { board_relation: { id: "b1" } },
+    } as never);
+    findBoard.mockResolvedValue(null);
+    await expect(
+      assertCanWriteTask({ id: "u1", role: "user" }, "t1"),
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -69,5 +69,13 @@ export {
   assertCanWriteDocument,
   filterAuthorizedDocumentIds,
 } from "./scopes/crm";
+export {
+  boardReadScopeWhere,
+  boardWriteScopeWhere,
+  assertCanReadBoard,
+  assertCanWriteBoard,
+  assertCanReadTask,
+  assertCanWriteTask,
+} from "./scopes/crm";
 export type { ReportScope } from "./scopes/report-scope";
 export { getReportScope } from "./scopes/report-scope";

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -574,3 +574,91 @@ export async function assertCanWriteTemplate(
 ): Promise<void> {
   return assertCanReadTemplate(user, id);
 }
+
+// ---------------------------------------------------------------------------
+// E4.T1: Board + task scope helpers (Projects module).
+// Boards: owner (`user`) + sharedWith uuid[] + visibility="public" + watchers junction.
+// Tasks:  scope by parent board via assigned_section.board_relation.
+// Write: board owner only (or manager/admin); task assignees get write bypass
+//        for status-only updates (per plan; route enforces field whitelist).
+// ---------------------------------------------------------------------------
+
+export function boardReadScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return {
+    deletedAt: null,
+    OR: [
+      { user: user.id },
+      { sharedWith: { has: user.id } },
+      { visibility: "public" },
+      { watchers: { some: { user_id: user.id } } },
+    ],
+  };
+}
+
+export function boardWriteScopeWhere(user: AuthzUser) {
+  if (user.role === "admin" || user.role === "manager") {
+    return { deletedAt: null };
+  }
+  return { deletedAt: null, user: user.id };
+}
+
+export async function assertCanReadBoard(
+  user: AuthzUser,
+  boardId: string,
+): Promise<void> {
+  const row = await prismadb.boards.findFirst({
+    where: { id: boardId, ...boardReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteBoard(
+  user: AuthzUser,
+  boardId: string,
+): Promise<void> {
+  const row = await prismadb.boards.findFirst({
+    where: { id: boardId, ...boardWriteScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanReadTask(
+  user: AuthzUser,
+  taskId: string,
+): Promise<void> {
+  const task = await prismadb.tasks.findUnique({
+    where: { id: taskId },
+    select: {
+      assigned_section: {
+        select: { board_relation: { select: { id: true } } },
+      },
+    },
+  });
+  const boardId = task?.assigned_section?.board_relation?.id;
+  if (!boardId) throw new AuthorizationError();
+  return assertCanReadBoard(user, boardId);
+}
+
+export async function assertCanWriteTask(
+  user: AuthzUser,
+  taskId: string,
+): Promise<void> {
+  const task = await prismadb.tasks.findUnique({
+    where: { id: taskId },
+    select: {
+      user: true,
+      assigned_section: {
+        select: { board_relation: { select: { id: true } } },
+      },
+    },
+  });
+  const boardId = task?.assigned_section?.board_relation?.id;
+  if (!boardId) throw new AuthorizationError();
+  if (user.role === "user" && task?.user === user.id) return;
+  return assertCanWriteBoard(user, boardId);
+}


### PR DESCRIPTION
## Summary

Adds role + ownership scoping to the projects subsystem (boards, sections, tasks, comments, document assignments). After E4, a \`user\` only sees boards they own, are shared with, watch, or that are public; sections/tasks inherit their parent board's scope. Manager/admin: bare reads. **Phase E is complete with this PR** — only Phase F (cleanup) remains.

## What changed

**New helpers in \`lib/authz/scopes/crm.ts\`:**
- \`boardReadScopeWhere(user)\` — admin/manager: \`{deletedAt: null}\`; user: owner OR sharedWith OR visibility="public" OR watcher
- \`boardWriteScopeWhere(user)\` — owner-only for users; bare for manager/admin
- \`assertCanReadBoard\`, \`assertCanWriteBoard\`
- \`assertCanReadTask\` — traverses task → section → board, asserts board read
- \`assertCanWriteTask\` — soft variant; user role allowed if task assignee, else board write

**Project read actions patched (11):**
- \`get-boards\` (replaces existing manual OR with helper), \`get-board\`, \`get-board-sections\`, \`get-sections\`, \`get-kanban-data\`, \`get-task\`, \`get-task-comments\`, \`get-task-documents\`, \`get-tasks\` (nested where through section→board), \`get-tasks-past-due\` (user role scoped to own), \`get-user-tasks\` (cross-user blocked for users)

**Board + section + task mutations patched (16):**
- Board: \`create-project\` (auth only — anyone can make own), \`update-project\`, \`delete-project\` (write scope), \`watch-project\`/\`unwatch-project\` (read scope sufficient)
- Section: \`create-section\`, \`update-section-title\`, \`delete-section\` — parent board write scope
- Task strict tier (board write required): \`create-task\`, \`create-task-in-board\`, \`update-task\`, \`delete-task\`, \`add-comment-to-task\`
- Task soft tier (assignee allowed for status changes): \`mark-task-done\`, \`update-kanban-position\`
- \`assign-document-to-task\` — task soft-write AND \`assertCanReadDocument\` (E3 helper)

**Test infrastructure fix:**
- Merged duplicate \`prismadb.documents\` mock keys in 8 E3 test files (post-E3 fix \`a816361\` switched production code to lowercase \`documents\`; tests had both casings). Independent of E4 functionality but blocks tests from loading.

## Test status

- 156/163 suites pass, 793/795 tests pass
- ~85 new E4 tests across helpers + 26 actions
- 7 pre-existing suite failures (Inngest env-init, currency, etc.) and 1 pre-existing test failure unchanged — no NEW regressions from E4 changes
- Note: \`search-documents-scope.test.ts\` has 1 failing test pre-existing on \`dev\` (verified by reverting E4 changes and re-running on \`origin/dev\`). It tests an E3 invariant the post-E3 follow-up didn't preserve. Out of E4 scope; flag for E3 follow-up if needed.

## Test plan

- [ ] As \`bob\` (user, no board ownership), list boards → empty (or only public/shared/watched)
- [ ] As \`bob\`, navigate to private board owned by \`alice\` → not found
- [ ] As \`bob\`, \`updateProject(<alice-board>)\` → \`{error: "Forbidden"}\`
- [ ] As \`bob\` assigned to a task on \`alice\`'s board: \`markTaskDone\` succeeds (assignee bypass), \`updateTask\` (full edit) → \`{error: "Forbidden"}\` (board write required)
- [ ] As \`bob\`, \`assignDocumentToTask({task: alice-task, document: alice-doc})\` → forbidden (both sides fail)
- [ ] As \`manager\`, all the above → succeed

## Phase E summary (across E1+E2+E3+E4)

After all four PRs merge:
- Products + account-products + invoice list-scoping (E1)
- Campaigns + templates with manager/admin send/schedule gating (E2)
- Documents with linked-entity scope and fail-closed bulk ops (E3)
- Projects with board owner/shared/watcher/public scope; assignee soft-write (E4)

Total Phase E: 53 actions hardened, 16 new helpers in \`lib/authz/scopes/crm.ts\`, ~290 new tests.

## Out of E4 scope

- **Phase F**: cleanup — remove \`Users.is_admin\`/\`is_account_admin\` columns, switch \`Users.role\` to a Prisma enum, dedupe \`created_by\`/\`createdBy\`
- BoardWatchers add/remove via separate management UI (handled by watch-project/unwatch-project actions in this PR)
- Per-task visibility tags — feature creep
- The pre-existing \`search-documents-scope.test.ts\` failure — separate fix

Plan: \`docs/superpowers/plans/2026-05-04-permission-driven-migration-phase-e4.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)