### PR TITLE
feat: AQUNAMA Phase 3 — SOW/quote approval workflow + case-study flags

### DIFF
--- a/__tests__/crm/approval-gate.test.ts
+++ b/__tests__/crm/approval-gate.test.ts
@@ -1,0 +1,55 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Opportunities_Sales_Stages: { findUnique: jest.fn() } },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { qualifiedEntryBlockReason } from "@/lib/crm/approval-gate";
+
+const stage = prismadb.crm_Opportunities_Sales_Stages.findUnique as jest.Mock;
+
+describe("qualifiedEntryBlockReason", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("blocks entering a qualified stage without approval", async () => {
+    stage.mockResolvedValue({ stage_kind: "qualified" });
+    const reason = await qualifiedEntryBlockReason({
+      fromStage: "s-presale", toStage: "s-qualified", approvalStatus: "NONE",
+    });
+    expect(reason).toContain("approval");
+  });
+
+  it("allows entering a qualified stage when APPROVED", async () => {
+    stage.mockResolvedValue({ stage_kind: "qualified" });
+    expect(
+      await qualifiedEntryBlockReason({
+        fromStage: "s-presale", toStage: "s-qualified", approvalStatus: "APPROVED",
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores non-qualified target stages", async () => {
+    stage.mockResolvedValue({ stage_kind: "care" });
+    expect(
+      await qualifiedEntryBlockReason({
+        fromStage: "a", toStage: "b", approvalStatus: "NONE",
+      }),
+    ).toBeNull();
+  });
+
+  it("no-ops when the stage is unchanged (already inside)", async () => {
+    expect(
+      await qualifiedEntryBlockReason({
+        fromStage: "s-qualified", toStage: "s-qualified", approvalStatus: "NONE",
+      }),
+    ).toBeNull();
+    expect(stage).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when toStage is null", async () => {
+    expect(
+      await qualifiedEntryBlockReason({
+        fromStage: "a", toStage: null, approvalStatus: "NONE",
+      }),
+    ).toBeNull();
+  });
+});

--- a/actions/crm/accounts/__tests__/case-study.test.ts
+++ b/actions/crm/accounts/__tests__/case-study.test.ts
@@ -1,0 +1,72 @@
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  requireRole: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Accounts: { findFirst: jest.fn(), update: jest.fn() } },
+}));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, requireRole } from "@/lib/authz";
+import {
+  setCaseStudyCandidate,
+  setCaseStudyApproved,
+} from "@/actions/crm/accounts/case-study";
+
+describe("case-study flags", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireAuthenticated as jest.Mock).mockResolvedValue({ id: "rep1", role: "user" });
+    (requireRole as jest.Mock).mockResolvedValue({ id: "cso1", role: "manager" });
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({
+      id: "a1", name: "Acme", case_study_candidate: true, case_study_approved: false,
+    });
+    (prismadb.crm_Accounts.update as jest.Mock).mockResolvedValue({});
+  });
+
+  it("rep can flag a candidate", async () => {
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({
+      id: "a1", case_study_candidate: false, case_study_approved: false,
+    });
+    const res = await setCaseStudyCandidate("a1", true);
+    expect(res).toEqual({});
+    const data = (prismadb.crm_Accounts.update as jest.Mock).mock.calls[0][0].data;
+    expect(data.case_study_candidate).toBe(true);
+  });
+
+  it("unflagging a candidate also clears approval", async () => {
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({
+      id: "a1", case_study_candidate: true, case_study_approved: true,
+    });
+    await setCaseStudyCandidate("a1", false);
+    const data = (prismadb.crm_Accounts.update as jest.Mock).mock.calls[0][0].data;
+    expect(data).toMatchObject({ case_study_candidate: false, case_study_approved: false });
+  });
+
+  it("manager approves a flagged candidate", async () => {
+    const res = await setCaseStudyApproved("a1", true);
+    expect(res).toEqual({});
+    const data = (prismadb.crm_Accounts.update as jest.Mock).mock.calls[0][0].data;
+    expect(data.case_study_approved).toBe(true);
+  });
+
+  it("cannot approve an account that is not a candidate", async () => {
+    (prismadb.crm_Accounts.findFirst as jest.Mock).mockResolvedValue({
+      id: "a1", case_study_candidate: false, case_study_approved: false,
+    });
+    const res = await setCaseStudyApproved("a1", true);
+    expect(res.error).toBeDefined();
+    expect(prismadb.crm_Accounts.update).not.toHaveBeenCalled();
+  });
+
+  it("approval requires manager/admin", async () => {
+    const { AuthorizationError } = jest.requireMock("@/lib/authz");
+    (requireRole as jest.Mock).mockRejectedValue(new AuthorizationError());
+    const res = await setCaseStudyApproved("a1", true);
+    expect(res.error).toBeDefined();
+  });
+});

--- a/actions/crm/accounts/case-study.ts
+++ b/actions/crm/accounts/case-study.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { prismadb } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+// Spec §3.8: clients with strong measurable results are flagged as
+// case-study candidates; the CSO approves.
+export async function setCaseStudyCandidate(
+  accountId: string,
+  candidate: boolean,
+): Promise<{ error?: string }> {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  const account = await prismadb.crm_Accounts.findFirst({
+    where: { id: accountId, deletedAt: null },
+  });
+  if (!account) return { error: "Account not found" };
+
+  await prismadb.crm_Accounts.update({
+    where: { id: accountId },
+    data: {
+      case_study_candidate: candidate,
+      // Withdrawing the candidacy withdraws any prior approval.
+      ...(candidate ? {} : { case_study_approved: false }),
+      updatedBy: user.id,
+    },
+  });
+  await writeAuditLog({
+    entityType: "account",
+    entityId: accountId,
+    action: "updated",
+    changes: [
+      {
+        field: "case_study_candidate",
+        old: account.case_study_candidate,
+        new: candidate,
+      },
+    ],
+    userId: user.id,
+  });
+  revalidatePath("/[locale]/(routes)/crm/accounts", "page");
+  return {};
+}
+
+export async function setCaseStudyApproved(
+  accountId: string,
+  approved: boolean,
+): Promise<{ error?: string }> {
+  let approver;
+  try {
+    approver = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError || e instanceof AuthorizationError) {
+      return { error: "Forbidden" };
+    }
+    throw e;
+  }
+
+  const account = await prismadb.crm_Accounts.findFirst({
+    where: { id: accountId, deletedAt: null },
+  });
+  if (!account) return { error: "Account not found" };
+  if (approved && !account.case_study_candidate)
+    return { error: "Flag the account as a case-study candidate first." };
+
+  await prismadb.crm_Accounts.update({
+    where: { id: accountId },
+    data: { case_study_approved: approved, updatedBy: approver.id },
+  });
+  await writeAuditLog({
+    entityType: "account",
+    entityId: accountId,
+    action: "updated",
+    changes: [
+      {
+        field: "case_study_approved",
+        old: account.case_study_approved,
+        new: approved,
+      },
+    ],
+    userId: approver.id,
+  });
+  revalidatePath("/[locale]/(routes)/crm/accounts", "page");
+  return {};
+}

--- a/actions/crm/opportunities/__tests__/approval.test.ts
+++ b/actions/crm/opportunities/__tests__/approval.test.ts
@@ -1,0 +1,118 @@
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  requireRole: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Opportunities: { findFirst: jest.fn(), update: jest.fn() },
+    users: { findMany: jest.fn(), findUnique: jest.fn() },
+  },
+}));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+const mockEmailSend = jest.fn().mockResolvedValue({});
+jest.mock("@/lib/resend", () => ({
+  __esModule: true,
+  default: jest.fn(async () => ({ emails: { send: mockEmailSend } })),
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, requireRole } from "@/lib/authz";
+import { requestApproval, decideApproval } from "@/actions/crm/opportunities/approval";
+
+describe("requestApproval", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireAuthenticated as jest.Mock).mockResolvedValue({ id: "rep1", role: "user" });
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({
+      id: "o1", name: "Deal", approval_status: "NONE", assigned_to: "rep1",
+    });
+    (prismadb.crm_Opportunities.update as jest.Mock).mockResolvedValue({ id: "o1" });
+    (prismadb.users.findMany as jest.Mock).mockResolvedValue([
+      { email: "cso@x.cz" },
+    ]);
+  });
+
+  it("moves NONE -> PENDING, stamps requested_at, notifies approvers", async () => {
+    const res = await requestApproval("o1");
+    expect(res).toEqual({});
+    const call = (prismadb.crm_Opportunities.update as jest.Mock).mock.calls[0][0];
+    expect(call.where).toEqual({ id: "o1" });
+    expect(call.data.approval_status).toBe("PENDING");
+    expect(call.data.approval_requested_at).toEqual(expect.any(Date));
+    expect(call.data.approval_note).toBeNull();
+    expect(mockEmailSend).toHaveBeenCalled();
+  });
+
+  it("rejects when already PENDING", async () => {
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({
+      id: "o1", approval_status: "PENDING",
+    });
+    const res = await requestApproval("o1");
+    expect(res.error).toBeDefined();
+    expect(prismadb.crm_Opportunities.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects when already APPROVED", async () => {
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({
+      id: "o1", approval_status: "APPROVED",
+    });
+    const res = await requestApproval("o1");
+    expect(res.error).toBeDefined();
+  });
+
+  it("allows re-request after REJECTED", async () => {
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({
+      id: "o1", approval_status: "REJECTED", assigned_to: "rep1",
+    });
+    const res = await requestApproval("o1");
+    expect(res).toEqual({});
+  });
+});
+
+describe("decideApproval", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ id: "cso1", role: "manager" });
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({
+      id: "o1", name: "Deal", approval_status: "PENDING", assigned_to: "rep1",
+    });
+    (prismadb.crm_Opportunities.update as jest.Mock).mockResolvedValue({ id: "o1" });
+    (prismadb.users.findUnique as jest.Mock).mockResolvedValue({ id: "rep1", email: "rep@x.cz" });
+  });
+
+  it("approves: sets status/by/at and notifies the rep", async () => {
+    const res = await decideApproval("o1", "APPROVED");
+    expect(res).toEqual({});
+    const data = (prismadb.crm_Opportunities.update as jest.Mock).mock.calls[0][0].data;
+    expect(data.approval_status).toBe("APPROVED");
+    expect(data.approved_by).toBe("cso1");
+    expect(data.approved_at).toEqual(expect.any(Date));
+    expect(mockEmailSend).toHaveBeenCalled();
+  });
+
+  it("rejects with a note", async () => {
+    await decideApproval("o1", "REJECTED", "  Missing pricing table  ");
+    const data = (prismadb.crm_Opportunities.update as jest.Mock).mock.calls[0][0].data;
+    expect(data.approval_status).toBe("REJECTED");
+    expect(data.approval_note).toBe("Missing pricing table");
+  });
+
+  it("errors when the deal is not PENDING", async () => {
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({
+      id: "o1", approval_status: "NONE",
+    });
+    const res = await decideApproval("o1", "APPROVED");
+    expect(res.error).toBeDefined();
+    expect(prismadb.crm_Opportunities.update).not.toHaveBeenCalled();
+  });
+
+  it("returns error for non-managers", async () => {
+    const { AuthorizationError } = jest.requireMock("@/lib/authz");
+    (requireRole as jest.Mock).mockRejectedValue(new AuthorizationError());
+    const res = await decideApproval("o1", "APPROVED");
+    expect(res.error).toBeDefined();
+  });
+});

--- a/actions/crm/opportunities/__tests__/get-pending-approvals.test.ts
+++ b/actions/crm/opportunities/__tests__/get-pending-approvals.test.ts
@@ -1,0 +1,45 @@
+jest.mock("@/lib/authz", () => ({
+  requireRole: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Opportunities: { findMany: jest.fn() } },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { requireRole } from "@/lib/authz";
+import { getPendingApprovals } from "@/actions/crm/opportunities/get-pending-approvals";
+
+describe("getPendingApprovals", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ id: "cso1", role: "manager" });
+  });
+
+  it("lists PENDING deals with serialized decimals, oldest request first", async () => {
+    (prismadb.crm_Opportunities.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: "o1", name: "Deal", approval_requested_at: new Date("2026-07-01"),
+        budget: { toNumber: () => 1000 }, expected_revenue: { toNumber: () => 800 },
+        assigned_account: { name: "Acme" }, assigned_to_user: { name: "Rep" },
+      },
+    ]);
+    const res = await getPendingApprovals();
+    expect(Array.isArray(res)).toBe(true);
+    const rows = res as any[];
+    expect(rows[0]).toMatchObject({
+      id: "o1", accountName: "Acme", repName: "Rep", budget: 1000,
+    });
+    const where = (prismadb.crm_Opportunities.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.approval_status).toBe("PENDING");
+    expect(where.deletedAt).toBeNull();
+  });
+
+  it("returns error for non-managers", async () => {
+    const { AuthorizationError } = jest.requireMock("@/lib/authz");
+    (requireRole as jest.Mock).mockRejectedValue(new AuthorizationError());
+    const res = await getPendingApprovals();
+    expect((res as any).error).toBeDefined();
+  });
+});

--- a/actions/crm/opportunities/__tests__/update-opportunity-currency.test.ts
+++ b/actions/crm/opportunities/__tests__/update-opportunity-currency.test.ts
@@ -2,6 +2,7 @@ jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     crm_Opportunities: { update: jest.fn(), findUnique: jest.fn() },
+    crm_Opportunities_Sales_Stages: { findUnique: jest.fn() },
     users: { findFirst: jest.fn() },
   },
 }));
@@ -43,5 +44,40 @@ describe("updateOpportunity currency handling", () => {
     await updateOpportunity({ id: "opp-1", name: "Deal", currency: "USD" } as any);
     const data = (prismadb.crm_Opportunities.update as jest.Mock).mock.calls[0][0].data;
     expect(data.currency).toBe("USD");
+  });
+});
+
+describe("updateOpportunity approval gate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSession as jest.Mock).mockResolvedValue({ user: { id: "u1" } });
+    (prismadb.crm_Opportunities.findUnique as jest.Mock).mockResolvedValue({
+      id: "opp-1", sales_stage: "s-old", approval_status: "NONE",
+    });
+    (prismadb.crm_Opportunities.update as jest.Mock).mockResolvedValue({ id: "opp-1" });
+  });
+
+  it("blocks moving an unapproved deal into a qualified-kind stage", async () => {
+    (prismadb.crm_Opportunities_Sales_Stages.findUnique as jest.Mock).mockResolvedValue({
+      stage_kind: "qualified",
+    });
+    const res = await updateOpportunity({
+      id: "opp-1", name: "Deal", sales_stage: "s-qualified",
+    } as any);
+    expect(res.error).toContain("approval");
+    expect(prismadb.crm_Opportunities.update).not.toHaveBeenCalled();
+  });
+
+  it("allows the move when the deal is APPROVED", async () => {
+    (prismadb.crm_Opportunities.findUnique as jest.Mock).mockResolvedValue({
+      id: "opp-1", sales_stage: "s-old", approval_status: "APPROVED",
+    });
+    (prismadb.crm_Opportunities_Sales_Stages.findUnique as jest.Mock).mockResolvedValue({
+      stage_kind: "qualified",
+    });
+    const res = await updateOpportunity({
+      id: "opp-1", name: "Deal", sales_stage: "s-qualified",
+    } as any);
+    expect(res.error).toBeUndefined();
   });
 });

--- a/actions/crm/opportunities/approval.ts
+++ b/actions/crm/opportunities/approval.ts
@@ -1,0 +1,149 @@
+"use server";
+
+import { prismadb } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import resendHelper from "@/lib/resend";
+import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+const APP_URL = () => process.env.NEXT_PUBLIC_APP_URL ?? "";
+const FROM = () =>
+  `${process.env.NEXT_PUBLIC_APP_NAME} <${process.env.EMAIL_FROM}>`;
+
+async function notify(to: string[], subject: string, text: string) {
+  if (to.length === 0) return;
+  try {
+    const resend = await resendHelper();
+    await resend.emails.send({ from: FROM(), to, subject, text });
+  } catch (error) {
+    console.error("[approval] notification failed:", error);
+  }
+}
+
+// Spec §3.5: rep submits the SOW/quote for CSO approval before it goes out.
+export async function requestApproval(
+  opportunityId: string,
+): Promise<{ error?: string }> {
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  const deal = await prismadb.crm_Opportunities.findFirst({
+    where: { id: opportunityId, deletedAt: null },
+  });
+  if (!deal) return { error: "Opportunity not found" };
+  if (deal.approval_status === "PENDING")
+    return { error: "Approval is already pending for this deal." };
+  if (deal.approval_status === "APPROVED")
+    return { error: "This deal is already approved." };
+
+  await prismadb.crm_Opportunities.update({
+    where: { id: opportunityId },
+    data: {
+      approval_status: "PENDING",
+      approval_requested_at: new Date(),
+      approval_note: null,
+      updatedBy: user.id,
+    },
+  });
+  await writeAuditLog({
+    entityType: "opportunity",
+    entityId: opportunityId,
+    action: "updated",
+    changes: [
+      { field: "approval_status", old: deal.approval_status, new: "PENDING" },
+    ],
+    userId: user.id,
+  });
+
+  const approvers = await prismadb.users.findMany({
+    where: { role: { in: ["manager", "admin"] }, userStatus: "ACTIVE" },
+    select: { email: true },
+  });
+  await notify(
+    approvers.map((a) => a.email).filter(Boolean) as string[],
+    `Approval requested: ${deal.name ?? opportunityId}`,
+    `A quote/SOW approval was requested for "${deal.name ?? opportunityId}".\n` +
+      `Review the queue: ${APP_URL()}/crm/approvals\n` +
+      `Deal: ${APP_URL()}/crm/opportunities/${opportunityId}\n` +
+      `(The SOW/quote should be attached to the deal's documents.)`,
+  );
+
+  revalidatePath("/[locale]/(routes)/crm/opportunities", "page");
+  return {};
+}
+
+// CSO decision — managers and admins only (2026-07-19 decision).
+export async function decideApproval(
+  opportunityId: string,
+  decision: "APPROVED" | "REJECTED",
+  note?: string,
+): Promise<{ error?: string }> {
+  let approver;
+  try {
+    approver = await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError || e instanceof AuthorizationError) {
+      return { error: "Forbidden" };
+    }
+    throw e;
+  }
+  if (decision !== "APPROVED" && decision !== "REJECTED")
+    return { error: "Invalid decision" };
+
+  const deal = await prismadb.crm_Opportunities.findFirst({
+    where: { id: opportunityId, deletedAt: null },
+  });
+  if (!deal) return { error: "Opportunity not found" };
+  if (deal.approval_status !== "PENDING")
+    return { error: "This deal has no pending approval request." };
+
+  const trimmedNote = note?.trim().slice(0, 1000) || null;
+  await prismadb.crm_Opportunities.update({
+    where: { id: opportunityId },
+    data: {
+      approval_status: decision,
+      approved_by: approver.id,
+      approved_at: new Date(),
+      approval_note: trimmedNote,
+      updatedBy: approver.id,
+    },
+  });
+  await writeAuditLog({
+    entityType: "opportunity",
+    entityId: opportunityId,
+    action: "updated",
+    changes: [
+      { field: "approval_status", old: "PENDING", new: decision },
+      ...(trimmedNote
+        ? [{ field: "approval_note", old: null, new: trimmedNote }]
+        : []),
+    ],
+    userId: approver.id,
+  });
+
+  if (deal.assigned_to) {
+    const rep = await prismadb.users.findUnique({ where: { id: deal.assigned_to } });
+    if (rep?.email) {
+      await notify(
+        [rep.email],
+        `Quote ${decision === "APPROVED" ? "approved" : "rejected"}: ${deal.name ?? opportunityId}`,
+        `Your quote/SOW for "${deal.name ?? opportunityId}" was ${decision.toLowerCase()}.` +
+          (trimmedNote ? `\nNote: ${trimmedNote}` : "") +
+          `\nDeal: ${APP_URL()}/crm/opportunities/${opportunityId}`,
+      );
+    }
+  }
+
+  revalidatePath("/[locale]/(routes)/crm/opportunities", "page");
+  return {};
+}

--- a/actions/crm/opportunities/get-pending-approvals.ts
+++ b/actions/crm/opportunities/get-pending-approvals.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { prismadb } from "@/lib/prisma";
+import { serializeDecimalsList } from "@/lib/serialize-decimals";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+export type PendingApproval = {
+  id: string;
+  name: string | null;
+  accountName: string | null;
+  repName: string | null;
+  budget: number;
+  expected_revenue: number;
+  approval_requested_at: Date | null;
+};
+
+export async function getPendingApprovals(): Promise<
+  PendingApproval[] | { error: string }
+> {
+  try {
+    await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError || e instanceof AuthorizationError) {
+      return { error: "Forbidden" };
+    }
+    throw e;
+  }
+
+  const rows = await prismadb.crm_Opportunities.findMany({
+    where: { approval_status: "PENDING", deletedAt: null },
+    include: {
+      assigned_account: { select: { name: true } },
+      assigned_to_user: { select: { name: true } },
+    },
+    orderBy: { approval_requested_at: "asc" },
+  });
+
+  return serializeDecimalsList(rows).map((r: any) => ({
+    id: r.id,
+    name: r.name ?? null,
+    accountName: r.assigned_account?.name ?? null,
+    repName: r.assigned_to_user?.name ?? null,
+    budget: r.budget ?? 0,
+    expected_revenue: r.expected_revenue ?? 0,
+    approval_requested_at: r.approval_requested_at ?? null,
+  }));
+}

--- a/actions/crm/opportunities/update-opportunity.ts
+++ b/actions/crm/opportunities/update-opportunity.ts
@@ -6,6 +6,7 @@ import { inngest } from "@/inngest/client";
 import { writeAuditLog, diffObjects } from "@/lib/audit-log";
 import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
 import { handleStageTransition } from "@/lib/crm/stage-transition";
+import { qualifiedEntryBlockReason } from "@/lib/crm/approval-gate";
 
 export const updateOpportunity = async (data: {
   id: string;
@@ -54,6 +55,12 @@ export const updateOpportunity = async (data: {
       ? await getSnapshotRate(currency, defaultCurrency)
       : null;
     const before = await prismadb.crm_Opportunities.findUnique({ where: { id, deletedAt: null } });
+    const blockReason = await qualifiedEntryBlockReason({
+      fromStage: before?.sales_stage ?? null,
+      toStage: sales_stage || null,
+      approvalStatus: before?.approval_status ?? "NONE",
+    });
+    if (blockReason) return { error: blockReason };
     const opportunity = await prismadb.crm_Opportunities.update({
       where: { id },
       data: {

--- a/app/[locale]/(routes)/components/app-sidebar.tsx
+++ b/app/[locale]/(routes)/components/app-sidebar.tsx
@@ -91,7 +91,7 @@ export function AppSidebar({
 
   const navItems = [
     getDashboardMenuItem({ title: dict?.dashboard || "Dashboard" }),
-    getCrmMenuItem({ localizations: dict.crm }),
+    getCrmMenuItem({ localizations: dict.crm, role: session?.user?.role ?? undefined }),
     getCampaignsMenuItem({
       localizations: {
         title: "Campaigns",

--- a/app/[locale]/(routes)/components/menu-items/Crm.tsx
+++ b/app/[locale]/(routes)/components/menu-items/Crm.tsx
@@ -21,9 +21,11 @@ type Props = {
     contracts: string;
     products: string;
   };
+  /** Current user's role — the Approvals queue is manager/admin only. */
+  role?: string;
 };
 
-export const getCrmMenuItem = ({ localizations }: Props): NavItem => {
+export const getCrmMenuItem = ({ localizations, role }: Props): NavItem => {
   return {
     title: localizations.title,
     icon: Coins,
@@ -64,6 +66,9 @@ export const getCrmMenuItem = ({ localizations }: Props): NavItem => {
         title: localizations.products,
         url: "/crm/products",
       },
+      ...(role === "manager" || role === "admin"
+        ? [{ title: "Approvals", url: "/crm/approvals" }]
+        : []),
     ],
   };
 };

--- a/app/[locale]/(routes)/crm/accounts/[accountId]/components/CaseStudyCard.tsx
+++ b/app/[locale]/(routes)/crm/accounts/[accountId]/components/CaseStudyCard.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  setCaseStudyCandidate,
+  setCaseStudyApproved,
+} from "@/actions/crm/accounts/case-study";
+
+type Props = {
+  accountId: string;
+  candidate: boolean;
+  approved: boolean;
+  canApprove: boolean; // manager/admin — computed server-side by the page
+};
+
+const CaseStudyCard = ({ accountId, candidate, approved, canApprove }: Props) => {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const run = async (fn: () => Promise<{ error?: string }>) => {
+    setBusy(true);
+    try {
+      const res = await fn();
+      if (res.error) toast.error(res.error);
+      else router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="flex items-center gap-2">
+          Case study
+          {approved ? (
+            <Badge>Approved</Badge>
+          ) : candidate ? (
+            <Badge variant="secondary">Candidate</Badge>
+          ) : null}
+        </CardTitle>
+        <div className="flex gap-2">
+          {candidate ? (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() => run(() => setCaseStudyCandidate(accountId, false))}
+            >
+              Withdraw candidacy
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() => run(() => setCaseStudyCandidate(accountId, true))}
+            >
+              Flag as candidate
+            </Button>
+          )}
+          {canApprove && candidate && !approved && (
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={() => run(() => setCaseStudyApproved(accountId, true))}
+            >
+              Approve case study
+            </Button>
+          )}
+          {canApprove && approved && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() => run(() => setCaseStudyApproved(accountId, false))}
+            >
+              Revoke approval
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        Clients with strong measurable results are flagged here; a manager
+        approves before marketing may reference them.
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CaseStudyCard;

--- a/app/[locale]/(routes)/crm/accounts/[accountId]/page.tsx
+++ b/app/[locale]/(routes)/crm/accounts/[accountId]/page.tsx
@@ -1,6 +1,8 @@
 import Container from "@/app/[locale]/(routes)/components/ui/Container";
 import React from "react";
 import { BasicView } from "./components/BasicView";
+import CaseStudyCard from "./components/CaseStudyCard";
+import { getSession } from "@/lib/auth-server";
 import { FindSimilarButton } from "@/components/crm/find-similar-button";
 
 import { getAccount } from "@/actions/crm/get-account";
@@ -49,6 +51,8 @@ interface AccountDetailPageProps {
 const AccountDetailPage = async (props: AccountDetailPageProps) => {
   const params = await props.params;
   const { accountId } = params;
+  const session = await getSession();
+  const sessionUserRole = (session?.user as any)?.role ?? "user";
   const account: crm_Accounts | null = await getAccount(accountId);
   const opportunities: crm_Opportunities[] = serializeDecimalsList(
     await getOpportunitiesFullByAccountId(accountId)
@@ -108,6 +112,14 @@ const AccountDetailPage = async (props: AccountDetailPageProps) => {
         <TabsContent value="overview">
           <div className="space-y-5">
             <BasicView data={account} />
+            <CaseStudyCard
+              accountId={account.id}
+              candidate={account.case_study_candidate}
+              approved={account.case_study_approved}
+              canApprove={
+                sessionUserRole === "manager" || sessionUserRole === "admin"
+              }
+            />
             <ActivitiesSection accountId={account.id} />
             <FindSimilarButton entityType="account" recordId={accountId} />
             <AccountsTasksView data={tasks} account={account} />

--- a/app/[locale]/(routes)/crm/approvals/components/ApprovalsTable.tsx
+++ b/app/[locale]/(routes)/crm/approvals/components/ApprovalsTable.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { decideApproval } from "@/actions/crm/opportunities/approval";
+import type { PendingApproval } from "@/actions/crm/opportunities/get-pending-approvals";
+
+const ApprovalsTable = ({ rows }: { rows: PendingApproval[] }) => {
+  const router = useRouter();
+  const [rejecting, setRejecting] = useState<PendingApproval | null>(null);
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const decide = async (
+    id: string,
+    decision: "APPROVED" | "REJECTED",
+    n?: string,
+  ) => {
+    setBusy(true);
+    try {
+      const res = await decideApproval(id, decision, n);
+      if (res.error) toast.error(res.error);
+      else {
+        toast.success(decision === "APPROVED" ? "Quote approved" : "Quote rejected");
+        setRejecting(null);
+        setNote("");
+        router.refresh();
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-muted-foreground">
+          No deals waiting for approval.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="px-4 py-3">Deal</th>
+              <th className="px-4 py-3">Account</th>
+              <th className="px-4 py-3">Rep</th>
+              <th className="px-4 py-3">Budget</th>
+              <th className="px-4 py-3">Requested</th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-b last:border-0">
+                <td className="px-4 py-3">
+                  <Link
+                    className="font-medium hover:underline"
+                    href={`/crm/opportunities/${r.id}`}
+                  >
+                    {r.name ?? r.id}
+                  </Link>
+                </td>
+                <td className="px-4 py-3">{r.accountName ?? "—"}</td>
+                <td className="px-4 py-3">{r.repName ?? "—"}</td>
+                <td className="px-4 py-3">{r.budget.toLocaleString()}</td>
+                <td className="px-4 py-3">
+                  {r.approval_requested_at
+                    ? new Date(r.approval_requested_at).toLocaleDateString()
+                    : "—"}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      size="sm"
+                      disabled={busy}
+                      onClick={() => decide(r.id, "APPROVED")}
+                    >
+                      Approve
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={busy}
+                      onClick={() => setRejecting(r)}
+                    >
+                      Reject
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+
+      <Dialog
+        open={!!rejecting}
+        onOpenChange={(v) => {
+          if (!v) setRejecting(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reject quote — {rejecting?.name ?? ""}</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            placeholder="What needs to change? (sent to the rep)"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            maxLength={1000}
+          />
+          <DialogFooter>
+            <Button
+              variant="destructive"
+              disabled={busy}
+              onClick={() => rejecting && decide(rejecting.id, "REJECTED", note)}
+            >
+              Reject quote
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+};
+
+export default ApprovalsTable;

--- a/app/[locale]/(routes)/crm/approvals/page.tsx
+++ b/app/[locale]/(routes)/crm/approvals/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+import Container from "../../components/ui/Container";
+import {
+  requireRole,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+import { getPendingApprovals } from "@/actions/crm/opportunities/get-pending-approvals";
+import ApprovalsTable from "./components/ApprovalsTable";
+
+const ApprovalsPage = async () => {
+  try {
+    await requireRole(["manager", "admin"]);
+  } catch (e) {
+    if (e instanceof AuthenticationError) redirect("/sign-in");
+    if (e instanceof AuthorizationError) redirect("/");
+    throw e;
+  }
+  const pending = await getPendingApprovals();
+  const rows = Array.isArray(pending) ? pending : [];
+  return (
+    <Container
+      title="Quote approvals"
+      description="Deals waiting for a quote/SOW decision"
+    >
+      <ApprovalsTable rows={rows} />
+    </Container>
+  );
+};
+
+export default ApprovalsPage;

--- a/app/[locale]/(routes)/crm/opportunities/[opportunityId]/components/BasicView.tsx
+++ b/app/[locale]/(routes)/crm/opportunities/[opportunityId]/components/BasicView.tsx
@@ -22,6 +22,8 @@ import { Clapperboard } from "lucide-react";
 import { prismadb } from "@/lib/prisma";
 import { getAllCrmData } from "@/actions/crm/get-crm-data";
 import { OpportunityDetailActions } from "./OpportunityDetailActions";
+import RequestApprovalButton from "./RequestApprovalButton";
+import { Badge } from "@/components/ui/badge";
 import { formatCurrency, convertAmount, getExchangeRates, getDefaultCurrency } from "@/lib/currency";
 import { Decimal } from "@prisma/client/runtime/client";
 import { cookies } from "next/headers";
@@ -57,9 +59,25 @@ export async function BasicView({ data }: OppsViewProps) {
       <CardHeader className="pb-3">
         <div className="flex w-full justify-between">
           <div>
-            <CardTitle>{data.name}</CardTitle>
+            <CardTitle className="flex items-center gap-2">
+              {data.name}
+              {data.approval_status === "PENDING" && (
+                <Badge variant="secondary">Approval pending</Badge>
+              )}
+              {data.approval_status === "APPROVED" && <Badge>Approved</Badge>}
+              {data.approval_status === "REJECTED" && (
+                <Badge variant="destructive" title={data.approval_note ?? undefined}>
+                  Rejected
+                </Badge>
+              )}
+            </CardTitle>
             <CardDescription>ID:{data.id}</CardDescription>
           </div>
+          <div className="flex items-start gap-2">
+          {(data.approval_status === "NONE" ||
+            data.approval_status === "REJECTED") && (
+            <RequestApprovalButton opportunityId={data.id} />
+          )}
           <OpportunityDetailActions
             opportunity={serializeDecimals(data)}
             saleTypes={saleTypes}
@@ -67,6 +85,7 @@ export async function BasicView({ data }: OppsViewProps) {
             campaigns={campaigns}
             currencies={currencies.map((c: { code: string; name: string; symbol: string }) => ({ code: c.code, name: c.name, symbol: c.symbol }))}
           />
+          </div>
         </div>
       </CardHeader>
       <CardContent className="grid grid-cols-2 gap-1">

--- a/app/[locale]/(routes)/crm/opportunities/[opportunityId]/components/RequestApprovalButton.tsx
+++ b/app/[locale]/(routes)/crm/opportunities/[opportunityId]/components/RequestApprovalButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { FileCheck2, Loader2 } from "lucide-react";
+import { requestApproval } from "@/actions/crm/opportunities/approval";
+
+const RequestApprovalButton = ({ opportunityId }: { opportunityId: string }) => {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    setLoading(true);
+    try {
+      const res = await requestApproval(opportunityId);
+      if (res.error) toast.error(res.error);
+      else {
+        toast.success("Approval requested — approvers were notified.");
+        router.refresh();
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={submit} disabled={loading}>
+      {loading ? (
+        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+      ) : (
+        <FileCheck2 className="h-4 w-4 mr-2" />
+      )}
+      Request approval
+    </Button>
+  );
+};
+
+export default RequestApprovalButton;

--- a/docs/internal/aqunama-p3-smoke-test.md
+++ b/docs/internal/aqunama-p3-smoke-test.md
@@ -1,0 +1,39 @@
+# AQUNAMA Phase 3 — Manual Smoke Test (~15 min)
+
+Prereqs: dev deployment, one admin/manager login (CSO) + one plain-user
+login (rep) — or one admin doing both sides. A throwaway deal in a
+pre_sale-kind stage.
+
+## 1. Gate blocks unapproved deals (2 min)
+- [ ] Drag the test deal into the Qualified-trigger stage on the kanban →
+      error toast "Quote approval is required…"; deal stays put.
+- [ ] Same via the deal's Update form → same error.
+
+## 2. Request approval (3 min)
+- [ ] Deal detail → **Request approval** → success toast; badge shows
+      "Approval pending"; the button disappears.
+- [ ] Second request attempt (reload → button gone; via another tab if
+      open) errors "already pending".
+- [ ] Manager/admin users receive the request email with queue + deal links.
+
+## 3. Approve & pass the gate (4 min)
+- [ ] As CSO: **CRM → Approvals** shows the deal (account, rep, budget,
+      requested date). Approvals nav item is hidden for plain users, and
+      opening /crm/approvals as a plain user redirects away.
+- [ ] Approve → row disappears; rep gets the "approved" email; deal badge
+      shows "Approved".
+- [ ] Drag the deal into the Qualified stage → succeeds now (and the
+      Phase 2 cadence run appears in Inngest).
+
+## 4. Rejection loop (3 min)
+- [ ] Flag a second test deal, request approval, then as CSO **Reject**
+      with a note → rep email contains the note; badge "Rejected" (note in
+      tooltip); gate still blocks; **Request approval** is available again.
+
+## 5. Case study (3 min)
+- [ ] Account detail → Case study card → **Flag as candidate** → badge
+      "Candidate".
+- [ ] As manager/admin: **Approve case study** → badge "Approved". Approve
+      button never shows for plain users.
+- [ ] **Withdraw candidacy** clears both badges (approval revoked too).
+- [ ] Audit Log shows the approval-status and case-study changes.

--- a/docs/internal/aqunama-setup-runbook.md
+++ b/docs/internal/aqunama-setup-runbook.md
@@ -69,3 +69,15 @@ What runs automatically:
   digest. Assign that list to a fresh campaign to re-try them.
 - **Renewals** (Mondays 07:00 UTC): contract reminder dates and product
   renewal dates within 30 days become tasks for the account's rep.
+
+## 8. Phase 3: quote approvals & case studies
+
+- Reps: open the deal → **Request approval** (attach the SOW/quote to the
+  deal's documents first). The deal cannot move into the Qualified stage
+  until a manager/admin approves — the kanban/form will refuse with an
+  explanatory error.
+- Managers/admins (CSO): work the **CRM → Approvals** queue — approve, or
+  reject with a note (the rep is emailed either way). Re-request after
+  fixing a rejection.
+- Case studies: on the account detail, reps flag **case-study candidates**;
+  managers/admins approve them (spec §3.8).

--- a/docs/superpowers/plans/2026-07-16-aqunama-roadmap.md
+++ b/docs/superpowers/plans/2026-07-16-aqunama-roadmap.md
@@ -27,7 +27,11 @@ The heart of the spec: automated funnel timing on Inngest.
 - **Renewal surfacing:** weekly cron emailing reps contracts/account-products with `renewal_date`/`renewalReminderDate` within 60 days.
 - **Prerequisite decision:** precise definition of "client activity" that restarts the 45-day clock.
 
-## Plan 3 — Minimal SOW/Quote Approval (gap G-04 + case-study flag from G-10) — stub
+## Plan 3 — Minimal SOW/Quote Approval ✅ implemented (2026-07-19)
+
+Full plan: `docs/superpowers/plans/2026-07-19-aqunama-p3-approval-workflow.md` — decisions: hard gate on Qualified entry; approvers = manager+admin; queue at /crm/approvals.
+
+Original stub (for reference):
 
 - **Data:** `approval_status` enum on `crm_Opportunities` (`none | pending_approval | approved | rejected`), `approved_by`/`approved_at`; `case_study_candidate` + `case_study_approved` on `crm_Accounts`.
 - **Flow:** rep attaches the SOW/quote document to the opportunity and requests approval → manager/admin (CSO) sees a pending-approvals view and approves/rejects (guarded by `isManagerOrAdmin`) → only approved deals can move to the Qualified stage (transition guard) → approval decisions audit-logged and email-notified.

--- a/lib/crm/approval-gate.ts
+++ b/lib/crm/approval-gate.ts
@@ -1,0 +1,23 @@
+import { prismadb } from "@/lib/prisma";
+
+// Spec §3.5 hard gate (2026-07-19 decision): a deal may only ENTER a stage
+// whose stage_kind is "qualified" (quote sent) when its SOW/quote is
+// APPROVED. Transitions elsewhere, staying in place, and clearing the
+// stage are unaffected.
+export async function qualifiedEntryBlockReason(opts: {
+  fromStage: string | null;
+  toStage: string | null;
+  approvalStatus: string;
+}): Promise<string | null> {
+  const { fromStage, toStage, approvalStatus } = opts;
+  if (!toStage || toStage === fromStage) return null;
+  if (approvalStatus === "APPROVED") return null;
+
+  const target = await prismadb.crm_Opportunities_Sales_Stages.findUnique({
+    where: { id: toStage },
+    select: { stage_kind: true },
+  });
+  if (target?.stage_kind !== "qualified") return null;
+
+  return "Quote approval is required before moving this deal to the Qualified stage. Request approval from the deal page first.";
+}

--- a/prisma/migrations/20260719071501_aqunama_p3_approval_and_case_study/migration.sql
+++ b/prisma/migrations/20260719071501_aqunama_p3_approval_and_case_study/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "crm_Approval_Status" AS ENUM ('NONE', 'PENDING', 'APPROVED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "crm_Accounts" ADD COLUMN     "case_study_approved" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "case_study_candidate" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "crm_Opportunities" ADD COLUMN     "approval_note" TEXT,
+ADD COLUMN     "approval_requested_at" TIMESTAMP(3),
+ADD COLUMN     "approval_status" "crm_Approval_Status" NOT NULL DEFAULT 'NONE',
+ADD COLUMN     "approved_at" TIMESTAMP(3),
+ADD COLUMN     "approved_by" UUID;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,9 @@ model crm_Accounts {
   shipping_state       String?
   shipping_street      String?
   status               String?   @default("Inactive")
+  /// Spec §3.8 case-study pipeline: rep flags the candidate, CSO approves.
+  case_study_candidate Boolean   @default(false)
+  case_study_approved  Boolean   @default(false)
   type                 String?   @default("Customer")
   vat                  String?
   website              String?
@@ -204,6 +207,12 @@ model crm_Opportunities {
   delivery_deadline DateTime?
   /// Set whenever sales_stage changes; anchors cadence/care timers.
   stage_entered_at  DateTime?
+  /// SOW/quote approval (spec §3.5: CSO approves before the quote is sent).
+  approval_status       crm_Approval_Status @default(NONE)
+  approval_requested_at DateTime?
+  approval_note         String?
+  approved_by           String?             @db.Uuid
+  approved_at           DateTime?
   contact          String?                 @db.Uuid
   createdBy        String?                 @db.Uuid
   created_on       DateTime?               @default(now())
@@ -249,6 +258,13 @@ model crm_Opportunities {
   @@index([close_date])
   @@index([status, sales_stage])
   @@index([deletedAt])
+}
+
+enum crm_Approval_Status {
+  NONE
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 enum crm_Opportunity_Status {


### PR DESCRIPTION
## Summary

The spec's "CSO must approve every SOW/quote before it is sent" (§3.5), implemented as a minimal approval workflow (plan: `docs/superpowers/plans/2026-07-19-aqunama-p3-approval-workflow.md`), plus the §3.8 case-study pipeline:

- **Approval state machine** on opportunities: `NONE → PENDING → APPROVED/REJECTED` (re-request allowed after rejection, double-request blocked). `requestApproval` notifies all active managers/admins; `decideApproval` (manager/admin only) notifies the rep, carrying the rejection note. Every transition audit-logged.
- **Hard gate**: a deal cannot ENTER any sales stage whose automation trigger is `qualified` unless APPROVED — enforced server-side in `updateOpportunity`, covering the edit form and the kanban drag (which surfaces the error as a toast and reverts). Creation paths are intentionally ungated (runbook flow enters at Pre-Sale).
- **`/crm/approvals` queue** for managers/admins: pending deals (account, rep, budget, requested date), one-click approve, reject-with-note dialog. Page server-gated (`requireRole`), nav item shown only to managers/admins.
- **Deal page**: approval badge (pending / approved / rejected-with-note-tooltip) + "Request approval" button.
- **Case studies**: `case_study_candidate`/`case_study_approved` on accounts — reps flag, managers/admins approve, withdrawal revokes; card on the account detail. All authorization server-side; UI role props are display-only.

## Test plan

- 22 new unit tests (approval state machine, gate semantics incl. bypass/no-op cases, queue authz, case-study rules); suite 979/979, typecheck clean.
- Migration authored via `migrate diff` (dev-DB drift protocol), verified additive-only and replayable on a fresh pgvector database — also enforced by CI's integration job.
- CI run 29678086850: all four blocking jobs green, including the 95-spec e2e suite (kanban drags and deal forms exercised).
- Manual script: `docs/internal/aqunama-p3-smoke-test.md` (~15 min, covers the gate, both decision paths, role visibility, and the case-study loop).

## After merge

Runbook §8: reps request approval from the deal page; CSOs work CRM → Approvals. No configuration needed — the gate keys off the existing `qualified` stage trigger from Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)