### PR TITLE
chore(release): make release-please-config.json actually apply

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Do not set release-type here: it switches the action to simple mode,
+      # which ignores release-please-config.json and its changelog-sections.
+      # The release type is declared in that config file instead.
       - uses: googleapis/release-please-action@v4.4.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: node
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,13 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
   "changelog-sections": [
-    { "type": "feat", "section": "### Added" },
-    { "type": "fix", "section": "### Fixed" },
-    { "type": "security", "section": "### Security" },
-    { "type": "refactor", "section": "### Changed" },
-    { "type": "perf", "section": "### Changed" },
+    { "type": "feat", "section": "Added" },
+    { "type": "fix", "section": "Fixed" },
+    { "type": "security", "section": "Security" },
+    { "type": "refactor", "section": "Changed" },
+    { "type": "perf", "section": "Changed" },
     { "type": "docs", "hidden": true },
     { "type": "chore", "hidden": true },
     { "type": "test", "hidden": true }


### PR DESCRIPTION
## The bug

`release-please-config.json` has never been applied. The workflow set `release-type: node`, which puts the action in **simple mode** — and simple mode ignores the config file entirely.

Per the [action docs](https://github.com/googleapis/release-please-action):

> "If you wish to use a manifest, simply ensure you do not explicitly set the `release-type` option."

## Evidence it's been dead

The config was committed **2026-04-03**, but every release since has used release-please's *default* section names rather than the ones it declares:

```
## [0.12.3] (2026-06-13)
### Bug Fixes          <- default; config says "### Fixed"
```

If the config were live, that would read `Fixed`. It's been dead code for ~2 months, which also means the `security` section it defines has never been reachable.

The `CHANGELOG.md` preamble advertises *"The format is based on Keep a Changelog"* — `Added`/`Fixed`/`Security` is what the config was reaching for, and what this restores.

## Changes

1. **Drop `release-type: node`** from the workflow; point at `config-file` / `manifest-file` explicitly so the config governs.
2. **Strip `###` from every section label.** release-please emits the heading level itself, so switching the config on *as written* would render `### ### Added`. This is not hypothetical — it is exactly what happened in `iso.xe.cz`, whose config was copied from this repo:
   ```
   ## [1.0.0] (2026-07-16)
   ### ### Added
   ```
3. Added `$schema` for editor validation.

## Effect on the next release

```
### Added      (was: ### Features)
### Fixed      (was: ### Bug Fixes)
```

Existing entries are untouched — release-please does not rewrite history.

## Safety

`.release-please-manifest.json`, `package.json`, and the newest tag all agree at **0.12.3**, so switching to manifest mode does not affect version computation. Simple mode had been keeping the manifest current, so it is already authoritative.

## Verification

- `actionlint .github/workflows/release-please.yml` → clean; config parses as valid JSON.
- The label format is confirmed empirically in `iso.xe.cz`: with `"### Added"` the changelog rendered `### ### Added`; after stripping to `"Added"`, a `release-please --dry-run` rendered a single correct `### Added`.
- The mode switch itself can only be observed once merged — a CLI dry-run passes `--config-file` explicitly and so always reads the config, regardless of the workflow. **Confirm on the next release PR that sections read `Added`/`Fixed` rather than `Features`/`Bug Fixes`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)