### PR TITLE
fix(mcp): set basePath so /api/mcp/{mcp,sse} actually route

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,19 +136,22 @@ NextCRM now ships with a built-in [Model Context Protocol](https://modelcontextp
 
 **Authentication:** Generate Bearer tokens (`nxtc__...`) from your profile page. Tokens are SHA-256 hashed — the raw value is shown only once and never stored.
 
-**Connect your MCP client:**
+**Connect your MCP client** (streamable HTTP — recommended):
 ```json
 {
   "mcpServers": {
     "nextcrm": {
-      "url": "https://your-nextcrm.com/api/mcp/sse",
+      "type": "http",
+      "url": "https://your-nextcrm.com/api/mcp/mcp",
       "headers": { "Authorization": "Bearer nxtc__your_token_here" }
     }
   }
 }
 ```
 
-Both SSE (`/api/mcp/sse`) and HTTP (`/api/mcp/http`) transports are supported.
+The server supports both MCP transports defined by `mcp-handler`:
+- **Streamable HTTP** at `/api/mcp/mcp` — single POST endpoint, current MCP spec default
+- **SSE (legacy)** at `/api/mcp/sse` — GET stream paired with POSTs to `/api/mcp/message` (client auto-discovers the message endpoint)
 
 **Claude Code Skill:** Download the [SKILL.md](/en/profile?tab=developer) from your Developer profile tab for a ready-to-use Claude Code skill with full tool documentation.
 
@@ -202,7 +205,7 @@ Global search across all CRM entities from a single search bar — grouped resul
 - [Vercel AI SDK 6.x](https://sdk.vercel.ai/) – Unified AI interface
 - [pgvector](https://github.com/pgvector/pgvector) – PostgreSQL vector extension for similarity search (HNSW indexes)
 - [E2B](https://e2b.dev/) – Cloud sandboxes with real Chrome browser for AI-driven web research and contact enrichment
-- [MCP Server](https://modelcontextprotocol.io/) – 127 tools across 15 modules via `@vercel/mcp-adapter`, Bearer token auth, SSE + HTTP transports
+- [MCP Server](https://modelcontextprotocol.io/) – 127 tools across 15 modules via `mcp-handler` (Vercel MCP adapter), Bearer token auth, streamable HTTP (`/api/mcp/mcp`) + legacy SSE (`/api/mcp/sse`) transports
 
 ### Data fetching
 

--- a/app/[locale]/(routes)/profile/components/SkillMdCopyButton.tsx
+++ b/app/[locale]/(routes)/profile/components/SkillMdCopyButton.tsx
@@ -6,7 +6,8 @@ import { Copy, Check } from "lucide-react";
 const MCP_CONFIG = `{
   "mcpServers": {
     "nextcrm": {
-      "url": "https://YOUR_NEXTCRM_URL/api/mcp/sse",
+      "type": "http",
+      "url": "https://YOUR_NEXTCRM_URL/api/mcp/mcp",
       "headers": { "Authorization": "Bearer YOUR_API_TOKEN" }
     }
   }

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -31,6 +31,9 @@ const handler = createMcpHandler(
   },
   {
     capabilities: { tools: {} },
+  },
+  {
+    basePath: "/api/mcp",
   }
 );
 

--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -9,12 +9,33 @@ Use the NextCRM MCP server to read and write CRM data. This skill documents all 
 
 ## Connection Setup
 
-Add this to your MCP client configuration:
+The server supports two MCP transports. Pick one — most modern clients (Claude Code, Cursor) work with either.
+
+### Option A — Streamable HTTP (recommended)
+
+Single POST endpoint. Simpler, the current MCP spec default.
 
 ```json
 {
   "mcpServers": {
     "nextcrm": {
+      "type": "http",
+      "url": "https://YOUR_NEXTCRM_URL/api/mcp/mcp",
+      "headers": { "Authorization": "Bearer YOUR_API_TOKEN" }
+    }
+  }
+}
+```
+
+### Option B — SSE (legacy, for older clients)
+
+Two endpoints: a GET SSE stream and a POST message channel. The client opens `/api/mcp/sse`, the server announces the matching `/api/mcp/message?sessionId=…` endpoint over the stream, and the client POSTs JSON-RPC there.
+
+```json
+{
+  "mcpServers": {
+    "nextcrm": {
+      "type": "sse",
       "url": "https://YOUR_NEXTCRM_URL/api/mcp/sse",
       "headers": { "Authorization": "Bearer YOUR_API_TOKEN" }
     }
@@ -22,10 +43,14 @@ Add this to your MCP client configuration:
 }
 ```
 
-- Replace `YOUR_NEXTCRM_URL` with your NextCRM instance URL
+You only configure the `/sse` URL — the client discovers the message endpoint automatically.
+
+### Notes
+
+- Replace `YOUR_NEXTCRM_URL` with your NextCRM instance URL (e.g. `http://localhost:3000` for local dev)
 - Replace `YOUR_API_TOKEN` with a token generated from Profile > Developer > API Tokens
 - Token prefix: `nxtc__`
-- Both SSE (`/api/mcp/sse`) and HTTP (`/api/mcp/http`) transports are supported
+- Some clients omit the `type` field and infer the transport from the URL — both forms above include it explicitly for clarity
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- Adds `basePath: \"/api/mcp\"` to the `createMcpHandler` call in `app/api/mcp/[transport]/route.ts`. Without it, mcp-handler was looking for routes at its default `/sse` and `/mcp` paths and every real request to `/api/mcp/{mcp,sse,message}` returned a bare \"Not found\".
- Documents both supported transports in `public/SKILL.md` as first-class options: streamable HTTP at `/api/mcp/mcp` (recommended) and legacy SSE at `/api/mcp/sse`. The previous text incorrectly advertised an `/api/mcp/http` path that never existed.
- Updates the **Copy MCP Config** button on `/en/profile?tab=developer` so the copied snippet uses `/api/mcp/mcp` with explicit `\"type\": \"http\"`, matching the recommended config.

## Test plan
- [x] Local `initialize` and `tools/list` against `http://localhost:3000/api/mcp/mcp` return 200 with valid server capabilities and the full tool list
- [x] `tools/call crm_list_accounts {limit: 3}` with a valid `nxtc__` bearer token returns real account data
- [x] Missing token → `{\"error\":\"Unauthorized\",\"code\":\"UNAUTHORIZED\"}`
- [x] Invalid token → `{\"error\":\"Invalid token\",\"code\":\"INTERNAL_ERROR\"}`
- [ ] Verify on deployed `dev` env that an MCP client (Claude Code, Cursor) can connect using the streamable-HTTP config from `SKILL.md`
- [ ] Verify SSE transport still works for clients configured against `/api/mcp/sse`
- [ ] Spot-check the Developer tab UI renders the copy button and the copied JSON is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)