### PR TITLE
fix(security): scope CRM accounts list by user authz read scope

### DIFF
--- a/actions/crm/__tests__/get-accounts-scope.test.ts
+++ b/actions/crm/__tests__/get-accounts-scope.test.ts
@@ -1,0 +1,74 @@
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findUnique: jest.fn() },
+    crm_Accounts: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { getAccounts } from "@/actions/crm/get-accounts";
+
+const mockUser = (role: "user" | "manager" | "admin", id = "u1") => {
+  (getSession as jest.Mock).mockResolvedValue({ user: { id } });
+  (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id, role });
+};
+
+describe("getAccounts (rich-shape, page-level)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("user role: where merges deletedAt:null + creator/assigned/watcher OR", async () => {
+    mockUser("user", "u1");
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    await getAccounts();
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({
+      deletedAt: null,
+      OR: [
+        { assigned_to: "u1" },
+        { createdBy: "u1" },
+        { watchers: { some: { user_id: "u1" } } },
+      ],
+    });
+  });
+
+  it("manager role: where = { deletedAt: null } (no OR)", async () => {
+    mockUser("manager", "m1");
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    await getAccounts();
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ deletedAt: null });
+  });
+
+  it("admin role: where = { deletedAt: null } (no OR)", async () => {
+    mockUser("admin", "a1");
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    await getAccounts();
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ deletedAt: null });
+  });
+
+  it("preserves the rich include shape used by AccountsView (assigned_to_user, contacts, watchers)", async () => {
+    mockUser("admin", "a1");
+    (prismadb.crm_Accounts.findMany as jest.Mock).mockResolvedValue([]);
+    await getAccounts();
+    const call = (prismadb.crm_Accounts.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.include).toMatchObject({
+      assigned_to_user: { select: { name: true } },
+      contacts: { select: { first_name: true, last_name: true } },
+      watchers: expect.objectContaining({
+        include: expect.objectContaining({
+          user: expect.objectContaining({
+            select: expect.objectContaining({
+              id: true,
+              name: true,
+              email: true,
+              avatar: true,
+            }),
+          }),
+        }),
+      }),
+    });
+  });
+});

--- a/actions/crm/get-accounts.ts
+++ b/actions/crm/get-accounts.ts
@@ -1,9 +1,11 @@
 import { cache } from "react";
 import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, accountReadScopeWhere } from "@/lib/authz";
 
 export const getAccounts = cache(async () => {
+  const user = await requireAuthenticated();
   const data = await prismadb.crm_Accounts.findMany({
-    where: { deletedAt: null },
+    where: accountReadScopeWhere(user),
     include: {
       assigned_to_user: {
         select: {


### PR DESCRIPTION
## Summary

Caught during manual smoke-test of the authz migration: `/en/crm/accounts` was leaking every account to every authenticated user.

**Root cause:** two `getAccounts` implementations exist in the repo.
- `actions/crm/get-accounts.ts` (this PR) — rich-shape variant used by the accounts page, the CRM main page, and `/documents`. Phase D2 missed it.
- `actions/crm/accounts/get-accounts.ts` — minimal-shape variant used by `update-contract.tsx`. Already scoped, has tests.

The page rendered the unscoped one. Tests passed against the scoped sibling and didn't catch it.

**Fix:** apply `requireAuthenticated()` + `accountReadScopeWhere(user)` to the rich-shape variant. Behavior:
- admin / manager → `where: { deletedAt: null }` (unchanged).
- user → `where: { deletedAt: null, OR: [assigned_to | createdBy | watcher] }`.

The rich `include` (assigned_to_user, contacts, watchers) is preserved so `AccountsView` and other consumers render unchanged.

## Sibling-regression sweep

Confirmed all other top-level list actions (`get-contacts`, `get-leads`, `get-opportunities`, `get-targets`, `get-target-lists`) already use their scope helpers. This was an isolated miss.

## Tests

New: `actions/crm/__tests__/get-accounts-scope.test.ts` — 4 cases (user / manager / admin / preserved include shape). Regression confirmed by running on pre-fix code (user case fails with extra `OR`). Post-fix, all pass; full Jest suite remains green (827 tests).

## Test plan

- [ ] CI green
- [ ] As a `user` on staging dev, `/crm/accounts` now lists only assigned/created/watched accounts.
- [ ] Manager / admin still see all accounts.
- [ ] CRM main page (`/crm`) shows the same scoped list.
- [ ] Documents page account dropdown shows the same scoped list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)