### PR TITLE
fix(security): enforce object-level authz in MCP campaign tools (GHSA-c9vg-c532-ppqx)

### DIFF
--- a/__tests__/mcp/campaigns-scope.test.ts
+++ b/__tests__/mcp/campaigns-scope.test.ts
@@ -1,0 +1,207 @@
+// Regression tests for GHSA-c9vg-c532-ppqx
+// BOLA/IDOR in MCP campaign tools: handlers must enforce per-user/role scope
+// so a normal user cannot list, read, or mutate campaigns owned by others.
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_campaigns: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    crm_campaign_templates: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    crm_campaign_steps: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    crm_campaign_sends: { findMany: jest.fn() },
+    campaignToTargetLists: { create: jest.fn(), delete: jest.fn() },
+  },
+}));
+jest.mock("@/inngest/client", () => ({ inngest: { send: jest.fn() } }));
+
+import { prismadb } from "@/lib/prisma";
+import { campaignTools } from "@/lib/mcp/tools/campaigns";
+
+type Role = "user" | "manager" | "admin";
+const USER = { id: "u1", role: "user" as Role };
+const MANAGER = { id: "m1", role: "manager" as Role };
+
+const tool = (name: string) => {
+  const t = campaignTools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool not found: ${name}`);
+  return t;
+};
+// Handlers receive (args, userId, user)
+const run = (name: string, args: any, user: { id: string; role: Role }) =>
+  (tool(name).handler as any)(args, user.id, user);
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("campaigns_list scope", () => {
+  it("normal user is scoped to created_by = own id", async () => {
+    (prismadb.crm_campaigns.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.crm_campaigns.count as jest.Mock).mockResolvedValue(0);
+    await run("campaigns_list", { limit: 20, offset: 0 }, USER);
+    const where = (prismadb.crm_campaigns.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.created_by).toBe("u1");
+  });
+
+  it("manager is NOT scoped by created_by", async () => {
+    (prismadb.crm_campaigns.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.crm_campaigns.count as jest.Mock).mockResolvedValue(0);
+    await run("campaigns_list", { limit: 20, offset: 0 }, MANAGER);
+    const where = (prismadb.crm_campaigns.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.created_by).toBeUndefined();
+  });
+});
+
+describe("campaigns_get scope", () => {
+  it("normal user: scope where includes created_by + status not deleted", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1" });
+    await run("campaigns_get", { id: "c1" }, USER);
+    const where = (prismadb.crm_campaigns.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.created_by).toBe("u1");
+    expect(where.status).toEqual({ not: "deleted" });
+  });
+
+  it("out-of-scope campaign returns NOT_FOUND", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_get", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe("campaigns_update scope", () => {
+  it("out-of-scope campaign throws NOT_FOUND and never updates", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      run("campaigns_update", { id: "victim", name: "hacked" }, USER)
+    ).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("scopes the ownership lookup by created_by for normal users", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue({ id: "c1", status: "draft" });
+    (prismadb.crm_campaigns.update as jest.Mock).mockResolvedValue({ id: "c1" });
+    await run("campaigns_update", { id: "c1", name: "ok" }, USER);
+    const where = (prismadb.crm_campaigns.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.created_by).toBe("u1");
+  });
+});
+
+describe("campaigns_delete scope", () => {
+  it("out-of-scope campaign throws NOT_FOUND and never soft-deletes", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_delete", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("campaigns_send / pause / resume scope", () => {
+  it("send: out-of-scope throws NOT_FOUND, no status change", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_send", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("pause: out-of-scope throws NOT_FOUND, no status change", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_pause", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+
+  it("resume: out-of-scope throws NOT_FOUND, no status change", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_resume", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaigns.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("campaigns_get_stats scope", () => {
+  it("out-of-scope throws NOT_FOUND and never reads sends", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_get_stats", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaign_sends.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("campaign step scope (parent campaign ownership)", () => {
+  it("create_step: parent campaign out-of-scope throws NOT_FOUND", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      run(
+        "campaigns_create_step",
+        { campaign_id: "victim", order: 1, template_id: "t1", subject: "x", delay_days: 0, send_to: "all" },
+        USER
+      )
+    ).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("update_step: parent campaign out-of-scope throws NOT_FOUND and never updates", async () => {
+    (prismadb.crm_campaign_steps.findUnique as jest.Mock).mockResolvedValue({ id: "s1", campaign_id: "victim" });
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_update_step", { id: "s1", subject: "x" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaign_steps.update).not.toHaveBeenCalled();
+  });
+
+  it("delete_step: parent campaign out-of-scope throws NOT_FOUND and never deletes", async () => {
+    (prismadb.crm_campaign_steps.findUnique as jest.Mock).mockResolvedValue({ id: "s1", campaign_id: "victim" });
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_delete_step", { id: "s1" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaign_steps.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("campaign target-list assignment scope", () => {
+  it("assign: parent campaign out-of-scope throws NOT_FOUND and never links", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      run("campaigns_assign_target_list", { campaign_id: "victim", target_list_id: "tl1" }, USER)
+    ).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.campaignToTargetLists.create).not.toHaveBeenCalled();
+  });
+
+  it("remove: parent campaign out-of-scope throws NOT_FOUND and never unlinks", async () => {
+    (prismadb.crm_campaigns.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      run("campaigns_remove_target_list", { campaign_id: "victim", target_list_id: "tl1" }, USER)
+    ).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.campaignToTargetLists.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("campaign template scope", () => {
+  it("list_templates: normal user scoped by created_by", async () => {
+    (prismadb.crm_campaign_templates.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.crm_campaign_templates.count as jest.Mock).mockResolvedValue(0);
+    await run("campaigns_list_templates", { limit: 20, offset: 0 }, USER);
+    const where = (prismadb.crm_campaign_templates.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.created_by).toBe("u1");
+  });
+
+  it("get_template: out-of-scope throws NOT_FOUND", async () => {
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_get_template", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("update_template: out-of-scope throws NOT_FOUND and never updates", async () => {
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      run("campaigns_update_template", { id: "victim", name: "x" }, USER)
+    ).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaign_templates.update).not.toHaveBeenCalled();
+  });
+
+  it("delete_template: out-of-scope throws NOT_FOUND and never updates", async () => {
+    (prismadb.crm_campaign_templates.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(run("campaigns_delete_template", { id: "victim" }, USER)).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.crm_campaign_templates.update).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -8,7 +8,9 @@ const handler = createMcpHandler(
       server.tool(tool.name, tool.description, tool.schema.shape, async (args: Record<string, unknown>) => {
         try {
           const mcpUser = await getMcpUser();
-          const result = await tool.handler(args as any, mcpUser.id);
+          // Pass userId (2nd arg, used by owner-scoped CRM tools) and the full
+          // authz user (3rd arg, used by role-aware campaign tools — GHSA-c9vg-c532-ppqx).
+          const result = await (tool.handler as any)(args as any, mcpUser.id, mcpUser);
           return {
             content: [{ type: "text" as const, text: JSON.stringify(result) }],
           };

--- a/lib/mcp/auth.ts
+++ b/lib/mcp/auth.ts
@@ -1,9 +1,13 @@
 import { validateApiToken } from "@/lib/api-tokens";
 import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { mapLegacyRole } from "@/lib/authz/roles";
+import type { AuthzUser } from "@/lib/authz";
 
-export interface McpUser {
-  id: string;
-}
+// McpUser carries the full authorization context (id + role) so tool handlers
+// can apply the same owner/role scoping as the server actions.
+// Shape-compatible with AuthzUser.
+export type McpUser = AuthzUser;
 
 export async function getMcpUser(): Promise<McpUser> {
   const { headers } = await import("next/headers");
@@ -13,19 +17,31 @@ export async function getMcpUser(): Promise<McpUser> {
     ? authHeader.slice(7)
     : null;
 
+  let userId: string | null = null;
+
   if (bearer?.startsWith("nxtc__")) {
-    const userId = await validateApiToken(bearer);
-    return { id: userId };
-  }
-
-  // Development-only fallback: better-auth session cookie
-  // Not used in production — session cannot substitute for token revocation
-  if (process.env.NODE_ENV === "development") {
+    userId = await validateApiToken(bearer);
+  } else if (process.env.NODE_ENV === "development") {
+    // Development-only fallback: better-auth session cookie
+    // Not used in production — session cannot substitute for token revocation
     const session = await getSession();
-    if (session?.user?.id) {
-      return { id: session.user.id };
-    }
+    userId = session?.user?.id ?? null;
   }
 
-  throw new Error("Unauthorized");
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
+
+  // Resolve the authorization role so handlers can enforce object-level access
+  // (GHSA-c9vg-c532-ppqx): without the role, scope helpers cannot distinguish
+  // owners from admins/managers.
+  const dbUser = await prismadb.users.findUnique({
+    where: { id: userId },
+    select: { id: true, role: true },
+  });
+  if (!dbUser) {
+    throw new Error("Unauthorized");
+  }
+
+  return { id: dbUser.id, role: mapLegacyRole(dbUser.role) };
 }

--- a/lib/mcp/tools/campaigns.ts
+++ b/lib/mcp/tools/campaigns.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
 import { inngest } from "@/inngest/client";
+import type { AuthzUser } from "@/lib/authz";
+import {
+  campaignReadScopeWhere,
+  campaignTemplateReadScopeWhere,
+} from "@/lib/authz/scopes/crm";
 import {
   paginationSchema,
   paginationArgs,
@@ -11,18 +16,31 @@ import {
   softDeleteData,
 } from "../helpers";
 
+// Object-level authorization for campaign tools (GHSA-c9vg-c532-ppqx).
+// Normal users are scoped to campaigns/templates they created; managers and
+// admins see all. Out-of-scope access returns NOT_FOUND (no existence leak),
+// consistent with the owner-scoped CRM tools.
+async function assertCampaignInScope(user: AuthzUser, campaignId: string): Promise<void> {
+  const row = await prismadb.crm_campaigns.findFirst({
+    where: { id: campaignId, ...campaignReadScopeWhere(user) },
+    select: { id: true },
+  });
+  if (!row) notFound("Campaign");
+}
+
 export const campaignTools = [
   // ── Campaigns CRUD ────────────────────────────────────
   {
     name: "campaigns_list",
-    description: "List campaigns (org-wide)",
+    description: "List campaigns the caller is allowed to see",
     schema: z.object({
       status: z.enum(["draft", "scheduled", "sending", "sent", "paused"]).optional(),
       ...paginationSchema,
     }),
-    async handler(args: { status?: string; limit: number; offset: number }, _userId: string) {
+    async handler(args: { status?: string; limit: number; offset: number }, _userId: string, user: AuthzUser) {
       const where: any = {
         deletedAt: null,
+        ...campaignReadScopeWhere(user),
         ...(args.status && { status: args.status }),
       };
       const [data, total] = await Promise.all([
@@ -41,9 +59,9 @@ export const campaignTools = [
     name: "campaigns_get",
     description: "Get a campaign by ID with steps and stats summary",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const campaign = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.id, deletedAt: null },
+        where: { id: args.id, deletedAt: null, ...campaignReadScopeWhere(user) },
         include: {
           steps: { orderBy: { order: "asc" }, include: { template: true } },
           target_lists: { include: { target_list: true } },
@@ -94,9 +112,9 @@ export const campaignTools = [
       reply_to: z.string().email().optional(),
       template_id: z.string().uuid().optional(),
     }),
-    async handler(args: Record<string, any>, _userId: string) {
+    async handler(args: Record<string, any>, _userId: string, user: AuthzUser) {
       const existing = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.id, deletedAt: null },
+        where: { id: args.id, deletedAt: null, ...campaignReadScopeWhere(user) },
       });
       if (!existing) notFound("Campaign");
       if (existing.status === "sending") conflict("Cannot update a campaign that is currently sending");
@@ -109,9 +127,9 @@ export const campaignTools = [
     name: "campaigns_delete",
     description: "Soft-delete a campaign (sets deletedAt timestamp)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
+    async handler(args: { id: string }, userId: string, user: AuthzUser) {
       const existing = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.id, deletedAt: null },
+        where: { id: args.id, deletedAt: null, ...campaignReadScopeWhere(user) },
       });
       if (!existing) notFound("Campaign");
       if (existing.status === "sending") conflict("Cannot delete a campaign that is currently sending");
@@ -128,9 +146,9 @@ export const campaignTools = [
     name: "campaigns_send",
     description: "Trigger sending a campaign. Campaign must be in draft or scheduled status.",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const campaign = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.id, deletedAt: null },
+        where: { id: args.id, deletedAt: null, ...campaignReadScopeWhere(user) },
       });
       if (!campaign) notFound("Campaign");
       if (!["draft", "scheduled"].includes(campaign.status ?? "")) {
@@ -149,9 +167,9 @@ export const campaignTools = [
     name: "campaigns_pause",
     description: "Pause an active/sending campaign",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const campaign = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.id },
+        where: { id: args.id, ...campaignReadScopeWhere(user) },
       });
       if (!campaign) notFound("Campaign");
       if (campaign.status !== "sending") conflict(`Cannot pause campaign in status: ${campaign.status}`);
@@ -163,9 +181,9 @@ export const campaignTools = [
     name: "campaigns_resume",
     description: "Resume a paused campaign",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const campaign = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.id },
+        where: { id: args.id, ...campaignReadScopeWhere(user) },
       });
       if (!campaign) notFound("Campaign");
       if (campaign.status !== "paused") conflict(`Cannot resume campaign in status: ${campaign.status}`);
@@ -178,10 +196,10 @@ export const campaignTools = [
   // ── Templates ─────────────────────────────────────────
   {
     name: "campaigns_list_templates",
-    description: "List campaign email templates (org-wide)",
+    description: "List campaign email templates the caller is allowed to see",
     schema: z.object({ ...paginationSchema }),
-    async handler(args: { limit: number; offset: number }, _userId: string) {
-      const where = { deletedAt: null };
+    async handler(args: { limit: number; offset: number }, _userId: string, user: AuthzUser) {
+      const where = { ...campaignTemplateReadScopeWhere(user) };
       const [data, total] = await Promise.all([
         prismadb.crm_campaign_templates.findMany({
           where,
@@ -197,8 +215,10 @@ export const campaignTools = [
     name: "campaigns_get_template",
     description: "Get a campaign template by ID",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
-      const template = await prismadb.crm_campaign_templates.findFirst({ where: { id: args.id, deletedAt: null } });
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      const template = await prismadb.crm_campaign_templates.findFirst({
+        where: { id: args.id, ...campaignTemplateReadScopeWhere(user) },
+      });
       if (!template) notFound("Template");
       return itemResponse(template);
     },
@@ -241,8 +261,10 @@ export const campaignTools = [
       content_html: z.string().optional(),
       content_json: z.any().optional(),
     }),
-    async handler(args: Record<string, any>, _userId: string) {
-      const existing = await prismadb.crm_campaign_templates.findFirst({ where: { id: args.id, deletedAt: null } });
+    async handler(args: Record<string, any>, _userId: string, user: AuthzUser) {
+      const existing = await prismadb.crm_campaign_templates.findFirst({
+        where: { id: args.id, ...campaignTemplateReadScopeWhere(user) },
+      });
       if (!existing) notFound("Template");
       const { id, ...updateData } = args;
       const template = await prismadb.crm_campaign_templates.update({ where: { id }, data: updateData });
@@ -253,8 +275,10 @@ export const campaignTools = [
     name: "campaigns_delete_template",
     description: "Soft-delete a campaign template (sets deletedAt timestamp)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
-      const existing = await prismadb.crm_campaign_templates.findFirst({ where: { id: args.id, deletedAt: null } });
+    async handler(args: { id: string }, userId: string, user: AuthzUser) {
+      const existing = await prismadb.crm_campaign_templates.findFirst({
+        where: { id: args.id, ...campaignTemplateReadScopeWhere(user) },
+      });
       if (!existing) notFound("Template");
       await prismadb.crm_campaign_templates.update({
         where: { id: args.id },
@@ -278,10 +302,11 @@ export const campaignTools = [
     }),
     async handler(
       args: { campaign_id: string; order: number; template_id: string; subject: string; delay_days: number; send_to: string },
-      _userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
       const campaign = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.campaign_id, deletedAt: null },
+        where: { id: args.campaign_id, deletedAt: null, ...campaignReadScopeWhere(user) },
       });
       if (!campaign) notFound("Campaign");
       const step = await prismadb.crm_campaign_steps.create({ data: args });
@@ -299,9 +324,10 @@ export const campaignTools = [
       delay_days: z.number().int().min(0).optional(),
       send_to: z.enum(["all", "non_openers"]).optional(),
     }),
-    async handler(args: Record<string, any>, _userId: string) {
+    async handler(args: Record<string, any>, _userId: string, user: AuthzUser) {
       const existing = await prismadb.crm_campaign_steps.findUnique({ where: { id: args.id } });
       if (!existing) notFound("CampaignStep");
+      await assertCampaignInScope(user, existing.campaign_id);
       const { id, ...updateData } = args;
       const step = await prismadb.crm_campaign_steps.update({ where: { id }, data: updateData });
       return itemResponse(step);
@@ -311,9 +337,10 @@ export const campaignTools = [
     name: "campaigns_delete_step",
     description: "Delete a campaign step by ID (hard delete — step has no status field)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const existing = await prismadb.crm_campaign_steps.findUnique({ where: { id: args.id } });
       if (!existing) notFound("CampaignStep");
+      await assertCampaignInScope(user, existing.campaign_id);
       await prismadb.crm_campaign_steps.delete({ where: { id: args.id } });
       return itemResponse({ id: args.id, deleted: true });
     },
@@ -327,9 +354,9 @@ export const campaignTools = [
       campaign_id: z.string().uuid(),
       target_list_id: z.string().uuid(),
     }),
-    async handler(args: { campaign_id: string; target_list_id: string }, _userId: string) {
+    async handler(args: { campaign_id: string; target_list_id: string }, _userId: string, user: AuthzUser) {
       const campaign = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.campaign_id, deletedAt: null },
+        where: { id: args.campaign_id, deletedAt: null, ...campaignReadScopeWhere(user) },
       });
       if (!campaign) notFound("Campaign");
       await prismadb.campaignToTargetLists.create({
@@ -345,7 +372,8 @@ export const campaignTools = [
       campaign_id: z.string().uuid(),
       target_list_id: z.string().uuid(),
     }),
-    async handler(args: { campaign_id: string; target_list_id: string }, _userId: string) {
+    async handler(args: { campaign_id: string; target_list_id: string }, _userId: string, user: AuthzUser) {
+      await assertCampaignInScope(user, args.campaign_id);
       await prismadb.campaignToTargetLists.delete({
         where: {
           campaign_id_target_list_id: {
@@ -363,9 +391,9 @@ export const campaignTools = [
     name: "campaigns_get_stats",
     description: "Get send/open/click/unsubscribe stats for a campaign",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const campaign = await prismadb.crm_campaigns.findFirst({
-        where: { id: args.id, deletedAt: null },
+        where: { id: args.id, deletedAt: null, ...campaignReadScopeWhere(user) },
       });
       if (!campaign) notFound("Campaign");
       const sends = await prismadb.crm_campaign_sends.findMany({


### PR DESCRIPTION
## Summary
Fixes **GHSA-c9vg-c532-ppqx** — a BOLA/IDOR (CVSS 7.6, High) where the MCP campaign tools authenticated the Bearer token but ignored the caller's identity, querying/mutating campaigns only by object ID. A low-privileged user with a valid MCP API token could enumerate, read, modify, delete, send, pause, or resume campaigns owned by other users.

## Changes
- **`lib/mcp/auth.ts`** — `getMcpUser()` resolves the full authz user (`{ id, role }`) from the DB; unknown user → `Unauthorized`.
- **`app/api/mcp/[transport]/route.ts`** — passes the authz user to handlers as a 3rd arg (additive; existing owner-scoped CRM tools untouched).
- **`lib/mcp/tools/campaigns.ts`** — every campaign/template handler scoped via `campaignReadScopeWhere` / `campaignTemplateReadScopeWhere`; step and target-list mutations verify the **parent campaign** is in scope via a new `assertCampaignInScope` helper. Out-of-scope access returns `NOT_FOUND` (no existence leak), consistent with sibling CRM tools.
- **`__tests__/mcp/campaigns-scope.test.ts`** — 20 regression tests (advisory recommendation #4).

## Authorization model (unchanged, now enforced via MCP)
- Normal users: only campaigns/templates where `created_by = user.id`
- Managers/admins: org-wide

## Testing
- TDD: tests written first (7 real RED failures) → implemented → **20/20 GREEN**.
- Full suite: no new regressions. The 3 pre-existing failing suites (invoices, documents, crm-settings) fail identically with this change stashed.

## Out of scope
The related enrichment-tool finding (`crm_enrich_*`) is flagged separately in the advisory and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)