### PR TITLE
fix(crm): serialize Prisma Decimals in opportunities/contracts fetches (RSC boundary error)

### DIFF
--- a/__tests__/actions/crm-decimal-serialization.test.ts
+++ b/__tests__/actions/crm-decimal-serialization.test.ts
@@ -1,0 +1,69 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Opportunities: { findMany: jest.fn() },
+    crm_Contracts: { findMany: jest.fn() },
+  },
+}));
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn().mockResolvedValue({ id: "u1", role: "admin" }),
+  opportunityReadScopeWhere: jest.fn(() => ({})),
+  contractReadScopeWhere: jest.fn(() => ({})),
+  assertCanReadAccount: jest.fn().mockResolvedValue(undefined),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getOpportunitiesFull } from "@/actions/crm/get-opportunities-with-includes";
+import {
+  getContractsWithIncludes,
+  getContractsByAccountId,
+} from "@/actions/crm/get-contracts";
+
+// Mimics Prisma's Decimal: an object with toNumber(), not serializable to RSC clients.
+const fakeDecimal = (n: number) => ({ toNumber: () => n });
+
+describe("CRM list fetches serialize Prisma Decimals for client components", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("getOpportunitiesFull returns plain numbers for Decimal fields", async () => {
+    (prismadb.crm_Opportunities.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: "o1",
+        name: "Deal",
+        budget: fakeDecimal(1000),
+        expected_revenue: fakeDecimal(2500.5),
+        snapshot_rate: fakeDecimal(24.5),
+        close_date: new Date("2026-09-30"),
+      },
+    ]);
+
+    const [opp] = (await getOpportunitiesFull()) as any[];
+
+    expect(opp.budget).toBe(1000);
+    expect(opp.expected_revenue).toBe(2500.5);
+    expect(opp.snapshot_rate).toBe(24.5);
+    expect(opp.close_date).toBeInstanceOf(Date);
+  });
+
+  it("getContractsWithIncludes returns plain numbers for Decimal fields", async () => {
+    (prismadb.crm_Contracts.findMany as jest.Mock).mockResolvedValue([
+      { id: "c1", title: "Contract", value: fakeDecimal(9999.99), snapshot_rate: null },
+    ]);
+
+    const [contract] = (await getContractsWithIncludes()) as any[];
+
+    expect(contract.value).toBe(9999.99);
+    expect(contract.snapshot_rate).toBeNull();
+  });
+
+  it("getContractsByAccountId returns plain numbers for Decimal fields", async () => {
+    (prismadb.crm_Contracts.findMany as jest.Mock).mockResolvedValue([
+      { id: "c2", title: "Contract 2", value: fakeDecimal(5) },
+    ]);
+
+    const [contract] = (await getContractsByAccountId("a1")) as any[];
+
+    expect(contract.value).toBe(5);
+  });
+});

--- a/actions/crm/get-contracts.ts
+++ b/actions/crm/get-contracts.ts
@@ -9,6 +9,7 @@ import {
   AuthenticationError,
   AuthorizationError,
 } from "@/lib/authz";
+import { serializeDecimalsList } from "@/lib/serialize-decimals";
 
 export const getContractsWithIncludes = cache(async () => {
   let user;
@@ -37,7 +38,7 @@ export const getContractsWithIncludes = cache(async () => {
       createdAt: "desc",
     },
   });
-  return data;
+  return serializeDecimalsList(data);
 });
 
 export const getContractsByAccountId = async (accountId: string) => {
@@ -74,5 +75,5 @@ export const getContractsByAccountId = async (accountId: string) => {
       },
     },
   });
-  return data;
+  return serializeDecimalsList(data);
 };

--- a/actions/crm/get-opportunities-with-includes.ts
+++ b/actions/crm/get-opportunities-with-includes.ts
@@ -7,6 +7,7 @@ import {
   opportunityReadScopeWhere,
   AuthenticationError,
 } from "@/lib/authz";
+import { serializeDecimalsList } from "@/lib/serialize-decimals";
 
 export const getOpportunitiesFull = cache(async () => {
   let user;
@@ -41,5 +42,5 @@ export const getOpportunitiesFull = cache(async () => {
     },
   });
 
-  return data;
+  return serializeDecimalsList(data);
 });


### PR DESCRIPTION
## Summary

The CRM main page logs \`Only plain objects can be passed to Client Components. Decimal objects are not supported\` for \`OpportunitiesView\`. Root cause: \`getOpportunitiesFull\` (and both contract list fetches, which carry \`value: Decimal\` — same latent bug on the same page) return raw Prisma rows to \`"use client"\` views. Pre-existing issue, unrelated to the AQUNAMA changes — the fetch code hadn't changed since before Phase 1; the repo's own \`serializeDecimalsList\` helper (already used by \`get-crm-data.ts\`) was simply never applied to these three fetches.

- Wrap the returns of \`getOpportunitiesFull\`, \`getContractsWithIncludes\`, \`getContractsByAccountId\` in \`serializeDecimalsList\`.
- Add regression tests asserting Decimal-like fields come back as plain numbers (Dates and nulls untouched).

## Test plan

- TDD: new suite failed before the fix (Decimal objects passed through), 3/3 green after.
- Full jest: 908/916 — only the 3 documented pre-existing failing suites. Typecheck clean.
- Possible follow-up: audit remaining CRM detail-page fetches for the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)