### PR TITLE
feat: AQUNAMA Phase 2 — funnel timer & task engine (kill rule, cadence, care, recycle, renewals)

### DIFF
--- a/__tests__/crm-settings-actions.test.ts
+++ b/__tests__/crm-settings-actions.test.ts
@@ -142,3 +142,36 @@ describe("deleteConfigValue", () => {
     );
   });
 });
+
+describe("salesStage stage kinds", () => {
+  it("creates a sales stage with a stage kind", async () => {
+    (mockPrisma.crm_Opportunities_Sales_Stages.create as jest.Mock).mockResolvedValue({});
+    await createConfigValue("salesStage", "Qualified Lead", "qualified");
+    expect(mockPrisma.crm_Opportunities_Sales_Stages.create).toHaveBeenCalledWith({
+      data: { name: "Qualified Lead", v: 0, stage_kind: "qualified" },
+    });
+  });
+
+  it("ignores stageKind for non-salesStage types", async () => {
+    (mockPrisma.crm_Contact_Types.create as jest.Mock).mockResolvedValue({});
+    await createConfigValue("contactType", "Investor", "qualified");
+    expect(mockPrisma.crm_Contact_Types.create).toHaveBeenCalledWith({
+      data: { name: "Investor", v: 0 },
+    });
+  });
+
+  it("updates a sales stage kind (null clears it)", async () => {
+    (mockPrisma.crm_Opportunities_Sales_Stages.update as jest.Mock).mockResolvedValue({});
+    await updateConfigValue("salesStage", "id-1", "Qualified Lead", null);
+    expect(mockPrisma.crm_Opportunities_Sales_Stages.update).toHaveBeenCalledWith({
+      where: { id: "id-1" },
+      data: { name: "Qualified Lead", stage_kind: null },
+    });
+  });
+
+  it("rejects an invalid stage kind", async () => {
+    await expect(
+      createConfigValue("salesStage", "X", "bogus" as any),
+    ).rejects.toThrow();
+  });
+});

--- a/__tests__/crm/auto-task.test.ts
+++ b/__tests__/crm/auto-task.test.ts
@@ -71,3 +71,37 @@ describe("createAutoTask", () => {
     expect(res).toEqual({ id: "t1" });
   });
 });
+
+describe("createAutoTask dedupAnyStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prismadb.crm_Accounts_Tasks.findFirst as jest.Mock).mockResolvedValue(null);
+    (prismadb.crm_Accounts_Tasks.create as jest.Mock).mockResolvedValue({ id: "t2" });
+    (prismadb.users.findUnique as jest.Mock).mockResolvedValue({
+      id: "u1", email: "rep@x.cz", userLanguage: "en",
+    });
+    mockSend.mockResolvedValue({ data: { id: "r1" }, error: null });
+  });
+
+  it("omits the status filter so completed tasks also dedup", async () => {
+    await createAutoTask({
+      title: "Renewal 2026-08-15: contract \"X\"",
+      content: "x", accountId: "a1",
+      assigneeId: "u1", dueDateAt: new Date(),
+      dedupAnyStatus: true,
+    });
+    const where = (prismadb.crm_Accounts_Tasks.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.taskStatus).toBeUndefined();
+    expect(where.account).toBe("a1");
+  });
+
+  it("keeps the open-status filter by default", async () => {
+    await createAutoTask({
+      title: "Cadence 1/5: Call — confirm quote receipt",
+      content: "x", accountId: "a1", opportunityId: "o1",
+      assigneeId: "u1", dueDateAt: new Date(),
+    });
+    const where = (prismadb.crm_Accounts_Tasks.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.taskStatus).toEqual({ in: ["ACTIVE", "PENDING"] });
+  });
+});

--- a/__tests__/crm/auto-task.test.ts
+++ b/__tests__/crm/auto-task.test.ts
@@ -1,0 +1,73 @@
+const mockSend = jest.fn();
+jest.mock("resend", () => ({
+  Resend: jest.fn().mockImplementation(() => ({ emails: { send: mockSend } })),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Accounts_Tasks: { findFirst: jest.fn(), create: jest.fn() },
+    users: { findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { createAutoTask } from "@/lib/crm/auto-task";
+
+describe("createAutoTask", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prismadb.crm_Accounts_Tasks.findFirst as jest.Mock).mockResolvedValue(null);
+    (prismadb.crm_Accounts_Tasks.create as jest.Mock).mockResolvedValue({ id: "t1" });
+    (prismadb.users.findUnique as jest.Mock).mockResolvedValue({
+      id: "u1", email: "rep@x.cz", userLanguage: "en",
+    });
+    mockSend.mockResolvedValue({ data: { id: "r1" }, error: null });
+  });
+
+  it("creates the task and notifies the assignee", async () => {
+    const res = await createAutoTask({
+      title: "Cadence 1/5: Call — confirm quote receipt",
+      content: "Call the client.",
+      accountId: "a1",
+      opportunityId: "o1",
+      assigneeId: "u1",
+      dueDateAt: new Date("2026-08-01"),
+    });
+    expect(res).toEqual({ id: "t1" });
+    const data = (prismadb.crm_Accounts_Tasks.create as jest.Mock).mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      v: 0, priority: "high", taskStatus: "ACTIVE",
+      account: "a1", opportunity_id: "o1",
+      user: "u1", createdBy: "u1", updatedBy: "u1",
+    });
+    expect(mockSend).toHaveBeenCalled();
+  });
+
+  it("skips when an open task with the same title exists for the deal", async () => {
+    (prismadb.crm_Accounts_Tasks.findFirst as jest.Mock).mockResolvedValue({ id: "existing" });
+    const res = await createAutoTask({
+      title: "Cadence 1/5: Call — confirm quote receipt",
+      content: "x", accountId: "a1", opportunityId: "o1",
+      assigneeId: "u1", dueDateAt: new Date(),
+    });
+    expect(res).toBeNull();
+    expect(prismadb.crm_Accounts_Tasks.create).not.toHaveBeenCalled();
+  });
+
+  it("skips when there is no assignee", async () => {
+    const res = await createAutoTask({
+      title: "T", content: "x", accountId: "a1", opportunityId: "o1",
+      assigneeId: null, dueDateAt: new Date(),
+    });
+    expect(res).toBeNull();
+    expect(prismadb.crm_Accounts_Tasks.create).not.toHaveBeenCalled();
+  });
+
+  it("still creates the task when the notification email fails", async () => {
+    mockSend.mockRejectedValue(new Error("resend down"));
+    const res = await createAutoTask({
+      title: "T", content: "x", accountId: "a1", opportunityId: "o1",
+      assigneeId: "u1", dueDateAt: new Date(),
+    });
+    expect(res).toEqual({ id: "t1" });
+  });
+});

--- a/__tests__/crm/business-days.test.ts
+++ b/__tests__/crm/business-days.test.ts
@@ -1,0 +1,26 @@
+import { addBusinessDays } from "@/lib/crm/business-days";
+
+describe("addBusinessDays", () => {
+  it("adds within a week", () => {
+    // Wed 2026-07-15 + 2 -> Fri 2026-07-17
+    expect(addBusinessDays(new Date("2026-07-15T10:00:00Z"), 2)).toEqual(
+      new Date("2026-07-17T10:00:00Z"),
+    );
+  });
+  it("skips a weekend", () => {
+    // Thu 2026-07-16 + 3 -> Tue 2026-07-21
+    expect(addBusinessDays(new Date("2026-07-16T10:00:00Z"), 3)).toEqual(
+      new Date("2026-07-21T10:00:00Z"),
+    );
+  });
+  it("starting on Saturday counts from the next Monday", () => {
+    // Sat 2026-07-18 + 1 -> Mon 2026-07-20
+    expect(addBusinessDays(new Date("2026-07-18T10:00:00Z"), 1)).toEqual(
+      new Date("2026-07-20T10:00:00Z"),
+    );
+  });
+  it("n=0 returns the same instant", () => {
+    const d = new Date("2026-07-15T10:00:00Z");
+    expect(addBusinessDays(d, 0)).toEqual(d);
+  });
+});

--- a/__tests__/crm/client-activity.test.ts
+++ b/__tests__/crm/client-activity.test.ts
@@ -1,0 +1,51 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    email: { findFirst: jest.fn() },
+    crm_Activities: { findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { getLastClientActivity } from "@/lib/crm/client-activity";
+
+describe("getLastClientActivity", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns the max of stage entry, inbound email, and logged activity", async () => {
+    (prismadb.email.findFirst as jest.Mock).mockResolvedValue({
+      sentAt: new Date("2026-06-10"),
+    });
+    (prismadb.crm_Activities.findFirst as jest.Mock).mockResolvedValue({
+      date: new Date("2026-06-20"),
+    });
+    const res = await getLastClientActivity({
+      id: "o1", contact: "c1", account: "a1",
+      stage_entered_at: new Date("2026-05-01"),
+    });
+    expect(res).toEqual(new Date("2026-06-20"));
+  });
+
+  it("queries inbound emails only, scoped to the deal's contact/account", async () => {
+    (prismadb.email.findFirst as jest.Mock).mockResolvedValue(null);
+    (prismadb.crm_Activities.findFirst as jest.Mock).mockResolvedValue(null);
+    await getLastClientActivity({
+      id: "o1", contact: "c1", account: "a1", stage_entered_at: null,
+    });
+    const where = (prismadb.email.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.folder).toBe("INBOX");
+    expect(where.OR).toEqual([
+      { contacts: { some: { contactId: "c1" } } },
+      { accounts: { some: { accountId: "a1" } } },
+    ]);
+  });
+
+  it("skips the email query entirely when the deal has no contact and no account", async () => {
+    (prismadb.crm_Activities.findFirst as jest.Mock).mockResolvedValue(null);
+    const res = await getLastClientActivity({
+      id: "o1", contact: null, account: null,
+      stage_entered_at: new Date("2026-05-01"),
+    });
+    expect(prismadb.email.findFirst).not.toHaveBeenCalled();
+    expect(res).toEqual(new Date("2026-05-01"));
+  });
+});

--- a/__tests__/crm/funnel-settings-actions.test.ts
+++ b/__tests__/crm/funnel-settings-actions.test.ts
@@ -1,0 +1,56 @@
+jest.mock("@/lib/authz", () => ({
+  requireRole: jest.fn(),
+  AuthorizationError: class AuthorizationError extends Error {},
+  AuthenticationError: class AuthenticationError extends Error {},
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_FunnelSettings: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { requireRole } from "@/lib/authz";
+import { DEFAULT_FUNNEL_SETTINGS } from "@/lib/crm/funnel-timers";
+import { updateFunnelSettings } from "@/app/[locale]/(routes)/admin/funnel-settings/_actions/funnel-settings";
+
+describe("updateFunnelSettings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ id: "admin1", role: "admin" });
+  });
+
+  it("creates the singleton row on first save", async () => {
+    (prismadb.crm_FunnelSettings.findFirst as jest.Mock).mockResolvedValue(null);
+    (prismadb.crm_FunnelSettings.create as jest.Mock).mockResolvedValue({});
+    const res = await updateFunnelSettings({ ...DEFAULT_FUNNEL_SETTINGS, killAfterDays: 30 });
+    expect(res).toEqual({});
+    const data = (prismadb.crm_FunnelSettings.create as jest.Mock).mock.calls[0][0].data;
+    expect(data.kill_after_days).toBe(30);
+    expect(data.recycle_after_days).toBe(90);
+    expect(data.updatedBy).toBe("admin1");
+  });
+
+  it("updates the existing singleton row", async () => {
+    (prismadb.crm_FunnelSettings.findFirst as jest.Mock).mockResolvedValue({ id: "row1" });
+    (prismadb.crm_FunnelSettings.update as jest.Mock).mockResolvedValue({});
+    await updateFunnelSettings({ ...DEFAULT_FUNNEL_SETTINGS, renewalWindowDays: 14 });
+    const call = (prismadb.crm_FunnelSettings.update as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ id: "row1" });
+    expect(call.data.renewal_window_days).toBe(14);
+  });
+
+  it("rejects out-of-range values", async () => {
+    const res = await updateFunnelSettings({ ...DEFAULT_FUNNEL_SETTINGS, killAfterDays: 0 });
+    expect(res.error).toBeDefined();
+    expect(prismadb.crm_FunnelSettings.create).not.toHaveBeenCalled();
+  });
+
+  it("returns error for non-admins", async () => {
+    const { AuthorizationError } = jest.requireMock("@/lib/authz");
+    (requireRole as jest.Mock).mockRejectedValue(new AuthorizationError());
+    const res = await updateFunnelSettings(DEFAULT_FUNNEL_SETTINGS);
+    expect(res.error).toBeDefined();
+  });
+});

--- a/__tests__/crm/funnel-timers.test.ts
+++ b/__tests__/crm/funnel-timers.test.ts
@@ -1,0 +1,140 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_FunnelSettings: { findFirst: jest.fn() } },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  cadenceSchedule,
+  resolveLastClientActivity,
+  isKillDue,
+  careSchedule,
+  renewalWindowEnd,
+  DEFAULT_FUNNEL_SETTINGS,
+} from "@/lib/crm/funnel-timers";
+import { getFunnelSettings } from "@/lib/crm/funnel-settings";
+import { addBusinessDays } from "@/lib/crm/business-days";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("cadenceSchedule", () => {
+  // Wed 2026-07-15
+  const entry = new Date("2026-07-15T09:00:00Z");
+  const s = cadenceSchedule(entry);
+
+  it("produces 5 touches with spec timings", () => {
+    expect(s).toHaveLength(5);
+    const t1 = addBusinessDays(entry, 3);
+    expect(s[0]).toMatchObject({ touch: 1, kind: "call", date: t1 });
+    expect(s[1]).toMatchObject({ touch: 2, kind: "email", date: new Date(t1.getTime() + 7 * DAY) });
+    const t3 = new Date(t1.getTime() + 17 * DAY);
+    expect(s[2]).toMatchObject({ touch: 3, kind: "email", date: t3 });
+    expect(s[3]).toMatchObject({ touch: 4, kind: "call", date: new Date(t3.getTime() + 15 * DAY) });
+    expect(s[4]).toMatchObject({ touch: 5, kind: "email", date: new Date(t3.getTime() + 45 * DAY) });
+  });
+
+  it("every touch has a non-empty title and content", () => {
+    for (const t of s) {
+      expect(t.title.length).toBeGreaterThan(0);
+      expect(t.content.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("resolveLastClientActivity / isKillDue", () => {
+  const now = new Date("2026-07-18T00:00:00Z");
+
+  it("takes the max of available dates", () => {
+    expect(
+      resolveLastClientActivity({
+        stageEnteredAt: new Date("2026-01-01"),
+        lastInboundEmailAt: new Date("2026-06-01"),
+        lastLoggedActivityAt: new Date("2026-03-01"),
+      }),
+    ).toEqual(new Date("2026-06-01"));
+  });
+
+  it("returns null when nothing is known", () => {
+    expect(
+      resolveLastClientActivity({
+        stageEnteredAt: null, lastInboundEmailAt: null, lastLoggedActivityAt: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("kill is due at 45+ days of silence, not before, never on null", () => {
+    expect(isKillDue(new Date(now.getTime() - 46 * DAY), now)).toBe(true);
+    expect(isKillDue(new Date(now.getTime() - 45 * DAY), now)).toBe(true);
+    expect(isKillDue(new Date(now.getTime() - 44 * DAY), now)).toBe(false);
+    expect(isKillDue(null, now)).toBe(false);
+  });
+});
+
+describe("careSchedule", () => {
+  const entry = new Date("2026-07-01T09:00:00Z");
+  const s = careSchedule(entry);
+
+  it("is +30d check-in, +90d referral, then 8 quarterly entries", () => {
+    expect(s).toHaveLength(10);
+    expect(s[0].date).toEqual(new Date(entry.getTime() + 30 * DAY));
+    expect(s[1].date).toEqual(new Date(entry.getTime() + 90 * DAY));
+    expect(s[2].date).toEqual(new Date(entry.getTime() + 180 * DAY));
+    expect(s[9].date).toEqual(new Date(entry.getTime() + (90 + 8 * 90) * DAY));
+  });
+});
+
+describe("renewalWindowEnd", () => {
+  it("is now + 30 days", () => {
+    const now = new Date("2026-07-18T00:00:00Z");
+    expect(renewalWindowEnd(now)).toEqual(new Date(now.getTime() + 30 * DAY));
+  });
+});
+
+describe("settings overrides", () => {
+  it("cadenceSchedule honors configured offsets", () => {
+    const entry = new Date("2026-07-15T09:00:00Z"); // Wed
+    const s = cadenceSchedule(entry, {
+      ...DEFAULT_FUNNEL_SETTINGS,
+      cadenceTouch1BusinessDays: 1,
+      cadenceTouch2OffsetDays: 2,
+    });
+    const t1 = addBusinessDays(entry, 1);
+    expect(s[0].date).toEqual(t1);
+    expect(s[1].date).toEqual(new Date(t1.getTime() + 2 * DAY));
+  });
+
+  it("isKillDue honors a configured threshold", () => {
+    const now = new Date("2026-07-18T00:00:00Z");
+    const s = { ...DEFAULT_FUNNEL_SETTINGS, killAfterDays: 10 };
+    expect(isKillDue(new Date(now.getTime() - 11 * DAY), now, s)).toBe(true);
+    expect(isKillDue(new Date(now.getTime() - 9 * DAY), now, s)).toBe(false);
+  });
+
+  it("careSchedule honors configured quarter count", () => {
+    const s = careSchedule(new Date("2026-07-01T09:00:00Z"), {
+      ...DEFAULT_FUNNEL_SETTINGS,
+      careQuarterCount: 2,
+    });
+    expect(s).toHaveLength(4);
+  });
+});
+
+describe("getFunnelSettings", () => {
+  it("returns defaults when no settings row exists", async () => {
+    (prismadb.crm_FunnelSettings.findFirst as jest.Mock).mockResolvedValue(null);
+    expect(await getFunnelSettings()).toEqual(DEFAULT_FUNNEL_SETTINGS);
+  });
+
+  it("maps a stored row to camelCase settings", async () => {
+    (prismadb.crm_FunnelSettings.findFirst as jest.Mock).mockResolvedValue({
+      kill_after_days: 30, recycle_after_days: 60,
+      cadence_touch1_business_days: 2, cadence_touch2_offset_days: 5,
+      cadence_touch3_offset_days: 7, cadence_touch4_offset_days: 10,
+      cadence_touch5_offset_days: 30, care_checkin_days: 14,
+      care_referral_days: 60, care_quarter_interval_days: 60,
+      care_quarter_count: 4, renewal_window_days: 21,
+    });
+    const s = await getFunnelSettings();
+    expect(s.killAfterDays).toBe(30);
+    expect(s.renewalWindowDays).toBe(21);
+  });
+});

--- a/__tests__/crm/recycle.test.ts
+++ b/__tests__/crm/recycle.test.ts
@@ -1,0 +1,54 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_campaign_sends: { findMany: jest.fn() },
+    crm_campaign_steps: { groupBy: jest.fn() },
+    crm_Targets: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { findRecycleCandidates } from "@/lib/crm/recycle";
+
+const DAY = 24 * 60 * 60 * 1000;
+const now = new Date("2026-07-18T00:00:00Z");
+const old = new Date(now.getTime() - 100 * DAY); // > 90 days ago
+const recent = new Date(now.getTime() - 10 * DAY);
+
+describe("findRecycleCandidates", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns targets whose final step was sent 90+ days ago", async () => {
+    (prismadb.crm_campaign_steps.groupBy as jest.Mock).mockResolvedValue([
+      { campaign_id: "camp1", _max: { order: 3 } },
+    ]);
+    (prismadb.crm_campaign_sends.findMany as jest.Mock).mockResolvedValue([
+      // t-done finished the sequence long ago; t-fresh finished recently;
+      // t-mid never got the last step
+      { target_id: "t-done", campaign_id: "camp1", sent_at: old, step: { order: 3 } },
+      { target_id: "t-fresh", campaign_id: "camp1", sent_at: recent, step: { order: 3 } },
+      { target_id: "t-mid", campaign_id: "camp1", sent_at: old, step: { order: 1 } },
+    ]);
+    (prismadb.crm_Targets.findMany as jest.Mock).mockResolvedValue([
+      { id: "t-done" }, // survives the eligibility filter
+    ]);
+
+    const ids = await findRecycleCandidates(now);
+    expect(ids).toEqual(["t-done"]);
+
+    // Eligibility filter excludes converted/suppressed/already-recycled targets
+    const where = (prismadb.crm_Targets.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.id.in).toEqual(["t-done"]);
+    expect(where.do_not_email).toBe(false);
+    expect(where.converted_at).toBeNull();
+    expect(where.deletedAt).toBeNull();
+    expect(where.target_lists.none.target_list.name).toBe("Recycled");
+  });
+
+  it("returns [] when no sequence has finished", async () => {
+    (prismadb.crm_campaign_steps.groupBy as jest.Mock).mockResolvedValue([]);
+    (prismadb.crm_campaign_sends.findMany as jest.Mock).mockResolvedValue([]);
+    const ids = await findRecycleCandidates(now);
+    expect(ids).toEqual([]);
+    expect(prismadb.crm_Targets.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/crm/recycle.test.ts
+++ b/__tests__/crm/recycle.test.ts
@@ -21,13 +21,15 @@ describe("findRecycleCandidates", () => {
     (prismadb.crm_campaign_steps.groupBy as jest.Mock).mockResolvedValue([
       { campaign_id: "camp1", _max: { order: 3 } },
     ]);
-    (prismadb.crm_campaign_sends.findMany as jest.Mock).mockResolvedValue([
-      // t-done finished the sequence long ago; t-fresh finished recently;
-      // t-mid never got the last step
-      { target_id: "t-done", campaign_id: "camp1", sent_at: old, step: { order: 3 } },
-      { target_id: "t-fresh", campaign_id: "camp1", sent_at: recent, step: { order: 3 } },
-      { target_id: "t-mid", campaign_id: "camp1", sent_at: old, step: { order: 1 } },
-    ]);
+    (prismadb.crm_campaign_sends.findMany as jest.Mock)
+      .mockResolvedValueOnce([
+        // t-done finished the sequence long ago; t-fresh finished recently;
+        // t-mid never got the last step
+        { target_id: "t-done", campaign_id: "camp1", sent_at: old, step: { order: 3 } },
+        { target_id: "t-fresh", campaign_id: "camp1", sent_at: recent, step: { order: 3 } },
+        { target_id: "t-mid", campaign_id: "camp1", sent_at: old, step: { order: 1 } },
+      ])
+      .mockResolvedValueOnce([]); // recent-activity check: none
     (prismadb.crm_Targets.findMany as jest.Mock).mockResolvedValue([
       { id: "t-done" }, // survives the eligibility filter
     ]);
@@ -42,6 +44,28 @@ describe("findRecycleCandidates", () => {
     expect(where.converted_at).toBeNull();
     expect(where.deletedAt).toBeNull();
     expect(where.target_lists.none.target_list.name).toBe("Recycled");
+  });
+
+  it("excludes targets with newer campaign activity (re-engaged in another sequence)", async () => {
+    (prismadb.crm_campaign_steps.groupBy as jest.Mock).mockResolvedValue([
+      { campaign_id: "camp1", _max: { order: 3 } },
+    ]);
+    // First findMany: old final sends. Second findMany: recent-activity check
+    // returns t-done as having a newer send (active in another campaign).
+    (prismadb.crm_campaign_sends.findMany as jest.Mock)
+      .mockResolvedValueOnce([
+        { target_id: "t-done", campaign_id: "camp1", sent_at: old, step: { order: 3 } },
+      ])
+      .mockResolvedValueOnce([{ target_id: "t-done" }]);
+
+    const ids = await findRecycleCandidates(now);
+    expect(ids).toEqual([]);
+    expect(prismadb.crm_Targets.findMany).not.toHaveBeenCalled();
+
+    // The recent-activity query must look for sends after the cutoff or queued
+    const recentWhere = (prismadb.crm_campaign_sends.findMany as jest.Mock).mock.calls[1][0].where;
+    expect(recentWhere.target_id.in).toEqual(["t-done"]);
+    expect(recentWhere.OR).toBeDefined();
   });
 
   it("returns [] when no sequence has finished", async () => {

--- a/__tests__/crm/stage-transition.test.ts
+++ b/__tests__/crm/stage-transition.test.ts
@@ -1,0 +1,54 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Opportunities: { update: jest.fn() } },
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({}) },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+import { handleStageTransition } from "@/lib/crm/stage-transition";
+
+describe("handleStageTransition", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("no-ops when the stage did not change", async () => {
+    const acted = await handleStageTransition({
+      opportunityId: "o1", fromStage: "s1", toStage: "s1",
+    });
+    expect(acted).toBe(false);
+    expect(prismadb.crm_Opportunities.update).not.toHaveBeenCalled();
+    expect(inngest.send).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when toStage is null", async () => {
+    const acted = await handleStageTransition({
+      opportunityId: "o1", fromStage: "s1", toStage: null,
+    });
+    expect(acted).toBe(false);
+  });
+
+  it("stamps stage_entered_at and emits the event on a real transition", async () => {
+    (prismadb.crm_Opportunities.update as jest.Mock).mockResolvedValue({});
+    const acted = await handleStageTransition({
+      opportunityId: "o1", fromStage: "s1", toStage: "s2",
+    });
+    expect(acted).toBe(true);
+    expect(prismadb.crm_Opportunities.update).toHaveBeenCalledWith({
+      where: { id: "o1" },
+      data: { stage_entered_at: expect.any(Date) },
+    });
+    expect(inngest.send).toHaveBeenCalledWith({
+      name: "crm/opportunity.stage-changed",
+      data: { record_id: "o1", to_stage: "s2" },
+    });
+  });
+
+  it("treats null -> stage as a transition (first stage assignment)", async () => {
+    (prismadb.crm_Opportunities.update as jest.Mock).mockResolvedValue({});
+    const acted = await handleStageTransition({
+      opportunityId: "o1", fromStage: null, toStage: "s2",
+    });
+    expect(acted).toBe(true);
+  });
+});

--- a/actions/crm/opportunities/create-opportunity.ts
+++ b/actions/crm/opportunities/create-opportunity.ts
@@ -6,6 +6,7 @@ import sendEmail from "@/lib/sendmail";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog } from "@/lib/audit-log";
 import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
+import { handleStageTransition } from "@/lib/crm/stage-transition";
 
 export const createOpportunity = async (data: {
   account?: string;
@@ -68,9 +69,16 @@ export const createOpportunity = async (data: {
         name,
         next_step: next_step || undefined,
         sales_stage: sales_stage || undefined,
+        stage_entered_at: new Date(),
         status: "ACTIVE",
         type: type || undefined,
       },
+    });
+
+    await handleStageTransition({
+      opportunityId: opportunity.id,
+      fromStage: null,
+      toStage: opportunity.sales_stage ?? null,
     });
 
     if (assigned_to && assigned_to !== userId) {

--- a/actions/crm/opportunities/update-opportunity.ts
+++ b/actions/crm/opportunities/update-opportunity.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog, diffObjects } from "@/lib/audit-log";
 import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
+import { handleStageTransition } from "@/lib/crm/stage-transition";
 
 export const updateOpportunity = async (data: {
   id: string;
@@ -74,6 +75,11 @@ export const updateOpportunity = async (data: {
         status: "ACTIVE",
         type: type || undefined,
       },
+    });
+    await handleStageTransition({
+      opportunityId: opportunity.id,
+      fromStage: before?.sales_stage ?? null,
+      toStage: opportunity.sales_stage ?? null,
     });
     const serialize = (obj: any) => JSON.parse(JSON.stringify(obj, (_, v) => typeof v === "bigint" ? v.toString() : v));
     const changes = before ? diffObjects(serialize(before), serialize(opportunity)) : null;

--- a/actions/crm/targets/__tests__/convert-target-to-deal.test.ts
+++ b/actions/crm/targets/__tests__/convert-target-to-deal.test.ts
@@ -4,7 +4,7 @@ jest.mock("@/lib/prisma", () => ({
     crm_Targets: { findFirst: jest.fn() },
     crm_campaign_sends: { findFirst: jest.fn() },
     crm_Opportunities_Sales_Stages: { findFirst: jest.fn() },
-    crm_Opportunities: { create: jest.fn(), findFirst: jest.fn() },
+    crm_Opportunities: { create: jest.fn(), findFirst: jest.fn(), update: jest.fn() },
   },
 }));
 jest.mock("@/inngest/client", () => ({
@@ -17,6 +17,7 @@ jest.mock("@/actions/crm/targets/convert-target", () => ({
 }));
 
 import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
 import { getSession } from "@/lib/auth-server";
 import { convertTarget } from "@/actions/crm/targets/convert-target";
 import { convertTargetToDeal } from "@/actions/crm/targets/convert-target-to-deal";
@@ -53,7 +54,10 @@ describe("convertTargetToDeal", () => {
       id: "stage-presale",
     });
     (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue(null);
-    (prismadb.crm_Opportunities.create as jest.Mock).mockResolvedValue({ id: "opp-1" });
+    (prismadb.crm_Opportunities.create as jest.Mock).mockResolvedValue({
+      id: "opp-1",
+      sales_stage: "stage-presale",
+    });
 
     const res = await convertTargetToDeal("t1");
 
@@ -65,6 +69,10 @@ describe("convertTargetToDeal", () => {
     expect(data.sales_stage).toBe("stage-presale");
     expect(data.assigned_to).toBe("u1");
     expect(data.status).toBe("ACTIVE");
+    expect(inngest.send).toHaveBeenCalledWith({
+      name: "crm/opportunity.stage-changed",
+      data: { record_id: "opp-1", to_stage: "stage-presale" },
+    });
   });
 
   it("works without any campaign send or configured stage", async () => {

--- a/actions/crm/targets/convert-target-to-deal.ts
+++ b/actions/crm/targets/convert-target-to-deal.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog } from "@/lib/audit-log";
 import { convertTarget } from "./convert-target";
+import { handleStageTransition } from "@/lib/crm/stage-transition";
 
 export async function convertTargetToDeal(
   targetId: string
@@ -55,6 +56,7 @@ export async function convertTargetToDeal(
         contact: converted.contactId,
         campaign: lastSend?.campaign_id ?? undefined,
         sales_stage: entryStage?.id ?? undefined,
+        stage_entered_at: new Date(),
         assigned_to: userId,
         createdBy: userId,
         updatedBy: userId,
@@ -62,6 +64,12 @@ export async function convertTargetToDeal(
         last_activity: new Date(),
         status: "ACTIVE",
       },
+    });
+
+    await handleStageTransition({
+      opportunityId: opportunity.id,
+      fromStage: null,
+      toStage: opportunity.sales_stage ?? null,
     });
 
     await writeAuditLog({

--- a/app/[locale]/(routes)/admin/_components/AdminSidebarNav.tsx
+++ b/app/[locale]/(routes)/admin/_components/AdminSidebarNav.tsx
@@ -10,6 +10,7 @@ const navItems = [
   { label: "Users",        href: "/admin/users",        icon: Users },
   { label: "Services",     href: "/admin/services",     icon: Settings },
   { label: "CRM Settings", href: "/admin/crm-settings", icon: SlidersHorizontal },
+  { label: "Funnel Settings", href: "/admin/funnel-settings", icon: SlidersHorizontal },
   { label: "Audit Log",    href: "/admin/audit-log",    icon: ClipboardList },
   { label: "Currencies",   href: "/admin/currencies",   icon: Coins },
   { label: "Invoices",     href: "/admin/invoices",     icon: FileText },

--- a/app/[locale]/(routes)/admin/crm-settings/_actions/crm-settings.ts
+++ b/app/[locale]/(routes)/admin/crm-settings/_actions/crm-settings.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { prismadb as prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
+import { STAGE_KINDS, type StageKind } from "@/lib/crm/stage-kinds";
 
 async function ensureAdmin(): Promise<{ error: string } | null> {
   try {
@@ -25,9 +26,16 @@ export type CrmConfigType =
   | "opportunityType"
   | "salesStage";
 
-export type ConfigValue = { id: string; name: string; usageCount: number };
+export type ConfigValue = {
+  id: string;
+  name: string;
+  usageCount: number;
+  /** Automation trigger — populated for salesStage rows only. */
+  stageKind?: string | null;
+};
 
 const nameSchema = z.string().trim().min(1, "Name is required").max(100, "Max 100 characters");
+const stageKindSchema = z.enum(STAGE_KINDS).nullable().optional();
 
 const configMap = {
   industry:        { model: () => prisma.crm_Industry_Type,               countRelation: "accounts",                              updateMany: null },
@@ -61,28 +69,42 @@ export async function getConfigValues(configType: CrmConfigType): Promise<Config
     id: r.id,
     name: r.name,
     usageCount: r._count[countRelation] ?? 0,
+    ...(configType === "salesStage" ? { stageKind: r.stage_kind ?? null } : {}),
   }));
 }
 
-export async function createConfigValue(configType: CrmConfigType, name: string): Promise<void> {
+export async function createConfigValue(
+  configType: CrmConfigType,
+  name: string,
+  stageKind?: StageKind | null
+): Promise<void> {
   const denied = await ensureAdmin();
   if (denied) throw new Error(denied.error);
   const parsed = nameSchema.parse(name);
   const { model } = configMap[configType];
-  await (model() as any).create({ data: { name: parsed, v: 0 } });
+  const data: Record<string, unknown> = { name: parsed, v: 0 };
+  if (configType === "salesStage" && stageKind !== undefined) {
+    data.stage_kind = stageKindSchema.parse(stageKind) ?? null;
+  }
+  await (model() as any).create({ data });
   revalidatePath("/", "layout");
 }
 
 export async function updateConfigValue(
   configType: CrmConfigType,
   id: string,
-  name: string
+  name: string,
+  stageKind?: StageKind | null
 ): Promise<void> {
   const denied = await ensureAdmin();
   if (denied) throw new Error(denied.error);
   const parsed = nameSchema.parse(name);
   const { model } = configMap[configType];
-  await (model() as any).update({ where: { id }, data: { name: parsed } });
+  const data: Record<string, unknown> = { name: parsed };
+  if (configType === "salesStage" && stageKind !== undefined) {
+    data.stage_kind = stageKindSchema.parse(stageKind) ?? null;
+  }
+  await (model() as any).update({ where: { id }, data });
   revalidatePath("/", "layout");
 }
 

--- a/app/[locale]/(routes)/admin/crm-settings/_components/ConfigAddDialog.tsx
+++ b/app/[locale]/(routes)/admin/crm-settings/_components/ConfigAddDialog.tsx
@@ -5,8 +5,12 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Plus } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { createConfigValue, type CrmConfigType } from "../_actions/crm-settings";
+import { STAGE_KINDS, type StageKind } from "@/lib/crm/stage-kinds";
 import { toast } from "sonner";
+
+const KIND_NONE = "__none__";
 
 interface Props {
   configType: CrmConfigType;
@@ -16,15 +20,23 @@ interface Props {
 export function ConfigAddDialog({ configType, label }: Props) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
+  const [stageKind, setStageKind] = useState<string>(KIND_NONE);
   const [loading, setLoading] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
     try {
-      await createConfigValue(configType, name);
+      await createConfigValue(
+        configType,
+        name,
+        configType === "salesStage"
+          ? (stageKind === KIND_NONE ? null : (stageKind as StageKind))
+          : undefined
+      );
       toast.success(`${label} added`);
       setName("");
+      setStageKind(KIND_NONE);
       setOpen(false);
     } catch (err: any) {
       toast.error(err.message ?? "Failed to add");
@@ -49,6 +61,22 @@ export function ConfigAddDialog({ configType, label }: Props) {
             <Label htmlFor="name">Name</Label>
             <Input id="name" value={name} onChange={(e) => setName(e.target.value)} maxLength={100} required />
           </div>
+          {configType === "salesStage" && (
+            <div className="space-y-1">
+              <Label>Automation trigger</Label>
+              <Select value={stageKind} onValueChange={setStageKind}>
+                <SelectTrigger>
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={KIND_NONE}>None</SelectItem>
+                  {STAGE_KINDS.map((k) => (
+                    <SelectItem key={k} value={k}>{k}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
           <Button type="submit" disabled={loading} className="w-full">
             {loading ? "Adding…" : "Add"}
           </Button>

--- a/app/[locale]/(routes)/admin/crm-settings/_components/ConfigEditDialog.tsx
+++ b/app/[locale]/(routes)/admin/crm-settings/_components/ConfigEditDialog.tsx
@@ -4,26 +4,39 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateConfigValue, type CrmConfigType } from "../_actions/crm-settings";
+import { STAGE_KINDS, type StageKind } from "@/lib/crm/stage-kinds";
 import { toast } from "sonner";
+
+const KIND_NONE = "__none__";
 
 interface Props {
   configType: CrmConfigType;
   id: string;
   currentName: string;
+  currentStageKind?: string | null;
   open: boolean;
   onOpenChange: (v: boolean) => void;
 }
 
-export function ConfigEditDialog({ configType, id, currentName, open, onOpenChange }: Props) {
+export function ConfigEditDialog({ configType, id, currentName, currentStageKind, open, onOpenChange }: Props) {
   const [name, setName] = useState(currentName);
+  const [stageKind, setStageKind] = useState<string>(currentStageKind ?? KIND_NONE);
   const [loading, setLoading] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
     try {
-      await updateConfigValue(configType, id, name);
+      await updateConfigValue(
+        configType,
+        id,
+        name,
+        configType === "salesStage"
+          ? (stageKind === KIND_NONE ? null : (stageKind as StageKind))
+          : undefined
+      );
       toast.success("Updated");
       onOpenChange(false);
     } catch (err: any) {
@@ -42,6 +55,22 @@ export function ConfigEditDialog({ configType, id, currentName, open, onOpenChan
             <Label htmlFor="edit-name">Name</Label>
             <Input id="edit-name" value={name} onChange={(e) => setName(e.target.value)} maxLength={100} required />
           </div>
+          {configType === "salesStage" && (
+            <div className="space-y-1">
+              <Label>Automation trigger</Label>
+              <Select value={stageKind} onValueChange={setStageKind}>
+                <SelectTrigger>
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={KIND_NONE}>None</SelectItem>
+                  {STAGE_KINDS.map((k) => (
+                    <SelectItem key={k} value={k}>{k}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
           <Button type="submit" disabled={loading} className="w-full">
             {loading ? "Saving…" : "Save"}
           </Button>

--- a/app/[locale]/(routes)/admin/crm-settings/_components/ConfigList.tsx
+++ b/app/[locale]/(routes)/admin/crm-settings/_components/ConfigList.tsx
@@ -35,6 +35,9 @@ export function ConfigList({ configType, label, values }: Props) {
               {item.usageCount > 0 && (
                 <Badge variant="secondary">{item.usageCount} in use</Badge>
               )}
+              {item.stageKind && (
+                <Badge variant="outline">{item.stageKind}</Badge>
+              )}
             </div>
             <div className="flex gap-1">
               <Button size="icon" variant="ghost" onClick={() => setEditItem(item)}>
@@ -58,6 +61,7 @@ export function ConfigList({ configType, label, values }: Props) {
           configType={configType}
           id={editItem.id}
           currentName={editItem.name}
+          currentStageKind={editItem.stageKind ?? null}
           open={!!editItem}
           onOpenChange={(v) => { if (!v) setEditItem(null); }}
         />

--- a/app/[locale]/(routes)/admin/funnel-settings/_actions/funnel-settings.ts
+++ b/app/[locale]/(routes)/admin/funnel-settings/_actions/funnel-settings.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { prismadb } from "@/lib/prisma";
+import { requireRole, AuthorizationError, AuthenticationError } from "@/lib/authz";
+import type { FunnelTimingSettings } from "@/lib/crm/funnel-timers";
+
+const dayField = z.number().int().min(1).max(365);
+const settingsSchema = z.object({
+  killAfterDays: dayField,
+  recycleAfterDays: dayField,
+  cadenceTouch1BusinessDays: dayField,
+  cadenceTouch2OffsetDays: dayField,
+  cadenceTouch3OffsetDays: dayField,
+  cadenceTouch4OffsetDays: dayField,
+  cadenceTouch5OffsetDays: dayField,
+  careCheckinDays: dayField,
+  careReferralDays: dayField,
+  careQuarterIntervalDays: dayField,
+  careQuarterCount: z.number().int().min(0).max(24),
+  renewalWindowDays: dayField,
+});
+
+export async function updateFunnelSettings(
+  values: FunnelTimingSettings,
+): Promise<{ error?: string }> {
+  let admin;
+  try {
+    admin = await requireRole(["admin"]);
+  } catch (e) {
+    if (e instanceof AuthorizationError || e instanceof AuthenticationError) {
+      return { error: "Forbidden" };
+    }
+    throw e;
+  }
+
+  const parsed = settingsSchema.safeParse(values);
+  if (!parsed.success) return { error: "Invalid values — all fields must be whole days in range." };
+  const v = parsed.data;
+
+  const data = {
+    kill_after_days: v.killAfterDays,
+    recycle_after_days: v.recycleAfterDays,
+    cadence_touch1_business_days: v.cadenceTouch1BusinessDays,
+    cadence_touch2_offset_days: v.cadenceTouch2OffsetDays,
+    cadence_touch3_offset_days: v.cadenceTouch3OffsetDays,
+    cadence_touch4_offset_days: v.cadenceTouch4OffsetDays,
+    cadence_touch5_offset_days: v.cadenceTouch5OffsetDays,
+    care_checkin_days: v.careCheckinDays,
+    care_referral_days: v.careReferralDays,
+    care_quarter_interval_days: v.careQuarterIntervalDays,
+    care_quarter_count: v.careQuarterCount,
+    renewal_window_days: v.renewalWindowDays,
+    updatedBy: admin.id,
+  };
+
+  const existing = await prismadb.crm_FunnelSettings.findFirst({ select: { id: true } });
+  if (existing) {
+    await prismadb.crm_FunnelSettings.update({ where: { id: existing.id }, data });
+  } else {
+    await prismadb.crm_FunnelSettings.create({ data });
+  }
+  revalidatePath("/[locale]/(routes)/admin/funnel-settings", "page");
+  return {};
+}

--- a/app/[locale]/(routes)/admin/funnel-settings/_components/FunnelSettingsForm.tsx
+++ b/app/[locale]/(routes)/admin/funnel-settings/_components/FunnelSettingsForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { FunnelTimingSettings } from "@/lib/crm/funnel-timers";
+import { updateFunnelSettings } from "../_actions/funnel-settings";
+
+const FIELDS: Array<{ key: keyof FunnelTimingSettings; label: string; group: string }> = [
+  { key: "killAfterDays", label: "Close deal after N days of client silence", group: "Kill rule" },
+  { key: "recycleAfterDays", label: "Recycle targets N days after sequence end", group: "Recycle" },
+  { key: "cadenceTouch1BusinessDays", label: "Touch 1: business days after quote", group: "Follow-up cadence" },
+  { key: "cadenceTouch2OffsetDays", label: "Touch 2: days after touch 1", group: "Follow-up cadence" },
+  { key: "cadenceTouch3OffsetDays", label: "Touch 3: days after touch 2", group: "Follow-up cadence" },
+  { key: "cadenceTouch4OffsetDays", label: "Touch 4: days after touch 3", group: "Follow-up cadence" },
+  { key: "cadenceTouch5OffsetDays", label: "Touch 5 (final): days after touch 3", group: "Follow-up cadence" },
+  { key: "careCheckinDays", label: "Care check-in after N days", group: "Care & renewals" },
+  { key: "careReferralDays", label: "Referral ask after N days", group: "Care & renewals" },
+  { key: "careQuarterIntervalDays", label: "Quarterly interval (days)", group: "Care & renewals" },
+  { key: "careQuarterCount", label: "Number of quarterly check-ins", group: "Care & renewals" },
+  { key: "renewalWindowDays", label: "Surface renewals N days ahead", group: "Care & renewals" },
+];
+
+const FunnelSettingsForm = ({ initial }: { initial: FunnelTimingSettings }) => {
+  const [values, setValues] = useState<FunnelTimingSettings>(initial);
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const res = await updateFunnelSettings(values);
+      if (res.error) toast.error(res.error);
+      else toast.success("Funnel settings saved");
+    } catch {
+      toast.error("Failed to save funnel settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const groups = Array.from(new Set(FIELDS.map((f) => f.group)));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Funnel timing — instance settings</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Changes apply to future stage entries and the next timer runs;
+          already-scheduled cadences keep the timings they started with.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {groups.map((group) => (
+          <div key={group} className="space-y-2">
+            <h3 className="text-sm font-semibold">{group}</h3>
+            <div className="grid gap-3 md:grid-cols-2">
+              {FIELDS.filter((f) => f.group === group).map((f) => (
+                <label key={f.key} className="space-y-1 text-sm">
+                  <span>{f.label}</span>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={values[f.key]}
+                    onChange={(e) =>
+                      setValues((prev) => ({ ...prev, [f.key]: Number(e.target.value) }))
+                    }
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+        ))}
+        <Button onClick={save} disabled={saving}>
+          {saving ? "Saving…" : "Save settings"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FunnelSettingsForm;

--- a/app/[locale]/(routes)/admin/funnel-settings/page.tsx
+++ b/app/[locale]/(routes)/admin/funnel-settings/page.tsx
@@ -1,0 +1,9 @@
+import { getFunnelSettings } from "@/lib/crm/funnel-settings";
+import FunnelSettingsForm from "./_components/FunnelSettingsForm";
+
+const FunnelSettingsPage = async () => {
+  const settings = await getFunnelSettings();
+  return <FunnelSettingsForm initial={settings} />;
+};
+
+export default FunnelSettingsPage;

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -20,6 +20,7 @@ import { campaignProcessFollowUp } from "@/inngest/functions/campaigns/process-f
 import { campaignSendNow } from "@/inngest/functions/campaigns/send-now";
 import { reportSendScheduled } from "@/inngest/functions/reports/send-scheduled";
 import { qualifiedCadence } from "@/inngest/functions/crm/qualified-cadence";
+import { killRule } from "@/inngest/functions/crm/kill-rule";
 import { enrichDocument } from "@/inngest/functions/documents/enrich-document";
 import { generateDocumentThumbnail } from "@/inngest/functions/documents/generate-thumbnail";
 import { syncExchangeRates } from "@/inngest/functions/ecb/sync-exchange-rates";
@@ -47,6 +48,7 @@ export const { GET, POST, PUT } = serve({
     campaignSendNow,
     reportSendScheduled,
     qualifiedCadence,
+    killRule,
     enrichDocument,
     generateDocumentThumbnail,
     syncExchangeRates,

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -23,6 +23,7 @@ import { qualifiedCadence } from "@/inngest/functions/crm/qualified-cadence";
 import { killRule } from "@/inngest/functions/crm/kill-rule";
 import { careTasks } from "@/inngest/functions/crm/care-tasks";
 import { recycleTargets } from "@/inngest/functions/crm/recycle-targets";
+import { renewalReminders } from "@/inngest/functions/crm/renewal-reminders";
 import { enrichDocument } from "@/inngest/functions/documents/enrich-document";
 import { generateDocumentThumbnail } from "@/inngest/functions/documents/generate-thumbnail";
 import { syncExchangeRates } from "@/inngest/functions/ecb/sync-exchange-rates";
@@ -53,6 +54,7 @@ export const { GET, POST, PUT } = serve({
     killRule,
     careTasks,
     recycleTargets,
+    renewalReminders,
     enrichDocument,
     generateDocumentThumbnail,
     syncExchangeRates,

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -22,6 +22,7 @@ import { reportSendScheduled } from "@/inngest/functions/reports/send-scheduled"
 import { qualifiedCadence } from "@/inngest/functions/crm/qualified-cadence";
 import { killRule } from "@/inngest/functions/crm/kill-rule";
 import { careTasks } from "@/inngest/functions/crm/care-tasks";
+import { recycleTargets } from "@/inngest/functions/crm/recycle-targets";
 import { enrichDocument } from "@/inngest/functions/documents/enrich-document";
 import { generateDocumentThumbnail } from "@/inngest/functions/documents/generate-thumbnail";
 import { syncExchangeRates } from "@/inngest/functions/ecb/sync-exchange-rates";
@@ -51,6 +52,7 @@ export const { GET, POST, PUT } = serve({
     qualifiedCadence,
     killRule,
     careTasks,
+    recycleTargets,
     enrichDocument,
     generateDocumentThumbnail,
     syncExchangeRates,

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -19,6 +19,7 @@ import { campaignSendStep } from "@/inngest/functions/campaigns/send-step";
 import { campaignProcessFollowUp } from "@/inngest/functions/campaigns/process-follow-up";
 import { campaignSendNow } from "@/inngest/functions/campaigns/send-now";
 import { reportSendScheduled } from "@/inngest/functions/reports/send-scheduled";
+import { qualifiedCadence } from "@/inngest/functions/crm/qualified-cadence";
 import { enrichDocument } from "@/inngest/functions/documents/enrich-document";
 import { generateDocumentThumbnail } from "@/inngest/functions/documents/generate-thumbnail";
 import { syncExchangeRates } from "@/inngest/functions/ecb/sync-exchange-rates";
@@ -45,6 +46,7 @@ export const { GET, POST, PUT } = serve({
     campaignProcessFollowUp,
     campaignSendNow,
     reportSendScheduled,
+    qualifiedCadence,
     enrichDocument,
     generateDocumentThumbnail,
     syncExchangeRates,

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -21,6 +21,7 @@ import { campaignSendNow } from "@/inngest/functions/campaigns/send-now";
 import { reportSendScheduled } from "@/inngest/functions/reports/send-scheduled";
 import { qualifiedCadence } from "@/inngest/functions/crm/qualified-cadence";
 import { killRule } from "@/inngest/functions/crm/kill-rule";
+import { careTasks } from "@/inngest/functions/crm/care-tasks";
 import { enrichDocument } from "@/inngest/functions/documents/enrich-document";
 import { generateDocumentThumbnail } from "@/inngest/functions/documents/generate-thumbnail";
 import { syncExchangeRates } from "@/inngest/functions/ecb/sync-exchange-rates";
@@ -49,6 +50,7 @@ export const { GET, POST, PUT } = serve({
     reportSendScheduled,
     qualifiedCadence,
     killRule,
+    careTasks,
     enrichDocument,
     generateDocumentThumbnail,
     syncExchangeRates,

--- a/docs/internal/aqunama-p2-smoke-test.md
+++ b/docs/internal/aqunama-p2-smoke-test.md
@@ -1,0 +1,157 @@
+# AQUNAMA Phase 2 — Manual Smoke Test
+
+Target environment: the **dev deployment** (dev.nextcrm.app) after PR #249 is deployed there.
+Time needed: ~30–45 min. The timers span days by design, so this script verifies each
+mechanism through the **Inngest dashboard** (runs, sleeps, cancellations) plus optional
+**SQL time-travel** snippets for the paths where you want to see the end result today.
+
+## Prerequisites
+
+- [ ] Admin login on the dev deployment (`test@nextcrm.app` or your own admin).
+- [ ] Inngest dashboard open: `http://10.100.90.29:8288` (the dev Inngest server). You should
+      see the five new functions registered: `CRM: Qualified follow-up cadence`,
+      `CRM: 45-day kill rule`, `CRM: Care touchpoints`, `CRM: Recycle exhausted targets`,
+      `CRM: Renewal reminders`.
+- [ ] Optional (for time-travel steps): psql access to the dev DB
+      (`psql postgresql://…@10.100.90.10:5433/nextcrm-dev`).
+- [ ] A throwaway test account + contact + deal you don't mind mutating. Create fresh ones
+      (e.g. account "Smoke P2", contact, and a deal via the opportunity form) so the kill
+      rule can't touch real data.
+
+---
+
+## Scenario 0 — Admin configuration (5 min)
+
+1. Go to **Administration → CRM Settings → Sales stage** tab.
+   - [ ] Each stage row shows an outline badge with its automation trigger where set
+         (seeded: New→pre_sale, Need analysis→qualified, Signing→purchase_order,
+         Realization of the project→delivery).
+   - [ ] Edit a stage: the dialog has an **Automation trigger** select (None + 5 kinds).
+         Set your Qualified-intent stage to `qualified` and (if missing) a stage to `care`.
+         Save → badge updates.
+2. Go to **Administration → Funnel Settings** (new sidebar item).
+   - [ ] The form shows 4 groups (Kill rule / Recycle / Follow-up cadence / Care & renewals)
+         with the defaults 45 / 90 / 3-7-10-15-45 / 30-90-90-8 / 30.
+   - [ ] Enter `0` into "Close deal after N days…" and save → red toast
+         ("Invalid values…"). Server-side validation works.
+   - [ ] Set "Close deal after N days of client silence" to `1` and save → success toast.
+         Reload the page → value persisted. **Leave it at 1 for Scenario 3; restore to 45
+         at the end.**
+
+## Scenario 1 — Stage change fires the cadence (5 min)
+
+1. Open **CRM → Dashboard** (kanban). Drag your test deal into the `qualified`-trigger
+   stage (or set the stage via the deal's Update form).
+2. In the Inngest dashboard → Runs:
+   - [ ] A new run of **CRM: Qualified follow-up cadence** exists for this event.
+   - [ ] Its step timeline shows `load-stage`, `load-settings` completed and it is now
+         **sleeping at `wait-touch-1`** until ~3 business days from now.
+   - [ ] A run of **CRM: Care touchpoints** also triggered and finished immediately with
+         `{ skipped: true, reason: "not a care stage" }` (both functions listen to the
+         same event — the guard is the point).
+3. Move a DIFFERENT deal between two non-qualified stages:
+   - [ ] The cadence run for it ends `skipped` — no sleeping run accumulates.
+
+## Scenario 2 — Leaving the stage cancels the cadence (2 min)
+
+1. Move the Scenario-1 deal from the qualified stage to any other stage.
+2. In Inngest → Runs:
+   - [ ] The sleeping cadence run from Scenario 1 flips to **Cancelled** (cancelOn matched
+         the new stage-changed event for the same deal).
+   - [ ] If you moved it into the `care` stage: a **CRM: Care touchpoints** run is now
+         sleeping at `wait-care-0` (≈30 days out) — that also covers Scenario 4's start.
+
+## Scenario 3 — Kill rule closes a silent deal (10 min, uses the 1-day setting + SQL)
+
+1. Move the test deal (back) into the `qualified` stage. Funnel Settings still has
+   kill = 1 day (Scenario 0).
+2. Time-travel the deal's clock — in psql (replace the name):
+
+   ```sql
+   UPDATE "crm_Opportunities"
+   SET stage_entered_at = NOW() - INTERVAL '2 days'
+   WHERE name = 'YOUR TEST DEAL NAME';
+   ```
+
+3. Trigger the sweep now instead of waiting for 06:00 UTC: Inngest dashboard →
+   Functions → **CRM: 45-day kill rule** → Invoke (empty payload `{}`).
+   - [ ] The run output shows `{ checked: N, closed: 1 }` (or more if other test deals
+         qualified — this is why you use throwaway data).
+   - [ ] The deal's status is now CLOSED — it disappears from the active pipeline/kanban.
+   - [ ] The rep (assigned user) received the "Deal closed by 1-day rule" email
+         (check the Resend dashboard or the inbox).
+   - [ ] Administration → Audit Log has an `opportunity / updated` entry with
+         status ACTIVE→CLOSED and `close_reason`.
+4. Clock-restart check (negative case): repeat with a second qualified test deal but first
+   log an activity on it (deal detail → activity, or any inbound synced email from its
+   contact) — then Invoke the function again:
+   - [ ] `closed` does NOT include this deal (activity restarted the clock).
+5. **Restore Funnel Settings kill days to 45.**
+
+## Scenario 4 — Care schedule (verify via Inngest, 2 min)
+
+Covered by Scenario 2 step 2 if you moved the deal to the care stage:
+- [ ] The Care run sleeps at `wait-care-0` ~30 days out (or your configured value).
+- [ ] Optional end-result proof: temporarily set "Care check-in after N days" to 1,
+      re-enter the care stage with a fresh test deal, and either wait a day or accept the
+      Inngest sleep as evidence. (sleepUntil timestamps are fixed at entry — changing the
+      setting after entry must NOT move the already-sleeping run: verify the sleeping
+      run's wake time stays put after you change the setting.)
+
+## Scenario 5 — Target recycle (SQL time-travel, 5 min)
+
+Needs a target that finished a campaign sequence. If dev has an old test campaign whose
+sends are `sent`, use it; otherwise send a 1-step campaign to a throwaway target first.
+
+1. Backdate the final send:
+
+   ```sql
+   UPDATE "crm_campaign_sends"
+   SET sent_at = NOW() - INTERVAL '100 days'
+   WHERE email = 'your-throwaway-target@example.com';
+   ```
+
+2. Inngest → Functions → **CRM: Recycle exhausted targets** → Invoke.
+   - [ ] Run output `{ recycled: 1 }`.
+   - [ ] Campaigns → Target lists: a list named **Recycled** exists and contains the target.
+   - [ ] Admin users received the "…targets recycled — assign a new sequence" digest email.
+3. Invoke the function again:
+   - [ ] `{ recycled: 0 }` — list membership makes it idempotent.
+4. Negative case: a target with a send in the last 90 days (any active sequence) must NOT
+   appear in Recycled even if an older sequence finished long ago.
+
+## Scenario 6 — Renewal reminders (5 min)
+
+1. On your test account, either set a contract's **Renewal reminder date** or assign a
+   product with a **renewal date** ~2 weeks from today.
+2. Inngest → Functions → **CRM: Renewal reminders** → Invoke.
+   - [ ] Run output `{ created: 1 }`.
+   - [ ] The account's task list shows a task titled `Renewal 2026-…: …` assigned to the
+         account's rep, due on the renewal date; the rep got the notification email.
+3. Invoke again → `{ created: 0 }` (idempotent while the task is open).
+4. **Complete the task**, then Invoke again:
+   - [ ] Still `{ created: 0 }` — completed renewals must not respawn (this was a
+         pre-push review fix; regression-check it explicitly).
+
+## Scenario 7 — Task wiring (2 min)
+
+For any auto-created task from Scenarios 3–6:
+- [ ] It appears in the account's tasks table (CRM → account detail) with priority high
+      and the correct due date.
+- [ ] The assignee email arrived with a working link to the task.
+
+## Wrap-up
+
+- [ ] Funnel Settings restored to defaults (45 / 90 / 3-7-10-15-45 / 30-90-90-8 / 30).
+- [ ] Test deals/targets cleaned up or clearly named as smoke-test data.
+- [ ] Anything unexpected → capture the Inngest run ID + screenshots and report.
+
+## Known limitations (don't file as bugs)
+
+- Cadence/care schedules snapshot Funnel Settings at stage entry — changing settings
+  never reshapes already-sleeping runs (by design, see Scenario 4).
+- Touch dates use day arithmetic in UTC; across a DST change a task's due time can shift
+  by an hour.
+- Recycled targets are NOT auto-enrolled in a new sequence — assigning the Recycled list
+  to a fresh campaign is a deliberate human step.
+- The cadence runs for every qualified deal (no low/high-value distinction yet).

--- a/docs/internal/aqunama-setup-runbook.md
+++ b/docs/internal/aqunama-setup-runbook.md
@@ -42,3 +42,30 @@ assigns lists to campaigns with `campaigns_assign_target_list`.
 - The 3-month recycle and 45-day kill rule are Phase 2 (automated);
   until then track them manually via the campaign stats and deal
   last-activity dates.
+
+## 7. Phase 2 automation (timers)
+
+After deploying Phase 2, connect the automation in **Admin → CRM settings →
+Sales stage**: each stage has an "Automation trigger" — set Pre-Sale →
+pre_sale, Qualified Lead → qualified, Purchase Order → purchase_order,
+Delivery → delivery, Care → care. Stages without a trigger are ignored by
+the timers (renaming a stage never breaks automation; the trigger does).
+
+All day counts below are the defaults — every one is editable at
+**Admin → Funnel Settings** (instance-wide; changes apply to future stage
+entries and the next timer runs).
+
+What runs automatically:
+- **Qualified entry** → 5-touch follow-up cadence as tasks for the deal's
+  rep (+3 business days call, +7d email, +10d email/call, day 15 and day
+  45 of the retention window). Leaves the stage → remaining touches cancel.
+- **45-day kill rule** (daily 06:00 UTC): Qualified deals with no client
+  activity (inbound synced email, logged activity) for 45 days are closed
+  as Lost and the rep is emailed. Reopen by setting status back to Active.
+- **Care entry** → +30d check-in, ~90d referral-ask, then quarterly tasks
+  (8 quarters).
+- **Recycle** (daily 06:30 UTC): targets whose sequence finished 90+ days
+  ago with no conversion land in the "Recycled" target list; admins get a
+  digest. Assign that list to a fresh campaign to re-try them.
+- **Renewals** (Mondays 07:00 UTC): contract reminder dates and product
+  renewal dates within 30 days become tasks for the account's rep.

--- a/docs/superpowers/plans/2026-07-16-aqunama-roadmap.md
+++ b/docs/superpowers/plans/2026-07-16-aqunama-roadmap.md
@@ -1,0 +1,48 @@
+# AQUNAMA on NextCRM — Implementation Roadmap
+
+**Status:** Plan 1 is fully specified; Plans 2–4 are scoped stubs to be expanded into full plans (via superpowers:writing-plans) when their turn comes.
+**Source analysis:** `docs/internal/aqunama-sales-process-gap-analysis.md`
+**Decisions made (2026-07-16):** top-of-funnel maps to Targets + target lists (not Leads); SOW/quote approval starts minimal (approval status on the opportunity + attached document, no quote entity); calendar scope is **full two-way sync** (Google Calendar + Calendly); work is split into independently shippable plans.
+
+---
+
+## Plan 1 — Compliance & Flow Glue ✅ specified
+
+Full plan: `docs/superpowers/plans/2026-07-16-aqunama-p1-compliance-flow-glue.md`
+Covers gaps G-02 (target→deal conversion), G-06 (global opt-out), G-08 (XLSX import), G-09 (delivery deadline), plus the Phase-0 configuration runbook. Ship this first — the global opt-out is a compliance prerequisite for everything that follows.
+
+## Plan 2 — Timer & Task Engine ✅ implemented (2026-07-18)
+
+Full plan: `docs/superpowers/plans/2026-07-18-aqunama-p2-timer-task-engine.md` — decisions: activity = inbound email OR logged activity; stage kinds connectable in admin (CRM settings); all timing values instance-configurable at Admin → Funnel Settings; weekend-only business days; kill = close + notify.
+
+Original stub (for reference):
+
+The heart of the spec: automated funnel timing on Inngest.
+
+- **Data:** add `funnel_state` tracking to targets/opportunities where needed (e.g. `sequence_exhausted_at`, `paused_until` on the target; task↔opportunity link `opportunity_id` on `crm_Accounts_Tasks`).
+- **Recycle timer:** daily Inngest cron — targets whose sequence exhausted ≥ 3 months ago and `do_not_email = false` move into a "Recycled" target list and get re-assigned a campaign.
+- **45-day kill rule:** daily cron over ACTIVE opportunities in Qualified stage — if `last_activity` (restarted by inbound synced email or logged activity; exact definition to confirm at plan time) is > 45 days old, set status to CLOSED/Lost and notify the rep.
+- **Cadence tasks:** on stage entry to Qualified (quote sent), schedule the 5-touch cadence as auto-created CRM tasks (+3 business days, +7 d, +10 d, day 15 and 45 of the retention window). Requires a business-day helper and a stage-transition event.
+- **Care tasks:** on stage entry to Care, schedule +30-day check-in, quarterly check-ins, and the ~90-day referral-ask task.
+- **Renewal surfacing:** weekly cron emailing reps contracts/account-products with `renewal_date`/`renewalReminderDate` within 60 days.
+- **Prerequisite decision:** precise definition of "client activity" that restarts the 45-day clock.
+
+## Plan 3 — Minimal SOW/Quote Approval (gap G-04 + case-study flag from G-10) — stub
+
+- **Data:** `approval_status` enum on `crm_Opportunities` (`none | pending_approval | approved | rejected`), `approved_by`/`approved_at`; `case_study_candidate` + `case_study_approved` on `crm_Accounts`.
+- **Flow:** rep attaches the SOW/quote document to the opportunity and requests approval → manager/admin (CSO) sees a pending-approvals view and approves/rejects (guarded by `isManagerOrAdmin`) → only approved deals can move to the Qualified stage (transition guard) → approval decisions audit-logged and email-notified.
+- **Upgrade path:** a structured `crm_Quotes` entity with line items + PDF (reusing the invoice `@react-pdf/renderer` pipeline) stays available as a later enhancement; nothing in the minimal flow blocks it.
+
+## Plan 4 — Calendar: Full Two-Way Sync (gap G-05) — stub, largest single item
+
+Decision was full sync (not webhook-only). Suggested internal milestones so value ships early:
+
+1. **Milestone A — Calendly inbound:** Calendly webhook endpoint (`invitee.created` / `invitee.canceled`) → match invitee email to target/contact → create a meeting activity + task on the matching record. Small, ships alone.
+2. **Milestone B — Google Calendar OAuth + inbound sync:** per-user OAuth (googleapis), store tokens alongside the existing email-account credentials pattern, watch/poll the rep's calendar, link events to CRM records by attendee email.
+3. **Milestone C — outbound + true two-way:** create/update calendar events from CRM (booked calls, cadence call tasks), handle reschedules/cancellations both directions, conflict resolution.
+- **Data:** `crm_Meetings` (or reuse `crm_Activities` with type MEETING) + external-id mapping table for sync idempotency.
+- **Risk:** Google OAuth verification/scopes and token refresh operational burden; Milestone A alone already satisfies "booked calls land in the CRM" if priorities shift.
+
+## Suggested order
+
+Plan 1 → Plan 2 → Plan 3 → Plan 4 (Milestone A of Plan 4 can run in parallel with Plan 3 if capacity allows). AI voice calls (G-12) remain out of scope until later 2026 per the spec.

--- a/inngest/functions/crm/care-tasks.ts
+++ b/inngest/functions/crm/care-tasks.ts
@@ -1,0 +1,59 @@
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+import { careSchedule } from "@/lib/crm/funnel-timers";
+import { getFunnelSettings } from "@/lib/crm/funnel-settings";
+import { createAutoTask } from "@/lib/crm/auto-task";
+
+// Spec §3.8: post-delivery Care touchpoints — check-in, referral ask, then
+// bounded quarterly entries (intervals instance-configurable). Cancelled
+// automatically if the deal changes stage again; each entry re-checks the
+// deal first.
+export const careTasks = inngest.createFunction(
+  {
+    id: "crm-care-tasks",
+    name: "CRM: Care touchpoints",
+    triggers: [{ event: "crm/opportunity.stage-changed" }],
+    cancelOn: [{ event: "crm/opportunity.stage-changed", match: "data.record_id" }],
+  },
+  async ({ event, step }) => {
+    const { record_id, to_stage } = event.data as { record_id: string; to_stage: string };
+
+    const stage = await step.run("load-stage", async () => {
+      return prismadb.crm_Opportunities_Sales_Stages.findUnique({
+        where: { id: to_stage },
+        select: { stage_kind: true },
+      });
+    });
+    if (stage?.stage_kind !== "care") return { skipped: true, reason: "not a care stage" };
+
+    const settings = await step.run("load-settings", async () => getFunnelSettings());
+    const entries = careSchedule(new Date(event.ts ?? Date.now()), settings);
+    let created = 0;
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      await step.sleepUntil(`wait-care-${i}`, entry.date);
+      const result = await step.run(`create-care-${i}`, async () => {
+        const opp = await prismadb.crm_Opportunities.findUnique({
+          where: { id: record_id },
+          select: {
+            status: true, account: true, assigned_to: true, name: true,
+            assigned_sales_stage: { select: { stage_kind: true } },
+          },
+        });
+        if (!opp || opp.status !== "ACTIVE") return null;
+        if (opp.assigned_sales_stage?.stage_kind !== "care") return null;
+        return createAutoTask({
+          title: entry.title,
+          content: `${entry.content}\nClient: ${opp.name ?? record_id}`,
+          accountId: opp.account,
+          opportunityId: record_id,
+          assigneeId: opp.assigned_to,
+          dueDateAt: entry.date,
+        });
+      });
+      if (result) created += 1;
+    }
+    return { created };
+  }
+);

--- a/inngest/functions/crm/kill-rule.ts
+++ b/inngest/functions/crm/kill-rule.ts
@@ -1,0 +1,82 @@
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+import { Resend } from "resend";
+import { isKillDue } from "@/lib/crm/funnel-timers";
+import { getFunnelSettings } from "@/lib/crm/funnel-settings";
+import { getLastClientActivity } from "@/lib/crm/client-activity";
+import { writeAuditLog } from "@/lib/audit-log";
+
+// Spec §3.5 kill rule: killAfterDays (default 45) of client silence on a
+// Qualified deal -> Lost (status CLOSED per the 2026-07-18 decision) + rep
+// notification. Daily sweep; the clock derives from getLastClientActivity,
+// so any inbound email or logged activity restarts it automatically.
+export const killRule = inngest.createFunction(
+  {
+    id: "crm-kill-rule",
+    name: "CRM: 45-day kill rule",
+    triggers: [{ cron: "0 6 * * *" }],
+  },
+  async ({ step }) => {
+    const settings = await step.run("load-settings", async () => getFunnelSettings());
+    const candidates = await step.run("find-qualified-deals", async () => {
+      return prismadb.crm_Opportunities.findMany({
+        where: {
+          status: "ACTIVE",
+          deletedAt: null,
+          assigned_sales_stage: { stage_kind: "qualified" },
+        },
+        select: {
+          id: true, name: true, contact: true, account: true,
+          stage_entered_at: true, assigned_to: true,
+        },
+        take: 500,
+      });
+    });
+
+    let closed = 0;
+    for (const opp of candidates) {
+      const didClose = await step.run(`check-${opp.id}`, async () => {
+        // step.run JSON-serializes returns — revive the date field.
+        const last = await getLastClientActivity({
+          ...opp,
+          stage_entered_at: opp.stage_entered_at ? new Date(opp.stage_entered_at) : null,
+        });
+        if (!isKillDue(last, new Date(), settings)) return false;
+
+        await prismadb.crm_Opportunities.update({
+          where: { id: opp.id },
+          data: { status: "CLOSED", updatedBy: opp.assigned_to ?? undefined },
+        });
+        await writeAuditLog({
+          entityType: "opportunity",
+          entityId: opp.id,
+          action: "updated",
+          changes: [
+            { field: "status", old: "ACTIVE", new: "CLOSED" },
+            { field: "close_reason", old: null, new: `${settings.killAfterDays}-day kill rule` },
+          ],
+          userId: opp.assigned_to ?? null,
+        });
+        if (opp.assigned_to) {
+          const rep = await prismadb.users.findUnique({ where: { id: opp.assigned_to } });
+          if (rep?.email) {
+            try {
+              const resend = new Resend(process.env.RESEND_API_KEY);
+              await resend.emails.send({
+                from: process.env.RESEND_FROM_EMAIL!,
+                to: rep.email,
+                subject: `Deal closed by ${settings.killAfterDays}-day rule: ${opp.name ?? opp.id}`,
+                text: `The deal "${opp.name ?? opp.id}" had no client activity for ${settings.killAfterDays} days and was closed as Lost.\nReopen it if this is wrong: ${process.env.NEXT_PUBLIC_APP_URL}/crm/opportunities/${opp.id}`,
+              });
+            } catch (error) {
+              console.error("[killRule] notification failed:", error);
+            }
+          }
+        }
+        return true;
+      });
+      if (didClose) closed += 1;
+    }
+    return { checked: candidates.length, closed };
+  }
+);

--- a/inngest/functions/crm/qualified-cadence.ts
+++ b/inngest/functions/crm/qualified-cadence.ts
@@ -1,0 +1,60 @@
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+import { cadenceSchedule } from "@/lib/crm/funnel-timers";
+import { getFunnelSettings } from "@/lib/crm/funnel-settings";
+import { createAutoTask } from "@/lib/crm/auto-task";
+
+// Spec §3.5: 5-touch follow-up cadence after the quote goes out (entry into
+// the stage whose stage_kind is "qualified"). A later stage change on the
+// same deal cancels the remaining touches via cancelOn; each touch also
+// re-checks the deal before creating its task (belt and suspenders).
+export const qualifiedCadence = inngest.createFunction(
+  {
+    id: "crm-qualified-cadence",
+    name: "CRM: Qualified follow-up cadence",
+    triggers: [{ event: "crm/opportunity.stage-changed" }],
+    cancelOn: [{ event: "crm/opportunity.stage-changed", match: "data.record_id" }],
+  },
+  async ({ event, step }) => {
+    const { record_id, to_stage } = event.data as { record_id: string; to_stage: string };
+
+    const stage = await step.run("load-stage", async () => {
+      return prismadb.crm_Opportunities_Sales_Stages.findUnique({
+        where: { id: to_stage },
+        select: { stage_kind: true },
+      });
+    });
+    if (stage?.stage_kind !== "qualified") return { skipped: true, reason: "not a qualified stage" };
+
+    // Instance settings at entry time — later changes affect future entries.
+    const settings = await step.run("load-settings", async () => getFunnelSettings());
+    const entry = new Date(event.ts ?? Date.now());
+    const touches = cadenceSchedule(entry, settings);
+    let created = 0;
+
+    for (const touch of touches) {
+      await step.sleepUntil(`wait-touch-${touch.touch}`, touch.date);
+      const result = await step.run(`create-touch-${touch.touch}`, async () => {
+        const opp = await prismadb.crm_Opportunities.findUnique({
+          where: { id: record_id },
+          select: {
+            status: true, sales_stage: true, account: true, assigned_to: true, name: true,
+            assigned_sales_stage: { select: { stage_kind: true } },
+          },
+        });
+        if (!opp || opp.status !== "ACTIVE") return null;
+        if (opp.assigned_sales_stage?.stage_kind !== "qualified") return null;
+        return createAutoTask({
+          title: touch.title,
+          content: `${touch.content}\nDeal: ${opp.name ?? record_id}`,
+          accountId: opp.account,
+          opportunityId: record_id,
+          assigneeId: opp.assigned_to,
+          dueDateAt: touch.date,
+        });
+      });
+      if (result) created += 1;
+    }
+    return { created };
+  }
+);

--- a/inngest/functions/crm/recycle-targets.ts
+++ b/inngest/functions/crm/recycle-targets.ts
@@ -1,0 +1,67 @@
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+import { Resend } from "resend";
+import { findRecycleCandidates, RECYCLED_LIST_NAME } from "@/lib/crm/recycle";
+import { getFunnelSettings } from "@/lib/crm/funnel-settings";
+
+// Documented deviation from spec §3.3 ("automatically re-tried with a
+// sequence"): campaign sends are unique per (step, target), so re-running
+// the same campaign is a no-op by design. Instead, recycled targets land
+// in the "Recycled" list and admins get a digest — a human assigns the
+// recycle batch to a fresh campaign.
+export const recycleTargets = inngest.createFunction(
+  {
+    id: "crm-recycle-targets",
+    name: "CRM: Recycle exhausted targets",
+    triggers: [{ cron: "30 6 * * *" }],
+  },
+  async ({ step }) => {
+    const candidateIds = await step.run("find-candidates", async () => {
+      return findRecycleCandidates(new Date(), await getFunnelSettings());
+    });
+    if (candidateIds.length === 0) return { recycled: 0 };
+
+    const listId = await step.run("ensure-recycled-list", async () => {
+      const existing = await prismadb.crm_TargetLists.findFirst({
+        where: { name: RECYCLED_LIST_NAME, deletedAt: null },
+      });
+      if (existing) return existing.id;
+      const created = await prismadb.crm_TargetLists.create({
+        data: {
+          name: RECYCLED_LIST_NAME,
+          description: "Auto-managed: targets whose sequence finished with no response after the recycle window.",
+        },
+      });
+      return created.id;
+    });
+
+    await step.run("add-to-list", async () => {
+      await prismadb.targetsToTargetLists.createMany({
+        data: candidateIds.map((target_id) => ({ target_id, target_list_id: listId })),
+        skipDuplicates: true,
+      });
+    });
+
+    await step.run("notify-admins", async () => {
+      const admins = await prismadb.users.findMany({
+        where: { role: "admin", userStatus: "ACTIVE" },
+        select: { email: true },
+      });
+      const to = admins.map((a) => a.email).filter(Boolean) as string[];
+      if (to.length === 0) return;
+      try {
+        const resend = new Resend(process.env.RESEND_API_KEY);
+        await resend.emails.send({
+          from: process.env.RESEND_FROM_EMAIL!,
+          to,
+          subject: `${candidateIds.length} targets recycled — assign a new sequence`,
+          text: `${candidateIds.length} targets finished their sequence with no response and were added to the "${RECYCLED_LIST_NAME}" target list.\nAssign the list to a fresh campaign: ${process.env.NEXT_PUBLIC_APP_URL}/campaigns/target-lists`,
+        });
+      } catch (error) {
+        console.error("[recycleTargets] digest failed:", error);
+      }
+    });
+
+    return { recycled: candidateIds.length };
+  }
+);

--- a/inngest/functions/crm/renewal-reminders.ts
+++ b/inngest/functions/crm/renewal-reminders.ts
@@ -1,0 +1,74 @@
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+import { renewalWindowEnd } from "@/lib/crm/funnel-timers";
+import { getFunnelSettings } from "@/lib/crm/funnel-settings";
+import { createAutoTask } from "@/lib/crm/auto-task";
+
+// Spec §3.8: "renewals surface automatically". Weekly sweep over contract
+// renewal reminders and account-product renewal dates in the configured
+// window; createAutoTask's title-based idempotency makes re-runs safe.
+export const renewalReminders = inngest.createFunction(
+  {
+    id: "crm-renewal-reminders",
+    name: "CRM: Renewal reminders",
+    triggers: [{ cron: "0 7 * * 1" }],
+  },
+  async ({ step }) => {
+    const now = new Date();
+    const settings = await step.run("load-settings", async () => getFunnelSettings());
+    const windowEnd = renewalWindowEnd(now, settings);
+    let created = 0;
+
+    const contracts = await step.run("find-contract-renewals", async () => {
+      return prismadb.crm_Contracts.findMany({
+        where: {
+          deletedAt: null,
+          renewalReminderDate: { gte: now, lte: windowEnd },
+        },
+        select: { id: true, title: true, account: true, assigned_to: true, renewalReminderDate: true },
+      });
+    });
+    for (const c of contracts) {
+      const result = await step.run(`contract-${c.id}`, async () => {
+        const reminderDate = c.renewalReminderDate ? new Date(c.renewalReminderDate) : now;
+        return createAutoTask({
+          title: `Renewal: contract "${c.title}"`,
+          content: `Contract renewal reminder date is ${reminderDate.toDateString()}. Reach out about renewal terms.\n${process.env.NEXT_PUBLIC_APP_URL}/crm/contracts/${c.id}`,
+          accountId: c.account,
+          assigneeId: c.assigned_to,
+          dueDateAt: reminderDate,
+        });
+      });
+      if (result) created += 1;
+    }
+
+    const products = await step.run("find-product-renewals", async () => {
+      return prismadb.crm_AccountProducts.findMany({
+        where: {
+          status: "ACTIVE",
+          renewal_date: { gte: now, lte: windowEnd },
+        },
+        select: {
+          id: true, renewal_date: true, accountId: true,
+          account: { select: { assigned_to: true, name: true } },
+          product: { select: { name: true } },
+        },
+      });
+    });
+    for (const p of products) {
+      const result = await step.run(`product-${p.id}`, async () => {
+        const renewalDate = p.renewal_date ? new Date(p.renewal_date) : now;
+        return createAutoTask({
+          title: `Renewal: ${p.product?.name ?? "product"} @ ${p.account?.name ?? p.accountId}`,
+          content: `Product subscription renews on ${renewalDate.toDateString()}. Confirm renewal with the client.`,
+          accountId: p.accountId,
+          assigneeId: p.account?.assigned_to ?? null,
+          dueDateAt: renewalDate,
+        });
+      });
+      if (result) created += 1;
+    }
+
+    return { created };
+  }
+);

--- a/inngest/functions/crm/renewal-reminders.ts
+++ b/inngest/functions/crm/renewal-reminders.ts
@@ -31,12 +31,15 @@ export const renewalReminders = inngest.createFunction(
     for (const c of contracts) {
       const result = await step.run(`contract-${c.id}`, async () => {
         const reminderDate = c.renewalReminderDate ? new Date(c.renewalReminderDate) : now;
+        // Date in the title = per-cycle uniqueness; dedupAnyStatus so a
+        // completed reminder is not respawned by next week's sweep.
         return createAutoTask({
-          title: `Renewal: contract "${c.title}"`,
+          title: `Renewal ${reminderDate.toISOString().slice(0, 10)}: contract "${c.title}"`,
           content: `Contract renewal reminder date is ${reminderDate.toDateString()}. Reach out about renewal terms.\n${process.env.NEXT_PUBLIC_APP_URL}/crm/contracts/${c.id}`,
           accountId: c.account,
           assigneeId: c.assigned_to,
           dueDateAt: reminderDate,
+          dedupAnyStatus: true,
         });
       });
       if (result) created += 1;
@@ -59,11 +62,12 @@ export const renewalReminders = inngest.createFunction(
       const result = await step.run(`product-${p.id}`, async () => {
         const renewalDate = p.renewal_date ? new Date(p.renewal_date) : now;
         return createAutoTask({
-          title: `Renewal: ${p.product?.name ?? "product"} @ ${p.account?.name ?? p.accountId}`,
+          title: `Renewal ${renewalDate.toISOString().slice(0, 10)}: ${p.product?.name ?? "product"} @ ${p.account?.name ?? p.accountId}`,
           content: `Product subscription renews on ${renewalDate.toDateString()}. Confirm renewal with the client.`,
           accountId: p.accountId,
           assigneeId: p.account?.assigned_to ?? null,
           dueDateAt: renewalDate,
+          dedupAnyStatus: true,
         });
       });
       if (result) created += 1;

--- a/lib/crm/auto-task.ts
+++ b/lib/crm/auto-task.ts
@@ -10,16 +10,23 @@ export async function createAutoTask(opts: {
   opportunityId?: string | null;
   assigneeId: string | null;
   dueDateAt: Date;
+  /**
+   * Default dedup only checks OPEN tasks, so a later re-entry into a stage
+   * can create a fresh cadence. Recurring sweeps (renewals) instead dedup
+   * against tasks of ANY status — completing the task must not respawn it
+   * on the next sweep (their titles carry the cycle date for uniqueness).
+   */
+  dedupAnyStatus?: boolean;
 }): Promise<{ id: string } | null> {
-  const { title, content, accountId, opportunityId, assigneeId, dueDateAt } = opts;
+  const { title, content, accountId, opportunityId, assigneeId, dueDateAt, dedupAnyStatus } = opts;
   if (!assigneeId) return null;
 
-  // Idempotency: one open task per (title, deal) — reruns and overlapping
-  // schedules must not duplicate work items.
+  // Idempotency: one task per (title, deal/account) — reruns and
+  // overlapping schedules must not duplicate work items.
   const existing = await prismadb.crm_Accounts_Tasks.findFirst({
     where: {
       title,
-      taskStatus: { in: ["ACTIVE", "PENDING"] },
+      ...(dedupAnyStatus ? {} : { taskStatus: { in: ["ACTIVE", "PENDING"] } }),
       ...(opportunityId ? { opportunity_id: opportunityId } : { account: accountId }),
     },
     select: { id: true },

--- a/lib/crm/auto-task.ts
+++ b/lib/crm/auto-task.ts
@@ -1,0 +1,61 @@
+import { prismadb } from "@/lib/prisma";
+import { Resend } from "resend";
+
+// Task creation for the funnel timer engine. No session context — the
+// assignee is the deal's rep; notification is best-effort.
+export async function createAutoTask(opts: {
+  title: string;
+  content: string;
+  accountId: string | null;
+  opportunityId?: string | null;
+  assigneeId: string | null;
+  dueDateAt: Date;
+}): Promise<{ id: string } | null> {
+  const { title, content, accountId, opportunityId, assigneeId, dueDateAt } = opts;
+  if (!assigneeId) return null;
+
+  // Idempotency: one open task per (title, deal) — reruns and overlapping
+  // schedules must not duplicate work items.
+  const existing = await prismadb.crm_Accounts_Tasks.findFirst({
+    where: {
+      title,
+      taskStatus: { in: ["ACTIVE", "PENDING"] },
+      ...(opportunityId ? { opportunity_id: opportunityId } : { account: accountId }),
+    },
+    select: { id: true },
+  });
+  if (existing) return null;
+
+  const task = await prismadb.crm_Accounts_Tasks.create({
+    data: {
+      v: 0,
+      title,
+      content,
+      priority: "high",
+      taskStatus: "ACTIVE",
+      account: accountId ?? undefined,
+      opportunity_id: opportunityId ?? undefined,
+      user: assigneeId,
+      createdBy: assigneeId,
+      updatedBy: assigneeId,
+      dueDateAt,
+    },
+  });
+
+  try {
+    const assignee = await prismadb.users.findUnique({ where: { id: assigneeId } });
+    if (assignee?.email) {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      await resend.emails.send({
+        from: process.env.RESEND_FROM_EMAIL!,
+        to: assignee.email,
+        subject: `New task - ${title}`,
+        text: `${content}\n\nDue: ${dueDateAt.toDateString()}\n${process.env.NEXT_PUBLIC_APP_URL}/crm/tasks/viewtask/${task.id}`,
+      });
+    }
+  } catch (error) {
+    console.error("[createAutoTask] notification failed:", error);
+  }
+
+  return { id: task.id };
+}

--- a/lib/crm/business-days.ts
+++ b/lib/crm/business-days.ts
@@ -1,0 +1,14 @@
+// Business-day arithmetic, weekends-only (no holiday calendar — decided
+// 2026-07-18; a task landing near a holiday just waits a day).
+export function addBusinessDays(start: Date, n: number): Date {
+  const d = new Date(start.getTime());
+  let remaining = n;
+  while (remaining > 0) {
+    d.setUTCDate(d.getUTCDate() + 1);
+    const dow = d.getUTCDay();
+    if (dow !== 0 && dow !== 6) remaining -= 1;
+  }
+  // A 0-add starting on a weekend still lands on the weekend; only shifts
+  // when days are actually added — matches "3 business days after X".
+  return d;
+}

--- a/lib/crm/client-activity.ts
+++ b/lib/crm/client-activity.ts
@@ -1,0 +1,40 @@
+import { prismadb } from "@/lib/prisma";
+import { resolveLastClientActivity } from "./funnel-timers";
+
+// "Client activity" per the 2026-07-18 decision: an inbound synced email
+// linked to the deal's contact or account, OR a logged crm_Activities
+// entry linked to the opportunity. Stage entry is the clock's floor.
+export async function getLastClientActivity(opp: {
+  id: string;
+  contact: string | null;
+  account: string | null;
+  stage_entered_at: Date | null;
+}): Promise<Date | null> {
+  const orScopes = [
+    ...(opp.contact ? [{ contacts: { some: { contactId: opp.contact } } }] : []),
+    ...(opp.account ? [{ accounts: { some: { accountId: opp.account } } }] : []),
+  ];
+
+  const lastInbound = orScopes.length
+    ? await prismadb.email.findFirst({
+        where: { folder: "INBOX", isDeleted: false, sentAt: { not: null }, OR: orScopes },
+        orderBy: { sentAt: "desc" },
+        select: { sentAt: true },
+      })
+    : null;
+
+  const lastActivity = await prismadb.crm_Activities.findFirst({
+    where: {
+      deletedAt: null,
+      links: { some: { entityType: "opportunity", entityId: opp.id } },
+    },
+    orderBy: { date: "desc" },
+    select: { date: true },
+  });
+
+  return resolveLastClientActivity({
+    stageEnteredAt: opp.stage_entered_at,
+    lastInboundEmailAt: lastInbound?.sentAt ?? null,
+    lastLoggedActivityAt: lastActivity?.date ?? null,
+  });
+}

--- a/lib/crm/funnel-settings.ts
+++ b/lib/crm/funnel-settings.ts
@@ -1,0 +1,26 @@
+import { prismadb } from "@/lib/prisma";
+import {
+  DEFAULT_FUNNEL_SETTINGS,
+  type FunnelTimingSettings,
+} from "./funnel-timers";
+
+// Singleton-by-convention read of the instance funnel settings. No row
+// yet (fresh install) -> spec defaults.
+export async function getFunnelSettings(): Promise<FunnelTimingSettings> {
+  const row = await prismadb.crm_FunnelSettings.findFirst();
+  if (!row) return DEFAULT_FUNNEL_SETTINGS;
+  return {
+    killAfterDays: row.kill_after_days,
+    recycleAfterDays: row.recycle_after_days,
+    cadenceTouch1BusinessDays: row.cadence_touch1_business_days,
+    cadenceTouch2OffsetDays: row.cadence_touch2_offset_days,
+    cadenceTouch3OffsetDays: row.cadence_touch3_offset_days,
+    cadenceTouch4OffsetDays: row.cadence_touch4_offset_days,
+    cadenceTouch5OffsetDays: row.cadence_touch5_offset_days,
+    careCheckinDays: row.care_checkin_days,
+    careReferralDays: row.care_referral_days,
+    careQuarterIntervalDays: row.care_quarter_interval_days,
+    careQuarterCount: row.care_quarter_count,
+    renewalWindowDays: row.renewal_window_days,
+  };
+}

--- a/lib/crm/funnel-timers.ts
+++ b/lib/crm/funnel-timers.ts
@@ -1,0 +1,142 @@
+import { addBusinessDays } from "./business-days";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+// Instance-grade timing knobs; the spec's numbers are the defaults, the
+// live values come from crm_FunnelSettings (Admin -> Funnel settings) via
+// lib/crm/funnel-settings.ts. This module stays prisma-free and pure.
+export type FunnelTimingSettings = {
+  killAfterDays: number;
+  recycleAfterDays: number;
+  cadenceTouch1BusinessDays: number;
+  cadenceTouch2OffsetDays: number;
+  cadenceTouch3OffsetDays: number;
+  cadenceTouch4OffsetDays: number;
+  cadenceTouch5OffsetDays: number;
+  careCheckinDays: number;
+  careReferralDays: number;
+  careQuarterIntervalDays: number;
+  careQuarterCount: number;
+  renewalWindowDays: number;
+};
+
+export const DEFAULT_FUNNEL_SETTINGS: FunnelTimingSettings = {
+  killAfterDays: 45,
+  recycleAfterDays: 90,
+  cadenceTouch1BusinessDays: 3,
+  cadenceTouch2OffsetDays: 7,
+  cadenceTouch3OffsetDays: 10,
+  cadenceTouch4OffsetDays: 15,
+  cadenceTouch5OffsetDays: 45,
+  careCheckinDays: 30,
+  careReferralDays: 90,
+  careQuarterIntervalDays: 90,
+  careQuarterCount: 8,
+  renewalWindowDays: 30,
+};
+
+export type CadenceTouch = {
+  touch: number;
+  date: Date;
+  kind: "call" | "email";
+  title: string;
+  content: string;
+};
+
+// Spec §3.5 follow-up cadence, anchored on Qualified-stage entry (quote sent).
+export function cadenceSchedule(
+  qualifiedEntry: Date,
+  s: FunnelTimingSettings = DEFAULT_FUNNEL_SETTINGS,
+): CadenceTouch[] {
+  const t1 = addBusinessDays(qualifiedEntry, s.cadenceTouch1BusinessDays);
+  const t2 = new Date(t1.getTime() + s.cadenceTouch2OffsetDays * DAY);
+  const t3 = new Date(t2.getTime() + s.cadenceTouch3OffsetDays * DAY);
+  const t4 = new Date(t3.getTime() + s.cadenceTouch4OffsetDays * DAY);
+  const t5 = new Date(t3.getTime() + s.cadenceTouch5OffsetDays * DAY);
+  return [
+    {
+      touch: 1, date: t1, kind: "call",
+      title: "Cadence 1/5: Call — confirm quote receipt",
+      content: "Call the client: confirm they received the quote/SOW and ask for questions.",
+    },
+    {
+      touch: 2, date: t2, kind: "email",
+      title: "Cadence 2/5: Email check-in",
+      content: "Send a short check-in email about the outstanding quote.",
+    },
+    {
+      touch: 3, date: t3, kind: "email",
+      title: "Cadence 3/5: Email or call",
+      content: "Reach out (email or call) — surface objections, offer a walkthrough.",
+    },
+    {
+      touch: 4, date: t4, kind: "call",
+      title: "Cadence 4/5: Call (day 15 of retention window)",
+      content: "Call the client — the quote has been out ~5 weeks; probe timeline and blockers.",
+    },
+    {
+      touch: 5, date: t5, kind: "email",
+      title: "Cadence 5/5: Final reminder — offer 15-day quote extension",
+      content: "Send the final reminder email; offer to extend the quote validity by 15 days if they need more time.",
+    },
+  ];
+}
+
+export function resolveLastClientActivity(d: {
+  stageEnteredAt: Date | null;
+  lastInboundEmailAt: Date | null;
+  lastLoggedActivityAt: Date | null;
+}): Date | null {
+  const dates = [d.stageEnteredAt, d.lastInboundEmailAt, d.lastLoggedActivityAt]
+    .filter((x): x is Date => x != null);
+  if (dates.length === 0) return null;
+  return new Date(Math.max(...dates.map((x) => x.getTime())));
+}
+
+export function isKillDue(
+  lastActivity: Date | null,
+  now: Date,
+  s: FunnelTimingSettings = DEFAULT_FUNNEL_SETTINGS,
+): boolean {
+  if (!lastActivity) return false;
+  return now.getTime() - lastActivity.getTime() >= s.killAfterDays * DAY;
+}
+
+export type CareEntry = { date: Date; title: string; content: string };
+
+// Spec §3.8: check-in, referral ask, then bounded quarterly touchpoints —
+// all intervals instance-configurable.
+export function careSchedule(
+  careEntry: Date,
+  s: FunnelTimingSettings = DEFAULT_FUNNEL_SETTINGS,
+): CareEntry[] {
+  const entries: CareEntry[] = [
+    {
+      date: new Date(careEntry.getTime() + s.careCheckinDays * DAY),
+      title: `Care: ${s.careCheckinDays}-day check-in`,
+      content: "Check in with the client — satisfaction, issues, quick wins since deployment.",
+    },
+    {
+      date: new Date(careEntry.getTime() + s.careReferralDays * DAY),
+      title: "Care: referral ask",
+      content: "Results should be measurable by now — ask for a referral and probe upsell openings.",
+    },
+  ];
+  for (let q = 1; q <= s.careQuarterCount; q++) {
+    entries.push({
+      date: new Date(
+        careEntry.getTime() + (s.careReferralDays + q * s.careQuarterIntervalDays) * DAY,
+      ),
+      title: `Care: quarterly check-in (Q${q})`,
+      content: "Quarterly relationship check-in — satisfaction, renewals, expansion opportunities.",
+    });
+  }
+  return entries;
+}
+
+export function renewalWindowEnd(
+  now: Date,
+  s: FunnelTimingSettings = DEFAULT_FUNNEL_SETTINGS,
+): Date {
+  return new Date(now.getTime() + s.renewalWindowDays * DAY);
+}

--- a/lib/crm/recycle.ts
+++ b/lib/crm/recycle.ts
@@ -45,9 +45,23 @@ export async function findRecycleCandidates(
   );
   if (finishedTargetIds.length === 0) return [];
 
+  // A target that finished an OLD sequence but has newer campaign activity
+  // (a send after the cutoff, or one still queued) is being actively worked
+  // in another sequence — do not recycle them out from under it.
+  const recentlyActive = await prismadb.crm_campaign_sends.findMany({
+    where: {
+      target_id: { in: finishedTargetIds },
+      OR: [{ sent_at: { gt: cutoff } }, { status: "queued" }],
+    },
+    select: { target_id: true },
+  });
+  const activeIds = new Set(recentlyActive.map((send) => send.target_id));
+  const quietTargetIds = finishedTargetIds.filter((id) => !activeIds.has(id));
+  if (quietTargetIds.length === 0) return [];
+
   const eligible = await prismadb.crm_Targets.findMany({
     where: {
-      id: { in: finishedTargetIds },
+      id: { in: quietTargetIds },
       do_not_email: false,
       converted_at: null,
       deletedAt: null,

--- a/lib/crm/recycle.ts
+++ b/lib/crm/recycle.ts
@@ -1,0 +1,59 @@
+import { prismadb } from "@/lib/prisma";
+import {
+  DEFAULT_FUNNEL_SETTINGS,
+  type FunnelTimingSettings,
+} from "./funnel-timers";
+
+export const RECYCLED_LIST_NAME = "Recycled";
+const DAY = 24 * 60 * 60 * 1000;
+
+// Spec §3.3: a target whose sequence finished with no response is paused
+// (recycleAfterDays, default 90), then recycled. "Sequence finished" = the
+// campaign's max-order step was sent to the target; "no response" = never
+// converted (an inbound reply leads to conversion in the runbook flow).
+export async function findRecycleCandidates(
+  now: Date,
+  s: FunnelTimingSettings = DEFAULT_FUNNEL_SETTINGS,
+): Promise<string[]> {
+  const cutoff = new Date(now.getTime() - s.recycleAfterDays * DAY);
+
+  const maxOrders = await prismadb.crm_campaign_steps.groupBy({
+    by: ["campaign_id"],
+    _max: { order: true },
+  });
+  const maxOrderByCampaign = new Map(
+    maxOrders.map((m) => [m.campaign_id, m._max.order ?? 0]),
+  );
+  if (maxOrderByCampaign.size === 0) return [];
+
+  const finalSends = await prismadb.crm_campaign_sends.findMany({
+    where: { status: "sent", sent_at: { lte: cutoff } },
+    select: { target_id: true, campaign_id: true, sent_at: true, step: { select: { order: true } } },
+  });
+
+  const finishedTargetIds = Array.from(
+    new Set(
+      finalSends
+        .filter(
+          (send) =>
+            send.step.order === maxOrderByCampaign.get(send.campaign_id) &&
+            send.sent_at != null &&
+            new Date(send.sent_at).getTime() <= cutoff.getTime(),
+        )
+        .map((send) => send.target_id),
+    ),
+  );
+  if (finishedTargetIds.length === 0) return [];
+
+  const eligible = await prismadb.crm_Targets.findMany({
+    where: {
+      id: { in: finishedTargetIds },
+      do_not_email: false,
+      converted_at: null,
+      deletedAt: null,
+      target_lists: { none: { target_list: { name: RECYCLED_LIST_NAME } } },
+    },
+    select: { id: true },
+  });
+  return eligible.map((t) => t.id);
+}

--- a/lib/crm/stage-kinds.ts
+++ b/lib/crm/stage-kinds.ts
@@ -1,0 +1,12 @@
+// Automation trigger kinds connectable to sales stages in admin CRM
+// settings. Lives outside the "use server" actions file (whose exports
+// must all be async functions) so both server and client code can import.
+export const STAGE_KINDS = [
+  "pre_sale",
+  "qualified",
+  "purchase_order",
+  "delivery",
+  "care",
+] as const;
+
+export type StageKind = (typeof STAGE_KINDS)[number];

--- a/lib/crm/stage-transition.ts
+++ b/lib/crm/stage-transition.ts
@@ -1,0 +1,24 @@
+import { prismadb } from "@/lib/prisma";
+import { inngest } from "@/inngest/client";
+
+// Single funnel-transition chokepoint: every action that writes
+// crm_Opportunities.sales_stage calls this after its update so the
+// timer engine (cadence/care) reacts to exactly one event shape.
+export async function handleStageTransition(opts: {
+  opportunityId: string;
+  fromStage: string | null;
+  toStage: string | null;
+}): Promise<boolean> {
+  const { opportunityId, fromStage, toStage } = opts;
+  if (!toStage || toStage === fromStage) return false;
+
+  await prismadb.crm_Opportunities.update({
+    where: { id: opportunityId },
+    data: { stage_entered_at: new Date() },
+  });
+  await inngest.send({
+    name: "crm/opportunity.stage-changed",
+    data: { record_id: opportunityId, to_stage: toStage },
+  });
+  return true;
+}

--- a/prisma/migrations/20260718082225_aqunama_p2_stage_kind_task_opportunity/migration.sql
+++ b/prisma/migrations/20260718082225_aqunama_p2_stage_kind_task_opportunity/migration.sql
@@ -1,0 +1,36 @@
+-- AlterTable
+ALTER TABLE "crm_Opportunities" ADD COLUMN     "stage_entered_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "crm_Opportunities_Sales_Stages" ADD COLUMN     "stage_kind" TEXT;
+
+-- AlterTable
+ALTER TABLE "crm_Accounts_Tasks" ADD COLUMN     "opportunity_id" UUID;
+
+-- CreateTable
+CREATE TABLE "crm_FunnelSettings" (
+    "id" UUID NOT NULL,
+    "kill_after_days" INTEGER NOT NULL DEFAULT 45,
+    "recycle_after_days" INTEGER NOT NULL DEFAULT 90,
+    "cadence_touch1_business_days" INTEGER NOT NULL DEFAULT 3,
+    "cadence_touch2_offset_days" INTEGER NOT NULL DEFAULT 7,
+    "cadence_touch3_offset_days" INTEGER NOT NULL DEFAULT 10,
+    "cadence_touch4_offset_days" INTEGER NOT NULL DEFAULT 15,
+    "cadence_touch5_offset_days" INTEGER NOT NULL DEFAULT 45,
+    "care_checkin_days" INTEGER NOT NULL DEFAULT 30,
+    "care_referral_days" INTEGER NOT NULL DEFAULT 90,
+    "care_quarter_interval_days" INTEGER NOT NULL DEFAULT 90,
+    "care_quarter_count" INTEGER NOT NULL DEFAULT 8,
+    "renewal_window_days" INTEGER NOT NULL DEFAULT 30,
+    "updatedAt" TIMESTAMP(3),
+    "updatedBy" UUID,
+
+    CONSTRAINT "crm_FunnelSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "crm_Accounts_Tasks_opportunity_id_idx" ON "crm_Accounts_Tasks"("opportunity_id");
+
+-- AddForeignKey
+ALTER TABLE "crm_Accounts_Tasks" ADD CONSTRAINT "crm_Accounts_Tasks_opportunity_id_fkey" FOREIGN KEY ("opportunity_id") REFERENCES "crm_Opportunities"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,8 @@ model crm_Opportunities {
   campaign         String?                 @db.Uuid
   close_date       DateTime?
   delivery_deadline DateTime?
+  /// Set whenever sales_stage changes; anchors cadence/care timers.
+  stage_entered_at  DateTime?
   contact          String?                 @db.Uuid
   createdBy        String?                 @db.Uuid
   created_on       DateTime?               @default(now())
@@ -231,6 +233,7 @@ model crm_Opportunities {
   contacts             ContactsToOpportunities[]
   embedding            crm_Embeddings_Opportunities?
   lineItems            crm_OpportunityLineItems[]
+  tasks                crm_Accounts_Tasks[]
   deletedAt            DateTime?
   deletedBy            String?   @db.Uuid
 
@@ -397,7 +400,30 @@ model crm_Opportunities_Sales_Stages {
   name                               String
   probability                        Int?
   order                              Int?
+  /// Automation trigger kind — connectable per stage in admin CRM settings.
+  /// One of: pre_sale | qualified | purchase_order | delivery | care. Null = no automation.
+  stage_kind                         String?
   assigned_opportunities_sales_stage crm_Opportunities[] @relation("assinged_sales_stage")
+}
+
+/// Instance-grade funnel timing settings (singleton row). Defaults are the
+/// AQUNAMA spec values; edited at Admin -> Funnel settings.
+model crm_FunnelSettings {
+  id                           String    @id @default(uuid()) @db.Uuid
+  kill_after_days              Int       @default(45)
+  recycle_after_days           Int       @default(90)
+  cadence_touch1_business_days Int       @default(3)
+  cadence_touch2_offset_days   Int       @default(7)
+  cadence_touch3_offset_days   Int       @default(10)
+  cadence_touch4_offset_days   Int       @default(15)
+  cadence_touch5_offset_days   Int       @default(45)
+  care_checkin_days            Int       @default(30)
+  care_referral_days           Int       @default(90)
+  care_quarter_interval_days   Int       @default(90)
+  care_quarter_count           Int       @default(8)
+  renewal_window_days          Int       @default(30)
+  updatedAt                    DateTime? @updatedAt
+  updatedBy                    String?   @db.Uuid
 }
 
 model crm_Opportunities_Type {
@@ -860,9 +886,11 @@ model crm_Accounts_Tasks {
   assigned_user Users?          @relation(fields: [user], references: [id])
 
   //CRM assigments
-  account      String?                       @db.Uuid
-  crm_accounts crm_Accounts?                 @relation(fields: [account], references: [id])
-  documents    DocumentsToCrmAccountsTasks[]
+  account        String?                       @db.Uuid
+  opportunity_id String?                       @db.Uuid
+  crm_accounts   crm_Accounts?                 @relation(fields: [account], references: [id])
+  opportunity    crm_Opportunities?            @relation(fields: [opportunity_id], references: [id])
+  documents      DocumentsToCrmAccountsTasks[]
 
   @@index([user])
   @@index([account])
@@ -873,6 +901,7 @@ model crm_Accounts_Tasks {
   @@index([dueDateAt])
   @@index([createdAt])
   @@index([account, taskStatus])
+  @@index([opportunity_id])
 }
 
 model tasksComments {

--- a/prisma/seeds/seed.ts
+++ b/prisma/seeds/seed.ts
@@ -86,6 +86,32 @@ async function main() {
   }
   console.log("Opportunity Sales Stages seeded");
 
+  // Connect automation kinds to the runbook stages (idempotent; matches by
+  // name, skips stages an admin renamed — kinds are then set in admin UI).
+  // The base seed's `crm_Opportunities_Sales_Stages.json` uses this repo's
+  // legacy stage names rather than the AQUNAMA runbook names, so the mapping
+  // below only covers names whose automation intent is unambiguous; the
+  // rest stay unmapped and are set via Admin -> Funnel settings.
+  const stageKindByName: Record<string, string> = {
+    "Pre-Sale": "pre_sale",
+    "Qualified Lead": "qualified",
+    "Purchase Order": "purchase_order",
+    "Delivery": "delivery",
+    "Care": "care",
+    // Legacy demo-data stage names (see crm_Opportunities_Sales_Stages.json)
+    "New": "pre_sale",
+    "Need analysis": "qualified",
+    "Signing": "purchase_order",
+    "Realization of the project": "delivery",
+  };
+  for (const [name, kind] of Object.entries(stageKindByName)) {
+    await prisma.crm_Opportunities_Sales_Stages.updateMany({
+      where: { name, stage_kind: null },
+      data: { stage_kind: kind },
+    });
+  }
+  console.log("Sales stage kinds connected");
+
   // CRM Industry Types (no unique on name — use findFirst + create/update)
   for (const item of crmIndustryTypeData) {
     const existing = await prisma.crm_Industry_Type.findFirst({


### PR DESCRIPTION
## Summary

The automated heart of the AQUNAMA sales process (plan: `docs/superpowers/plans/2026-07-18-aqunama-p2-timer-task-engine.md`), built on Inngest and driven by admin-configurable stage kinds:

- **Stage automation triggers**: `stage_kind` on sales stages, connectable per stage at Admin → CRM Settings (renaming a stage never breaks automation). Every stage-writing action (update, create, target conversion, kanban drag) emits `crm/opportunity.stage-changed` through one shared helper that also stamps `stage_entered_at`.
- **Qualified follow-up cadence**: 5 touches (+3 business days call, +7d email, +10d email/call, day 15 & 45) created as rep tasks via Inngest `sleepUntil`, auto-cancelled (`cancelOn`) when the deal changes stage, each touch re-verifying the deal first.
- **45-day kill rule** (daily cron): Qualified deals with no client activity — inbound synced email via the deal's contact/account, or a logged activity — for 45 days are closed as Lost, audited, and the rep is emailed.
- **Care touchpoints**: +30d check-in, ~90d referral ask, then quarterly ×8 — same cancel/recheck discipline.
- **Target recycle** (daily cron): targets whose sequence finished 90+ days ago with no conversion land in a "Recycled" target list with an admin digest. Targets actively mid-sequence in a *newer* campaign are protected from recycling.
- **Renewal sweep** (weekly): contract reminder dates and product renewal dates within 30 days become rep tasks; completed reminders don't respawn (date-carrying titles + any-status dedup).
- **Instance-grade timing settings**: every day-count above is a default in the `crm_FunnelSettings` singleton, editable at the new **Admin → Funnel Settings** page (zod-validated, admin-gated). Cadence/care schedules snapshot settings at stage entry.
- Tasks created by the engine link to both the account and the opportunity (`opportunity_id` added to CRM tasks).

## Test plan

- 41 new unit tests (schedule math incl. weekend/boundary cases, kill predicate, activity resolution, recycle eligibility, task idempotency, settings loader/actions, stage transitions); suite green at 957/957, typecheck clean.
- Migration verified replayable on a fresh pgvector database (locally and by CI's integration job); seed idempotent.
- CI run 29643399099: all four jobs green including the 95-spec e2e suite.
- Pre-push review caught and fixed two defects (re-engaged-target recycle leak; renewal task respawn after completion).

## Deviations (documented in the plan/ledger)

- Recycle notifies admins + lists targets instead of auto-resending (campaign sends are unique per step+target by design; a human picks the fresh campaign).
- Care quarterly touchpoints bounded at 8 quarters per Care entry.
- `STAGE_KINDS` lives in `lib/crm/stage-kinds.ts` ("use server" files may only export async functions).

## After merge (runbook §7)

Connect the five stage triggers at Admin → CRM Settings and review timing defaults at Admin → Funnel Settings. Note: do not run `prisma migrate dev` against the dev DB until its pre-existing schema drift is reconciled (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)