### PR TITLE
fix(security): enforce manager/admin RBAC in MCP product tools (GHSA-wv63-cq38-qg58)

### DIFF
--- a/__tests__/mcp/products-rbac.test.ts
+++ b/__tests__/mcp/products-rbac.test.ts
@@ -1,0 +1,106 @@
+// Regression tests for GHSA-wv63-cq38-qg58
+// RBAC bypass in MCP product tools: product create/update/delete are
+// manager/admin-only (matching the server actions). A role:"user" MCP token
+// must be rejected with FORBIDDEN; reads remain open org-wide.
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Products: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { crmProductTools } from "@/lib/mcp/tools/crm-products";
+
+type Role = "user" | "manager" | "admin";
+const USER = { id: "u1", role: "user" as Role };
+const MANAGER = { id: "m1", role: "manager" as Role };
+const ADMIN = { id: "a1", role: "admin" as Role };
+
+const tool = (name: string) => {
+  const t = crmProductTools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool not found: ${name}`);
+  return t;
+};
+// Handlers receive (args, userId, user)
+const run = (name: string, args: any, user: { id: string; role: Role }) =>
+  (tool(name).handler as any)(args, user.id, user);
+
+const createArgs = {
+  name: "Widget",
+  type: "PRODUCT",
+  unit_price: 10,
+  currency: "USD",
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("crm_create_product RBAC", () => {
+  it("role 'user' is forbidden and no product is created", async () => {
+    await expect(run("crm_create_product", createArgs, USER)).rejects.toThrow("FORBIDDEN");
+    expect(prismadb.crm_Products.create).not.toHaveBeenCalled();
+  });
+
+  it("role 'manager' may create", async () => {
+    (prismadb.crm_Products.create as jest.Mock).mockResolvedValue({ id: "p1" });
+    await run("crm_create_product", createArgs, MANAGER);
+    expect(prismadb.crm_Products.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("role 'admin' may create", async () => {
+    (prismadb.crm_Products.create as jest.Mock).mockResolvedValue({ id: "p1" });
+    await run("crm_create_product", createArgs, ADMIN);
+    expect(prismadb.crm_Products.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("crm_update_product RBAC", () => {
+  it("role 'user' is forbidden and no product is updated", async () => {
+    await expect(
+      run("crm_update_product", { id: "p1", name: "hacked" }, USER)
+    ).rejects.toThrow("FORBIDDEN");
+    expect(prismadb.crm_Products.update).not.toHaveBeenCalled();
+  });
+
+  it("role 'manager' may update", async () => {
+    (prismadb.crm_Products.findFirst as jest.Mock).mockResolvedValue({ id: "p1" });
+    (prismadb.crm_Products.update as jest.Mock).mockResolvedValue({ id: "p1" });
+    await run("crm_update_product", { id: "p1", name: "ok" }, MANAGER);
+    expect(prismadb.crm_Products.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("crm_delete_product RBAC", () => {
+  it("role 'user' is forbidden and no product is archived", async () => {
+    await expect(run("crm_delete_product", { id: "p1" }, USER)).rejects.toThrow("FORBIDDEN");
+    expect(prismadb.crm_Products.update).not.toHaveBeenCalled();
+  });
+
+  it("role 'manager' may soft-delete", async () => {
+    (prismadb.crm_Products.findFirst as jest.Mock).mockResolvedValue({ id: "p1" });
+    (prismadb.crm_Products.update as jest.Mock).mockResolvedValue({ id: "p1" });
+    await run("crm_delete_product", { id: "p1" }, MANAGER);
+    expect(prismadb.crm_Products.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("product reads remain open to any authenticated role", () => {
+  it("role 'user' may list products", async () => {
+    (prismadb.crm_Products.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.crm_Products.count as jest.Mock).mockResolvedValue(0);
+    await run("crm_list_products", { limit: 20, offset: 0 }, USER);
+    expect(prismadb.crm_Products.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("role 'user' may get a product", async () => {
+    (prismadb.crm_Products.findFirst as jest.Mock).mockResolvedValue({ id: "p1" });
+    const res = await run("crm_get_product", { id: "p1" }, USER);
+    expect(res).toEqual({ data: { id: "p1" } });
+  });
+});

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -18,6 +18,7 @@ const handler = createMcpHandler(
           const msg: string = err.message ?? "Unknown error";
           const code =
             msg === "NOT_FOUND" ? "NOT_FOUND"
+            : msg === "FORBIDDEN" ? "FORBIDDEN"
             : msg === "Unauthorized" ? "UNAUTHORIZED"
             : msg.startsWith("CONFLICT:") ? "INVALID_REQUEST"
             : msg.startsWith("VALIDATION_ERROR:") ? "INVALID_PARAMS"

--- a/lib/mcp/helpers.ts
+++ b/lib/mcp/helpers.ts
@@ -43,6 +43,10 @@ export function notFound(_entity: string): never {
   throw new Error("NOT_FOUND");
 }
 
+export function forbidden(): never {
+  throw new Error("FORBIDDEN");
+}
+
 export function conflict(msg: string): never {
   throw new Error(`CONFLICT: ${msg}`);
 }

--- a/lib/mcp/tools/crm-products.ts
+++ b/lib/mcp/tools/crm-products.ts
@@ -1,12 +1,20 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
+import type { AuthzUser } from "@/lib/authz";
 import {
   paginationSchema,
   paginationArgs,
   listResponse,
   itemResponse,
   notFound,
+  forbidden,
 } from "../helpers";
+
+// The product catalog is org-wide; writes are manager/admin-only, matching the
+// server actions' requireRole(["manager", "admin"]) (GHSA-wv63-cq38-qg58).
+function assertCanManageProducts(user: AuthzUser): void {
+  if (user.role !== "manager" && user.role !== "admin") forbidden();
+}
 
 export const crmProductTools = [
   {
@@ -81,8 +89,10 @@ export const crmProductTools = [
         billing_period?: string;
         categoryId?: string;
       },
-      userId: string
+      userId: string,
+      user: AuthzUser
     ) {
+      assertCanManageProducts(user);
       const product = await prismadb.crm_Products.create({
         data: {
           name: args.name,
@@ -124,7 +134,8 @@ export const crmProductTools = [
       billing_period: z.enum(["MONTHLY", "QUARTERLY", "SEMIANNUALLY", "ANNUALLY"]).optional(),
       categoryId: z.string().uuid().optional(),
     }),
-    async handler(args: Record<string, any>, userId: string) {
+    async handler(args: Record<string, any>, userId: string, user: AuthzUser) {
+      assertCanManageProducts(user);
       const existing = await prismadb.crm_Products.findFirst({
         where: { id: args.id, deletedAt: null },
       });
@@ -141,7 +152,8 @@ export const crmProductTools = [
     name: "crm_delete_product",
     description: "Soft-delete a CRM product (sets deletedAt timestamp)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
+    async handler(args: { id: string }, userId: string, user: AuthzUser) {
+      assertCanManageProducts(user);
       const existing = await prismadb.crm_Products.findFirst({
         where: { id: args.id, deletedAt: null },
       });


### PR DESCRIPTION
## Summary
Fixes **GHSA-wv63-cq38-qg58** — an RBAC bypass (CVSS 7.1, High) where the MCP product tools exposed product create/update/delete without any role check. The browser/server-action surface restricts these writes to `manager`/`admin` via `requireRole(["manager","admin"])`, but the MCP surface did not — so any authenticated `user` with an MCP API token could create, modify, archive, or soft-delete products in the shared org-wide catalog.

## Changes
- **`lib/mcp/tools/crm-products.ts`** — `crm_create_product`, `crm_update_product`, `crm_delete_product` now call `assertCanManageProducts(user)`, rejecting any non-manager/admin caller before touching the DB. Reads (`crm_list_products`, `crm_get_product`) remain open org-wide (unchanged).
- **`lib/mcp/helpers.ts`** — new `forbidden()` helper (`throw Error("FORBIDDEN")`).
- **`app/api/mcp/[transport]/route.ts`** — maps `FORBIDDEN` → `FORBIDDEN` error code so the denial surfaces cleanly instead of as a generic 500.
- **`__tests__/mcp/products-rbac.test.ts`** — 9 regression tests (advisory recommendation #3).

This builds on the authz-user threading shipped in GHSA-c9vg-c532-ppqx: the full `{ id, role }` is already passed to handlers as the 3rd arg, so no auth-layer change was needed.

## Testing
- TDD: 3 RED failures (create/update/delete by role `user`) → implemented → **9/9 GREEN**.
- Full suite: no new regressions. The 3 pre-existing failing suites (invoices, documents, crm-settings) are unrelated and fail identically on `main`.

## Note
`assertCanManageProducts` inlines the manager/admin check rather than importing `isManagerOrAdmin` from the authz barrel, because that barrel transitively pulls `better-auth` (ESM) into the Jest runtime. Logic is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)