### PR TITLE
feat(crm): AQUNAMA Phase 4 — calendar sync (Calendly + Google Calendar inbound)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,7 @@ EMAIL_ENCRYPTION_KEY=your_64_hex_char_key_here
 # Campaigns — Resend email sending
 RESEND_WEBHOOK_SECRET=     # Resend webhook signing secret
 RESEND_FROM_EMAIL=         # e.g. noreply@yourdomain.com
+
+# Google Calendar sync (AQUNAMA Phase 4) — Workspace-internal OAuth app
+GOOGLE_CALENDAR_CLIENT_ID=
+GOOGLE_CALENDAR_CLIENT_SECRET=

--- a/__tests__/crm/client-activity.test.ts
+++ b/__tests__/crm/client-activity.test.ts
@@ -48,4 +48,31 @@ describe("getLastClientActivity", () => {
     expect(prismadb.email.findFirst).not.toHaveBeenCalled();
     expect(res).toEqual(new Date("2026-05-01"));
   });
+
+  it("excludes cancelled activities from the kill-clock query so a cancelled future meeting can't hold a deal active, while a scheduled one still counts", async () => {
+    (prismadb.email.findFirst as jest.Mock).mockResolvedValue(null);
+    // Simulate Prisma applying the status filter: a cancelled-only activity set
+    // resolves to null, as the real DB would exclude it via `status: { not: "cancelled" }`.
+    (prismadb.crm_Activities.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const res = await getLastClientActivity({
+      id: "o1", contact: "c1", account: "a1",
+      stage_entered_at: new Date("2026-05-01"),
+    });
+
+    const where = (prismadb.crm_Activities.findFirst as jest.Mock).mock.calls[0][0].where;
+    expect(where.status).toEqual({ not: "cancelled" });
+    // With the cancelled activity excluded, the clock falls back to stage entry.
+    expect(res).toEqual(new Date("2026-05-01"));
+
+    // A scheduled activity, by contrast, still counts and wins the max().
+    (prismadb.crm_Activities.findFirst as jest.Mock).mockResolvedValue({
+      date: new Date("2026-06-15"),
+    });
+    const res2 = await getLastClientActivity({
+      id: "o1", contact: "c1", account: "a1",
+      stage_entered_at: new Date("2026-05-01"),
+    });
+    expect(res2).toEqual(new Date("2026-06-15"));
+  });
 });

--- a/app/[locale]/(routes)/admin/_components/AdminSidebarNav.tsx
+++ b/app/[locale]/(routes)/admin/_components/AdminSidebarNav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Key, Users, Settings, SlidersHorizontal, ClipboardList, Coins, FileText } from "lucide-react";
+import { Key, Users, Settings, SlidersHorizontal, ClipboardList, Coins, FileText, CalendarClock } from "lucide-react";
 
 const navItems = [
   { label: "LLM Keys",     href: "/admin/llm-keys",     icon: Key },
@@ -11,6 +11,7 @@ const navItems = [
   { label: "Services",     href: "/admin/services",     icon: Settings },
   { label: "CRM Settings", href: "/admin/crm-settings", icon: SlidersHorizontal },
   { label: "Funnel Settings", href: "/admin/funnel-settings", icon: SlidersHorizontal },
+  { label: "Calendar Settings", href: "/admin/calendar-settings", icon: CalendarClock },
   { label: "Audit Log",    href: "/admin/audit-log",    icon: ClipboardList },
   { label: "Currencies",   href: "/admin/currencies",   icon: Coins },
   { label: "Invoices",     href: "/admin/invoices",     icon: FileText },

--- a/app/[locale]/(routes)/admin/calendar-settings/_actions/calendly.ts
+++ b/app/[locale]/(routes)/admin/calendar-settings/_actions/calendly.ts
@@ -1,26 +1,27 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { getSession } from "@/lib/auth-server";
-import { prismadb } from "@/lib/prisma";
+import { requireRole, AuthenticationError, AuthorizationError } from "@/lib/authz";
 import {
   getCalendlySettings,
   saveCalendlySettings,
   setCalendlyWebhookUri,
 } from "@/lib/crm/calendar/calendly-settings";
 
-async function requireAdmin() {
-  const session = await getSession();
-  if (!session?.user?.id) throw new Error("Unauthorized");
-  const user = await prismadb.users.findUnique({
-    where: { id: session.user.id },
-    select: { role: true },
-  });
-  if (user?.role !== "admin") throw new Error("Forbidden");
+async function ensureAdmin(): Promise<{ error: string } | null> {
+  try {
+    await requireRole(["admin"]);
+    return null;
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 }
 
 export async function saveCalendlyAction(formData: FormData) {
-  await requireAdmin();
+  const denied = await ensureAdmin();
+  if (denied) throw new Error(denied.error);
   const apiToken = String(formData.get("apiToken") ?? "").trim();
   const signingKey = String(formData.get("signingKey") ?? "").trim();
   await saveCalendlySettings({
@@ -31,35 +32,44 @@ export async function saveCalendlyAction(formData: FormData) {
 }
 
 export async function subscribeCalendlyWebhook(): Promise<{ ok: boolean; error?: string }> {
-  await requireAdmin();
-  const { apiToken } = await getCalendlySettings();
-  if (!apiToken) return { ok: false, error: "Save the API token first." };
+  const denied = await ensureAdmin();
+  if (denied) return { ok: false, error: denied.error };
 
-  const headers = {
-    Authorization: `Bearer ${apiToken}`,
-    "Content-Type": "application/json",
-  };
+  try {
+    const { apiToken } = await getCalendlySettings();
+    if (!apiToken) return { ok: false, error: "Save the API token first." };
 
-  const meRes = await fetch("https://api.calendly.com/users/me", { headers });
-  if (!meRes.ok) return { ok: false, error: `Calendly /users/me failed (${meRes.status})` };
-  const me = (await meRes.json()) as { resource: { current_organization: string } };
+    const headers = {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    };
 
-  const subRes = await fetch("https://api.calendly.com/webhook_subscriptions", {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      url: `${process.env.NEXT_PUBLIC_APP_URL}/api/crm/calendar/webhooks/calendly`,
-      events: ["invitee.created", "invitee.canceled"],
-      organization: me.resource.current_organization,
-      scope: "organization",
-    }),
-  });
-  if (!subRes.ok) {
-    const detail = await subRes.text();
-    return { ok: false, error: `Subscription failed (${subRes.status}): ${detail.slice(0, 200)}` };
+    const meRes = await fetch("https://api.calendly.com/users/me", { headers });
+    if (!meRes.ok) return { ok: false, error: `Calendly /users/me failed (${meRes.status})` };
+    const me = (await meRes.json()) as { resource: { current_organization: string } };
+
+    const subRes = await fetch("https://api.calendly.com/webhook_subscriptions", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        url: `${process.env.NEXT_PUBLIC_APP_URL}/api/crm/calendar/webhooks/calendly`,
+        events: ["invitee.created", "invitee.canceled"],
+        organization: me.resource.current_organization,
+        scope: "organization",
+      }),
+    });
+    if (!subRes.ok) {
+      const detail = await subRes.text();
+      return { ok: false, error: `Subscription failed (${subRes.status}): ${detail.slice(0, 200)}` };
+    }
+    const sub = (await subRes.json()) as { resource: { uri: string } };
+    await setCalendlyWebhookUri(sub.resource.uri);
+    revalidatePath("/admin/calendar-settings");
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Calendly request failed",
+    };
   }
-  const sub = (await subRes.json()) as { resource: { uri: string } };
-  await setCalendlyWebhookUri(sub.resource.uri);
-  revalidatePath("/admin/calendar-settings");
-  return { ok: true };
 }

--- a/app/[locale]/(routes)/admin/calendar-settings/_actions/calendly.ts
+++ b/app/[locale]/(routes)/admin/calendar-settings/_actions/calendly.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import {
+  getCalendlySettings,
+  saveCalendlySettings,
+  setCalendlyWebhookUri,
+} from "@/lib/crm/calendar/calendly-settings";
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.user?.id) throw new Error("Unauthorized");
+  const user = await prismadb.users.findUnique({
+    where: { id: session.user.id },
+    select: { role: true },
+  });
+  if (user?.role !== "admin") throw new Error("Forbidden");
+}
+
+export async function saveCalendlyAction(formData: FormData) {
+  await requireAdmin();
+  const apiToken = String(formData.get("apiToken") ?? "").trim();
+  const signingKey = String(formData.get("signingKey") ?? "").trim();
+  await saveCalendlySettings({
+    ...(apiToken ? { apiToken } : {}),
+    ...(signingKey ? { signingKey } : {}),
+  });
+  revalidatePath("/admin/calendar-settings");
+}
+
+export async function subscribeCalendlyWebhook(): Promise<{ ok: boolean; error?: string }> {
+  await requireAdmin();
+  const { apiToken } = await getCalendlySettings();
+  if (!apiToken) return { ok: false, error: "Save the API token first." };
+
+  const headers = {
+    Authorization: `Bearer ${apiToken}`,
+    "Content-Type": "application/json",
+  };
+
+  const meRes = await fetch("https://api.calendly.com/users/me", { headers });
+  if (!meRes.ok) return { ok: false, error: `Calendly /users/me failed (${meRes.status})` };
+  const me = (await meRes.json()) as { resource: { current_organization: string } };
+
+  const subRes = await fetch("https://api.calendly.com/webhook_subscriptions", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      url: `${process.env.NEXT_PUBLIC_APP_URL}/api/crm/calendar/webhooks/calendly`,
+      events: ["invitee.created", "invitee.canceled"],
+      organization: me.resource.current_organization,
+      scope: "organization",
+    }),
+  });
+  if (!subRes.ok) {
+    const detail = await subRes.text();
+    return { ok: false, error: `Subscription failed (${subRes.status}): ${detail.slice(0, 200)}` };
+  }
+  const sub = (await subRes.json()) as { resource: { uri: string } };
+  await setCalendlyWebhookUri(sub.resource.uri);
+  revalidatePath("/admin/calendar-settings");
+  return { ok: true };
+}

--- a/app/[locale]/(routes)/admin/calendar-settings/_components/CalendlyForm.tsx
+++ b/app/[locale]/(routes)/admin/calendar-settings/_components/CalendlyForm.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { saveCalendlyAction, subscribeCalendlyWebhook } from "../_actions/calendly";
+
+export function CalendlyForm(props: {
+  hasToken: boolean;
+  hasSigningKey: boolean;
+  webhookUri: string | null;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  return (
+    <div className="max-w-xl space-y-4 rounded-lg border p-4">
+      <form action={saveCalendlyAction} className="space-y-3">
+        <div>
+          <label className="text-sm font-medium">
+            API token {props.hasToken ? "(saved)" : ""}
+          </label>
+          <Input name="apiToken" type="password" placeholder="Calendly personal access token" />
+        </div>
+        <div>
+          <label className="text-sm font-medium">
+            Webhook signing key {props.hasSigningKey ? "(saved)" : ""}
+          </label>
+          <Input name="signingKey" type="password" placeholder="Webhook signing key" />
+        </div>
+        <Button type="submit">Save</Button>
+      </form>
+
+      <div className="border-t pt-4">
+        <Button
+          variant="secondary"
+          disabled={pending || !props.hasToken}
+          onClick={() =>
+            startTransition(async () => {
+              const res = await subscribeCalendlyWebhook();
+              setMessage(res.ok ? "Webhook subscribed." : res.error ?? "Failed.");
+            })
+          }
+        >
+          {props.webhookUri ? "Re-subscribe webhook" : "Subscribe webhook"}
+        </Button>
+        {props.webhookUri && (
+          <p className="mt-2 break-all text-xs text-muted-foreground">
+            Active subscription: {props.webhookUri}
+          </p>
+        )}
+        {message && <p className="mt-2 text-sm">{message}</p>}
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(routes)/admin/calendar-settings/page.tsx
+++ b/app/[locale]/(routes)/admin/calendar-settings/page.tsx
@@ -1,18 +1,7 @@
-import { getSession } from "@/lib/auth-server";
-import { prismadb } from "@/lib/prisma";
-import { redirect } from "next/navigation";
 import { getCalendlySettings } from "@/lib/crm/calendar/calendly-settings";
 import { CalendlyForm } from "./_components/CalendlyForm";
 
 export default async function CalendarSettingsPage() {
-  const session = await getSession();
-  if (!session?.user?.id) redirect("/sign-in");
-  const user = await prismadb.users.findUnique({
-    where: { id: session.user.id },
-    select: { role: true },
-  });
-  if (user?.role !== "admin") redirect("/");
-
   const settings = await getCalendlySettings();
 
   return (

--- a/app/[locale]/(routes)/admin/calendar-settings/page.tsx
+++ b/app/[locale]/(routes)/admin/calendar-settings/page.tsx
@@ -1,0 +1,33 @@
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import { getCalendlySettings } from "@/lib/crm/calendar/calendly-settings";
+import { CalendlyForm } from "./_components/CalendlyForm";
+
+export default async function CalendarSettingsPage() {
+  const session = await getSession();
+  if (!session?.user?.id) redirect("/sign-in");
+  const user = await prismadb.users.findUnique({
+    where: { id: session.user.id },
+    select: { role: true },
+  });
+  if (user?.role !== "admin") redirect("/");
+
+  const settings = await getCalendlySettings();
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Calendar settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Calendly organization webhook for booked-call capture.
+        </p>
+      </div>
+      <CalendlyForm
+        hasToken={Boolean(settings.apiToken)}
+        hasSigningKey={Boolean(settings.signingKey)}
+        webhookUri={settings.webhookUri}
+      />
+    </div>
+  );
+}

--- a/app/[locale]/(routes)/profile/components/CalendarConnectionsList.tsx
+++ b/app/[locale]/(routes)/profile/components/CalendarConnectionsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 type Connection = {
@@ -12,14 +13,43 @@ type Connection = {
   lastSyncError: string | null;
 };
 
+// Outcome of the Google OAuth callback, passed back as ?calendar=<result>.
+const CALLBACK_MESSAGES: Record<string, { tone: "success" | "error"; text: string }> = {
+  connected: { tone: "success", text: "Google Calendar connected." },
+  error: {
+    tone: "error",
+    text: "Connection failed — ask an admin to check the server logs for [google-calendar-callback].",
+  },
+  "state-mismatch": {
+    tone: "error",
+    text: "Sign-in verification failed (state mismatch). Please try connecting again.",
+  },
+  "no-refresh-token": {
+    tone: "error",
+    text: "Google did not return a refresh token. Remove this app's access at myaccount.google.com/permissions, then connect again.",
+  },
+};
+
 export function CalendarConnectionsList() {
+  const searchParams = useSearchParams();
+  const callbackResult = searchParams.get("calendar");
+  const banner = callbackResult ? CALLBACK_MESSAGES[callbackResult] ?? null : null;
+
   const [connections, setConnections] = useState<Connection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
-    const res = await fetch("/api/profile/calendar-connections");
-    if (res.ok) setConnections((await res.json()).connections);
-    setLoading(false);
+    try {
+      const res = await fetch("/api/profile/calendar-connections");
+      if (!res.ok) throw new Error(`Failed to load connections (${res.status})`);
+      setConnections((await res.json()).connections);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load connections");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
@@ -27,12 +57,30 @@ export function CalendarConnectionsList() {
   }, [load]);
 
   async function disconnect(id: string) {
-    await fetch(`/api/profile/calendar-connections/${id}`, { method: "DELETE" });
-    await load();
+    try {
+      const res = await fetch(`/api/profile/calendar-connections/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error(`Disconnect failed (${res.status})`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Disconnect failed");
+    }
   }
 
   return (
     <div className="space-y-3 rounded-lg border p-4">
+      {banner && (
+        <p
+          className={
+            banner.tone === "success"
+              ? "rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400"
+              : "rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          }
+        >
+          {banner.text}
+        </p>
+      )}
       <div className="flex items-center justify-between">
         <h3 className="font-medium">Calendar connections</h3>
         <Button asChild size="sm">
@@ -41,6 +89,7 @@ export function CalendarConnectionsList() {
           </a>
         </Button>
       </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : connections.length === 0 ? (

--- a/app/[locale]/(routes)/profile/components/CalendarConnectionsList.tsx
+++ b/app/[locale]/(routes)/profile/components/CalendarConnectionsList.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+type Connection = {
+  id: string;
+  provider: string;
+  accountEmail: string;
+  isActive: boolean;
+  lastSyncedAt: string | null;
+  lastSyncError: string | null;
+};
+
+export function CalendarConnectionsList() {
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const res = await fetch("/api/profile/calendar-connections");
+    if (res.ok) setConnections((await res.json()).connections);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function disconnect(id: string) {
+    await fetch(`/api/profile/calendar-connections/${id}`, { method: "DELETE" });
+    await load();
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">Calendar connections</h3>
+        <Button asChild size="sm">
+          <a href="/api/profile/calendar-connections/google/authorize">
+            Connect Google Calendar
+          </a>
+        </Button>
+      </div>
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : connections.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No calendars connected.</p>
+      ) : (
+        <ul className="space-y-2">
+          {connections.map((c) => (
+            <li key={c.id} className="flex items-center justify-between rounded border p-2">
+              <div>
+                <p className="text-sm font-medium">{c.accountEmail}</p>
+                <p className="text-xs text-muted-foreground">
+                  {c.isActive
+                    ? c.lastSyncedAt
+                      ? `Synced ${new Date(c.lastSyncedAt).toLocaleString()}`
+                      : "Waiting for first sync"
+                    : `Needs reconnect${c.lastSyncError ? `: ${c.lastSyncError}` : ""}`}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                {!c.isActive && (
+                  <Button asChild size="sm" variant="secondary">
+                    <a href="/api/profile/calendar-connections/google/authorize">Reconnect</a>
+                  </Button>
+                )}
+                <Button size="sm" variant="destructive" onClick={() => disconnect(c.id)}>
+                  Disconnect
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/[locale]/(routes)/profile/components/ProfileTabs.tsx
+++ b/app/[locale]/(routes)/profile/components/ProfileTabs.tsx
@@ -4,12 +4,12 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
-import { UserCircle, Lock, Globe, Code2, Mail, KeyRound } from "lucide-react";
+import { UserCircle, Lock, Globe, Code2, Mail, CalendarClock, KeyRound } from "lucide-react";
 
 // Do NOT import tab content components here — they are Server Components
 // and must be passed as ReactNode props from page.tsx
 
-type Tab = "profile" | "security" | "preferences" | "developer" | "emails" | "llms";
+type Tab = "profile" | "security" | "preferences" | "developer" | "emails" | "calendar" | "llms";
 
 const TAB_ICONS: Record<Tab, React.ElementType> = {
   profile: UserCircle,
@@ -17,6 +17,7 @@ const TAB_ICONS: Record<Tab, React.ElementType> = {
   preferences: Globe,
   developer: Code2,
   emails: Mail,
+  calendar: CalendarClock,
   llms: KeyRound,
 };
 
@@ -26,6 +27,7 @@ type Props = {
   preferencesContent: React.ReactNode;
   developerContent: React.ReactNode;
   emailsContent: React.ReactNode;
+  calendarContent: React.ReactNode;
   llmsContent: React.ReactNode;
 };
 
@@ -35,13 +37,14 @@ export function ProfileTabs({
   preferencesContent,
   developerContent,
   emailsContent,
+  calendarContent,
   llmsContent,
 }: Props) {
   const t = useTranslations("ProfilePage");
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const TAB_IDS: Tab[] = ["profile", "security", "preferences", "developer", "emails", "llms"];
+  const TAB_IDS: Tab[] = ["profile", "security", "preferences", "developer", "emails", "calendar", "llms"];
   const raw = searchParams.get("tab");
   const activeTab: Tab = TAB_IDS.includes(raw as Tab) ? (raw as Tab) : "profile";
 
@@ -51,6 +54,7 @@ export function ProfileTabs({
     { id: "preferences", label: t("tabs.preferences"), desc: t("tabs.preferencesDesc") },
     { id: "developer", label: t("tabs.developer"), desc: t("tabs.developerDesc") },
     { id: "emails", label: t("tabs.emails"), desc: t("tabs.emailsDesc") },
+    { id: "calendar", label: t("tabs.calendar"), desc: t("tabs.calendarDesc") },
     { id: "llms", label: t("tabs.llms"), desc: t("tabs.llmsDesc") },
   ];
 
@@ -62,6 +66,7 @@ export function ProfileTabs({
     preferences: preferencesContent,
     developer: developerContent,
     emails: emailsContent,
+    calendar: calendarContent,
     llms: llmsContent,
   };
 

--- a/app/[locale]/(routes)/profile/components/tabs/CalendarTabContent.tsx
+++ b/app/[locale]/(routes)/profile/components/tabs/CalendarTabContent.tsx
@@ -1,0 +1,9 @@
+import { CalendarConnectionsList } from "../CalendarConnectionsList";
+
+export function CalendarTabContent() {
+  return (
+    <div className="space-y-4">
+      <CalendarConnectionsList />
+    </div>
+  );
+}

--- a/app/[locale]/(routes)/profile/components/tabs/EmailAccountsTabContent.tsx
+++ b/app/[locale]/(routes)/profile/components/tabs/EmailAccountsTabContent.tsx
@@ -1,5 +1,6 @@
 import { getEmailAccounts } from "@/actions/emails/accounts";
 import { EmailAccountsList } from "../EmailAccountsList";
+import { CalendarConnectionsList } from "../CalendarConnectionsList";
 
 export async function EmailAccountsTabContent() {
   const accounts = await getEmailAccounts();
@@ -11,6 +12,7 @@ export async function EmailAccountsTabContent() {
         </h3>
         <EmailAccountsList accounts={accounts} />
       </div>
+      <CalendarConnectionsList />
     </div>
   );
 }

--- a/app/[locale]/(routes)/profile/components/tabs/EmailAccountsTabContent.tsx
+++ b/app/[locale]/(routes)/profile/components/tabs/EmailAccountsTabContent.tsx
@@ -1,6 +1,5 @@
 import { getEmailAccounts } from "@/actions/emails/accounts";
 import { EmailAccountsList } from "../EmailAccountsList";
-import { CalendarConnectionsList } from "../CalendarConnectionsList";
 
 export async function EmailAccountsTabContent() {
   const accounts = await getEmailAccounts();
@@ -12,7 +11,6 @@ export async function EmailAccountsTabContent() {
         </h3>
         <EmailAccountsList accounts={accounts} />
       </div>
-      <CalendarConnectionsList />
     </div>
   );
 }

--- a/app/[locale]/(routes)/profile/page.tsx
+++ b/app/[locale]/(routes)/profile/page.tsx
@@ -11,6 +11,7 @@ import { SecurityTabContent } from "./components/tabs/SecurityTabContent";
 import { PreferencesTabContent } from "./components/tabs/PreferencesTabContent";
 import { DeveloperTabContent } from "./components/tabs/DeveloperTabContent";
 import { EmailAccountsTabContent } from "./components/tabs/EmailAccountsTabContent";
+import { CalendarTabContent } from "./components/tabs/CalendarTabContent";
 import { LlmsTabContent } from "./components/tabs/LlmsTabContent";
 import { getUserApiKeys } from "./actions/api-keys";
 
@@ -35,6 +36,7 @@ const ProfilePage = async () => {
             preferencesContent={<PreferencesTabContent userId={data.id} />}
             developerContent={<DeveloperTabContent userId={data.id} />}
             emailsContent={<EmailAccountsTabContent />}
+            calendarContent={<CalendarTabContent />}
             llmsContent={<LlmsTabContent initialKeys={llmKeys} />}
           />
         </Suspense>

--- a/app/api/crm/calendar/webhooks/calendly/__tests__/route.test.ts
+++ b/app/api/crm/calendar/webhooks/calendly/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+jest.mock("@/lib/crm/calendar/calendly-settings", () => ({
+  getCalendlySettings: jest.fn(),
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({ ids: ["1"] }) },
+}));
+
+import { createHmac } from "crypto";
+import { NextRequest } from "next/server";
+import { getCalendlySettings } from "@/lib/crm/calendar/calendly-settings";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const settings = getCalendlySettings as jest.Mock;
+const send = inngest.send as jest.Mock;
+const KEY = "sk";
+
+function sign(body: string) {
+  const t = "1721400000";
+  const v1 = createHmac("sha256", KEY).update(`${t}.${body}`).digest("hex");
+  return `t=${t},v1=${v1}`;
+}
+
+function makeReq(body: object, signature?: string) {
+  const raw = JSON.stringify(body);
+  return new NextRequest("http://localhost/api/crm/calendar/webhooks/calendly", {
+    method: "POST",
+    body: raw,
+    headers: {
+      "content-type": "application/json",
+      ...(signature !== undefined
+        ? { "calendly-webhook-signature": signature }
+        : { "calendly-webhook-signature": sign(raw) }),
+    },
+  });
+}
+
+const CREATED = {
+  event: "invitee.created",
+  payload: {
+    uri: "https://api.calendly.com/scheduled_events/EV1/invitees/INV1",
+    email: "jane@client.com",
+    name: "Jane Doe",
+    scheduled_event: {
+      uri: "https://api.calendly.com/scheduled_events/EV1",
+      name: "Intro call",
+      start_time: "2026-07-21T10:00:00.000000Z",
+      end_time: "2026-07-21T10:30:00.000000Z",
+      event_memberships: [{ user_email: "rep@aqunama.com" }],
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  settings.mockResolvedValue({ apiToken: "tok", signingKey: KEY, webhookUri: null });
+});
+
+describe("POST /api/crm/calendar/webhooks/calendly", () => {
+  it("401 on bad signature", async () => {
+    const res = await POST(makeReq(CREATED, "t=1,v1=bad"));
+    expect(res.status).toBe(401);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("401 when no signing key is configured", async () => {
+    settings.mockResolvedValue({ apiToken: null, signingKey: null, webhookUri: null });
+    const res = await POST(makeReq(CREATED));
+    expect(res.status).toBe(401);
+  });
+
+  it("forwards invitee.created to inngest and ACKs", async () => {
+    const res = await POST(makeReq(CREATED));
+    expect(res.status).toBe(200);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "crm/calendar.event.received",
+        data: expect.objectContaining({
+          source: "calendly",
+          externalId: CREATED.payload.uri,
+          title: "Intro call",
+          counterpartyEmails: ["jane@client.com"],
+          hostEmail: "rep@aqunama.com",
+          status: "scheduled",
+        }),
+      })
+    );
+  });
+
+  it("maps invitee.canceled to status cancelled", async () => {
+    const res = await POST(makeReq({ ...CREATED, event: "invitee.canceled" }));
+    expect(res.status).toBe(200);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "cancelled" }),
+      })
+    );
+  });
+
+  it("ACKs 200 for unhandled event types without sending", async () => {
+    const res = await POST(makeReq({ event: "routing_form_submission.created", payload: {} }));
+    expect(res.status).toBe(200);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/crm/calendar/webhooks/calendly/route.ts
+++ b/app/api/crm/calendar/webhooks/calendly/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyCalendlySignature } from "@/lib/crm/calendar/calendly-signature";
+import { getCalendlySettings } from "@/lib/crm/calendar/calendly-settings";
+import { inngest } from "@/inngest/client";
+
+type CalendlyWebhookBody = {
+  event: string;
+  payload: {
+    uri?: string;
+    email?: string;
+    name?: string;
+    scheduled_event?: {
+      uri?: string;
+      name?: string;
+      start_time?: string;
+      end_time?: string;
+      event_memberships?: Array<{ user_email?: string }>;
+    };
+  };
+};
+
+export async function POST(req: NextRequest) {
+  const rawBody = await req.text();
+  const { signingKey } = await getCalendlySettings();
+
+  if (
+    !signingKey ||
+    !verifyCalendlySignature(
+      rawBody,
+      req.headers.get("calendly-webhook-signature"),
+      signingKey
+    )
+  ) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  let body: CalendlyWebhookBody;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    // Never bounce Calendly into disabling the subscription over a bad payload.
+    return NextResponse.json({ ok: true });
+  }
+
+  if (body.event !== "invitee.created" && body.event !== "invitee.canceled") {
+    return NextResponse.json({ ok: true });
+  }
+
+  const p = body.payload;
+  const ev = p.scheduled_event;
+  if (!p.uri || !ev?.start_time) return NextResponse.json({ ok: true });
+
+  await inngest.send({
+    name: "crm/calendar.event.received",
+    data: {
+      source: "calendly",
+      externalId: p.uri,
+      iCalUID: null,
+      connectionId: null,
+      title: ev.name ?? "Calendly meeting",
+      startAt: ev.start_time,
+      endAt: ev.end_time ?? null,
+      counterpartyEmails: p.email ? [p.email] : [],
+      hostEmail: ev.event_memberships?.[0]?.user_email ?? null,
+      status: body.event === "invitee.canceled" ? "cancelled" : "scheduled",
+      rawPayload: body,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/crm/calendar/webhooks/calendly/route.ts
+++ b/app/api/crm/calendar/webhooks/calendly/route.ts
@@ -48,7 +48,13 @@ export async function POST(req: NextRequest) {
 
   const p = body.payload;
   const ev = p.scheduled_event;
-  if (!p.uri || !ev?.start_time) return NextResponse.json({ ok: true });
+  if (!p.uri || !ev?.start_time) {
+    console.warn(
+      "[calendly-webhook] dropping event with missing uri/start_time",
+      body.event
+    );
+    return NextResponse.json({ ok: true });
+  }
 
   await inngest.send({
     name: "crm/calendar.event.received",

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -24,6 +24,7 @@ import { killRule } from "@/inngest/functions/crm/kill-rule";
 import { careTasks } from "@/inngest/functions/crm/care-tasks";
 import { recycleTargets } from "@/inngest/functions/crm/recycle-targets";
 import { renewalReminders } from "@/inngest/functions/crm/renewal-reminders";
+import { calendarProcessEvent } from "@/inngest/functions/calendar/process-event";
 import { enrichDocument } from "@/inngest/functions/documents/enrich-document";
 import { generateDocumentThumbnail } from "@/inngest/functions/documents/generate-thumbnail";
 import { syncExchangeRates } from "@/inngest/functions/ecb/sync-exchange-rates";
@@ -55,6 +56,7 @@ export const { GET, POST, PUT } = serve({
     careTasks,
     recycleTargets,
     renewalReminders,
+    calendarProcessEvent,
     enrichDocument,
     generateDocumentThumbnail,
     syncExchangeRates,

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -25,6 +25,8 @@ import { careTasks } from "@/inngest/functions/crm/care-tasks";
 import { recycleTargets } from "@/inngest/functions/crm/recycle-targets";
 import { renewalReminders } from "@/inngest/functions/crm/renewal-reminders";
 import { calendarProcessEvent } from "@/inngest/functions/calendar/process-event";
+import { googleCalendarSyncAll } from "@/inngest/functions/calendar/google-sync-all";
+import { googleCalendarSyncConnection } from "@/inngest/functions/calendar/google-sync-connection";
 import { enrichDocument } from "@/inngest/functions/documents/enrich-document";
 import { generateDocumentThumbnail } from "@/inngest/functions/documents/generate-thumbnail";
 import { syncExchangeRates } from "@/inngest/functions/ecb/sync-exchange-rates";
@@ -57,6 +59,8 @@ export const { GET, POST, PUT } = serve({
     recycleTargets,
     renewalReminders,
     calendarProcessEvent,
+    googleCalendarSyncAll,
+    googleCalendarSyncConnection,
     enrichDocument,
     generateDocumentThumbnail,
     syncExchangeRates,

--- a/app/api/profile/calendar-connections/[id]/route.ts
+++ b/app/api/profile/calendar-connections/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  const connection = await prismadb.calendarConnection.findUnique({ where: { id } });
+  if (!connection || connection.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  await prismadb.calendarConnection.delete({ where: { id } });
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/profile/calendar-connections/google/authorize/route.ts
+++ b/app/api/profile/calendar-connections/google/authorize/route.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "crypto";
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import { getGoogleAuthUrl } from "@/lib/crm/calendar/google";
@@ -7,5 +8,15 @@ export async function GET() {
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  return NextResponse.redirect(getGoogleAuthUrl());
+
+  const state = randomBytes(16).toString("hex");
+  const res = NextResponse.redirect(getGoogleAuthUrl(state));
+  res.cookies.set("gcal_oauth_state", state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 600,
+    path: "/api/profile/calendar-connections/google",
+  });
+  return res;
 }

--- a/app/api/profile/calendar-connections/google/authorize/route.ts
+++ b/app/api/profile/calendar-connections/google/authorize/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { getGoogleAuthUrl } from "@/lib/crm/calendar/google";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return NextResponse.redirect(getGoogleAuthUrl());
+}

--- a/app/api/profile/calendar-connections/google/callback/route.ts
+++ b/app/api/profile/calendar-connections/google/callback/route.ts
@@ -27,19 +27,19 @@ export async function GET(req: NextRequest) {
   }
   const code = req.nextUrl.searchParams.get("code");
   const appUrl = process.env.NEXT_PUBLIC_APP_URL!;
-  if (!code) return redirectAndClearState(`${appUrl}/profile?calendar=error`);
+  if (!code) return redirectAndClearState(`${appUrl}/profile?tab=calendar&calendar=error`);
 
   const cookieState = req.cookies.get(STATE_COOKIE)?.value;
   const queryState = req.nextUrl.searchParams.get("state");
   if (!cookieState || !queryState || cookieState !== queryState) {
-    return redirectAndClearState(`${appUrl}/profile?calendar=state-mismatch`);
+    return redirectAndClearState(`${appUrl}/profile?tab=calendar&calendar=state-mismatch`);
   }
 
   try {
     const auth = getGoogleOAuthClient();
     const { tokens } = await auth.getToken(code);
     if (!tokens.refresh_token) {
-      return redirectAndClearState(`${appUrl}/profile?calendar=no-refresh-token`);
+      return redirectAndClearState(`${appUrl}/profile?tab=calendar&calendar=no-refresh-token`);
     }
     auth.setCredentials(tokens);
 
@@ -47,7 +47,7 @@ export async function GET(req: NextRequest) {
     const primary = await calendar.calendarList.get({ calendarId: "primary" });
     const accountEmail = primary.data.id;
     if (!accountEmail) {
-      return redirectAndClearState(`${appUrl}/profile?calendar=error`);
+      return redirectAndClearState(`${appUrl}/profile?tab=calendar&calendar=error`);
     }
 
     await prismadb.calendarConnection.upsert({
@@ -76,12 +76,12 @@ export async function GET(req: NextRequest) {
       },
     });
 
-    return redirectAndClearState(`${appUrl}/profile?calendar=connected`);
+    return redirectAndClearState(`${appUrl}/profile?tab=calendar&calendar=connected`);
   } catch (error) {
     console.error(
       "[google-calendar-callback]",
       error instanceof Error ? error.message : String(error)
     );
-    return redirectAndClearState(`${appUrl}/profile?calendar=error`);
+    return redirectAndClearState(`${appUrl}/profile?tab=calendar&calendar=error`);
   }
 }

--- a/app/api/profile/calendar-connections/google/callback/route.ts
+++ b/app/api/profile/calendar-connections/google/callback/route.ts
@@ -5,6 +5,21 @@ import { prismadb } from "@/lib/prisma";
 import { encrypt } from "@/lib/email-crypto";
 import { getGoogleOAuthClient } from "@/lib/crm/calendar/google";
 
+const STATE_COOKIE = "gcal_oauth_state";
+const STATE_COOKIE_PATH = "/api/profile/calendar-connections/google";
+
+function redirectAndClearState(url: string) {
+  const res = NextResponse.redirect(url);
+  res.cookies.set(STATE_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 0,
+    path: STATE_COOKIE_PATH,
+  });
+  return res;
+}
+
 export async function GET(req: NextRequest) {
   const session = await getSession();
   if (!session?.user?.id) {
@@ -12,13 +27,19 @@ export async function GET(req: NextRequest) {
   }
   const code = req.nextUrl.searchParams.get("code");
   const appUrl = process.env.NEXT_PUBLIC_APP_URL!;
-  if (!code) return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+  if (!code) return redirectAndClearState(`${appUrl}/profile?calendar=error`);
+
+  const cookieState = req.cookies.get(STATE_COOKIE)?.value;
+  const queryState = req.nextUrl.searchParams.get("state");
+  if (!cookieState || !queryState || cookieState !== queryState) {
+    return redirectAndClearState(`${appUrl}/profile?calendar=state-mismatch`);
+  }
 
   try {
     const auth = getGoogleOAuthClient();
     const { tokens } = await auth.getToken(code);
     if (!tokens.refresh_token) {
-      return NextResponse.redirect(`${appUrl}/profile?calendar=no-refresh-token`);
+      return redirectAndClearState(`${appUrl}/profile?calendar=no-refresh-token`);
     }
     auth.setCredentials(tokens);
 
@@ -26,7 +47,7 @@ export async function GET(req: NextRequest) {
     const primary = await calendar.calendarList.get({ calendarId: "primary" });
     const accountEmail = primary.data.id;
     if (!accountEmail) {
-      return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+      return redirectAndClearState(`${appUrl}/profile?calendar=error`);
     }
 
     await prismadb.calendarConnection.upsert({
@@ -55,9 +76,12 @@ export async function GET(req: NextRequest) {
       },
     });
 
-    return NextResponse.redirect(`${appUrl}/profile?calendar=connected`);
+    return redirectAndClearState(`${appUrl}/profile?calendar=connected`);
   } catch (error) {
-    console.error("[google-calendar-callback]", error);
-    return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+    console.error(
+      "[google-calendar-callback]",
+      error instanceof Error ? error.message : String(error)
+    );
+    return redirectAndClearState(`${appUrl}/profile?calendar=error`);
   }
 }

--- a/app/api/profile/calendar-connections/google/callback/route.ts
+++ b/app/api/profile/calendar-connections/google/callback/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { google } from "googleapis";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { encrypt } from "@/lib/email-crypto";
+import { getGoogleOAuthClient } from "@/lib/crm/calendar/google";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const code = req.nextUrl.searchParams.get("code");
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL!;
+  if (!code) return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+
+  try {
+    const auth = getGoogleOAuthClient();
+    const { tokens } = await auth.getToken(code);
+    if (!tokens.refresh_token) {
+      return NextResponse.redirect(`${appUrl}/profile?calendar=no-refresh-token`);
+    }
+    auth.setCredentials(tokens);
+
+    const calendar = google.calendar({ version: "v3", auth });
+    const primary = await calendar.calendarList.get({ calendarId: "primary" });
+    const accountEmail = primary.data.id;
+    if (!accountEmail) {
+      return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+    }
+
+    await prismadb.calendarConnection.upsert({
+      where: {
+        userId_provider_accountEmail: {
+          userId: session.user.id,
+          provider: "google",
+          accountEmail,
+        },
+      },
+      update: {
+        refreshTokenEncrypted: encrypt(tokens.refresh_token),
+        accessTokenEncrypted: tokens.access_token ? encrypt(tokens.access_token) : null,
+        tokenExpiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+        isActive: true,
+        lastSyncError: null,
+        syncToken: null, // force a fresh full-window sync
+      },
+      create: {
+        userId: session.user.id,
+        provider: "google",
+        accountEmail,
+        refreshTokenEncrypted: encrypt(tokens.refresh_token),
+        accessTokenEncrypted: tokens.access_token ? encrypt(tokens.access_token) : null,
+        tokenExpiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+      },
+    });
+
+    return NextResponse.redirect(`${appUrl}/profile?calendar=connected`);
+  } catch (error) {
+    console.error("[google-calendar-callback]", error);
+    return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+  }
+}

--- a/app/api/profile/calendar-connections/route.ts
+++ b/app/api/profile/calendar-connections/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const connections = await prismadb.calendarConnection.findMany({
+    where: { userId: session.user.id },
+    select: {
+      id: true,
+      provider: true,
+      accountEmail: true,
+      isActive: true,
+      lastSyncedAt: true,
+      lastSyncError: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+  return NextResponse.json({ connections });
+}

--- a/docs/superpowers/plans/2026-07-16-aqunama-roadmap.md
+++ b/docs/superpowers/plans/2026-07-16-aqunama-roadmap.md
@@ -37,7 +37,11 @@ Original stub (for reference):
 - **Flow:** rep attaches the SOW/quote document to the opportunity and requests approval → manager/admin (CSO) sees a pending-approvals view and approves/rejects (guarded by `isManagerOrAdmin`) → only approved deals can move to the Qualified stage (transition guard) → approval decisions audit-logged and email-notified.
 - **Upgrade path:** a structured `crm_Quotes` entity with line items + PDF (reusing the invoice `@react-pdf/renderer` pipeline) stays available as a later enhancement; nothing in the minimal flow blocks it.
 
-## Plan 4 — Calendar: Full Two-Way Sync (gap G-05) — stub, largest single item
+## Plan 4 — Calendar Sync ✅ Milestones A+B implemented (2026-07-19)
+
+Full plan: `docs/superpowers/plans/2026-07-19-aqunama-p4-calendar-sync.md` — spec: `docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md`. Decisions: A+B only (outbound two-way deferred); org-scope Calendly webhook; Workspace-internal Google OAuth, readonly scope, 15-min Inngest polling; unmatched Calendly invitees auto-create Targets; synced meetings restart the 45-day kill clock.
+
+Original stub (for reference):
 
 Decision was full sync (not webhook-only). Suggested internal milestones so value ships early:
 

--- a/docs/superpowers/plans/2026-07-19-aqunama-p4-calendar-sync.md
+++ b/docs/superpowers/plans/2026-07-19-aqunama-p4-calendar-sync.md
@@ -1,0 +1,2036 @@
+# AQUNAMA Phase 4 — Calendar Sync (Calendly + Google Calendar inbound) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Booked calls land in the CRM automatically — Calendly bookings arrive via an org-scope webhook, Google Calendar meetings arrive via 15-minute Inngest polling, and both become `meeting` activities linked to the matching CRM record.
+
+**Architecture:** Two inbound pipelines (Calendly webhook route → Inngest event; Google `events.list` incremental polling → same Inngest event) converge on one shared processor `lib/crm/calendar/sync.ts` that matches attendee emails to contacts/targets/leads, dedups cross-source, and upserts idempotent meeting activities. Spec: `docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md`.
+
+**Tech Stack:** Next.js 16 App Router, Prisma 7 (PostgreSQL), Inngest 4, `googleapis` (new dependency), jest 30, existing `lib/email-crypto.ts` AES helper.
+
+## Global Constraints
+
+- **Migrations: do NOT run `prisma migrate dev` against the dev DB (known drift).** Author via `pnpm exec prisma migrate diff --from-schema-datamodel <git-show-of-old-schema> --to-schema-datamodel prisma/schema.prisma --script` into a timestamped migration folder, then verify by fresh-DB replay (disposable pgvector container) — same procedure as Phases 1–3.
+- Meeting activities are plain `crm_Activities` rows (`type: meeting`) linked via `crm_ActivityLinks`; the Phase 2 kill clock (`lib/crm/client-activity.ts`) must need **zero changes**.
+- Unmatched Calendly invitee → auto-create `crm_Targets`; unmatched Google event → skip, store nothing.
+- Google scope is `https://www.googleapis.com/auth/calendar.readonly` only (inbound; Milestone C adds write later).
+- Tokens/secrets at rest are encrypted with `encrypt`/`decrypt` from `@/lib/email-crypto`.
+- All work on `dev` branch; commit after every task; conventional commit messages.
+- Tests: `pnpm jest <path>` for a single file, `pnpm test` for the full suite (921 baseline, no known failures).
+- entityType strings for `crm_ActivityLinks`: `"account" | "contact" | "lead" | "opportunity" | "target"`.
+- Inngest event name for processing: `"crm/calendar.event.received"`; Google per-connection sync event: `"crm/calendar.google-sync"`.
+
+---
+
+### Task 1: Prisma schema + migration
+
+**Files:**
+- Modify: `prisma/schema.prisma` (add enum + 2 models; back-relations on `Users` and `crm_Activities`)
+- Create: `prisma/migrations/<timestamp>_aqunama_p4_calendar_sync/migration.sql`
+
+**Interfaces:**
+- Produces: `CalendarConnection` and `crm_CalendarEvents` Prisma models used by every later task. Unique keys: `CalendarConnection @@unique([userId, provider, accountEmail])`, `crm_CalendarEvents @@unique([source, externalId])` (compound name `source_externalId`).
+
+- [ ] **Step 1: Add models to `prisma/schema.prisma`**
+
+Append near the EMAIL FEATURE section (after `EmailEmbedding`):
+
+```prisma
+// ============================================
+// CALENDAR SYNC (AQUNAMA Phase 4)
+// ============================================
+
+enum CalendarProvider {
+  google
+}
+
+model CalendarConnection {
+  id                    String           @id @default(uuid()) @db.Uuid
+  userId                String           @db.Uuid
+  provider              CalendarProvider
+  accountEmail          String
+  accessTokenEncrypted  String?
+  refreshTokenEncrypted String
+  tokenExpiresAt        DateTime?
+  syncToken             String?
+  isActive              Boolean          @default(true)
+  lastSyncedAt          DateTime?
+  lastSyncError         String?
+  createdAt             DateTime         @default(now())
+  updatedAt             DateTime         @updatedAt
+
+  user           Users               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  calendarEvents crm_CalendarEvents[]
+
+  @@unique([userId, provider, accountEmail])
+  @@index([userId])
+  @@index([isActive])
+}
+
+model crm_CalendarEvents {
+  id             String    @id @default(uuid()) @db.Uuid
+  source         String
+  externalId     String
+  iCalUID        String?
+  connectionId   String?   @db.Uuid
+  activityId     String    @db.Uuid
+  startAt        DateTime
+  endAt          DateTime?
+  attendeeEmails Json      @default("[]")
+  status         String    @default("scheduled")
+  rawPayload     Json?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  connection CalendarConnection? @relation(fields: [connectionId], references: [id], onDelete: SetNull)
+  activity   crm_Activities      @relation(fields: [activityId], references: [id], onDelete: Cascade)
+
+  @@unique([source, externalId])
+  @@index([iCalUID])
+  @@index([activityId])
+  @@index([startAt])
+}
+```
+
+Add back-relations:
+- In `model Users` (next to `emailAccounts EmailAccount[]`): `calendarConnections CalendarConnection[]`
+- In `model crm_Activities` (next to `links`): `calendar_events crm_CalendarEvents[]`
+
+- [ ] **Step 2: Generate the migration SQL (no `migrate dev`)**
+
+```bash
+git show HEAD:prisma/schema.prisma > /tmp/schema-old.prisma
+mkdir -p prisma/migrations/$(date +%Y%m%d%H%M%S)_aqunama_p4_calendar_sync
+pnpm exec prisma migrate diff \
+  --from-schema-datamodel /tmp/schema-old.prisma \
+  --to-schema-datamodel prisma/schema.prisma \
+  --script > prisma/migrations/*_aqunama_p4_calendar_sync/migration.sql
+```
+
+Inspect the SQL: it must create `CalendarProvider` enum, both tables, FKs, unique + regular indexes — nothing else (no drops).
+
+- [ ] **Step 3: Verify by fresh-DB replay**
+
+```bash
+docker run -d --name p4-migrate-check -e POSTGRES_PASSWORD=postgres -p 55432:5432 pgvector/pgvector:pg16
+sleep 3
+docker exec p4-migrate-check psql -U postgres -c 'CREATE DATABASE p4;'
+DATABASE_URL=postgresql://postgres:postgres@localhost:55432/p4 pnpm exec prisma migrate deploy
+docker rm -f p4-migrate-check
+```
+
+Expected: all migrations apply cleanly, ending with `…_aqunama_p4_calendar_sync`.
+
+- [ ] **Step 4: Regenerate client + typecheck**
+
+```bash
+pnpm exec prisma generate && pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prisma
+git commit -m "feat(calendar): CalendarConnection + crm_CalendarEvents models for Phase 4 sync"
+```
+
+---
+
+### Task 2: Calendly webhook signature verification
+
+**Files:**
+- Create: `lib/crm/calendar/calendly-signature.ts`
+- Test: `lib/crm/calendar/__tests__/calendly-signature.test.ts`
+
+**Interfaces:**
+- Produces: `verifyCalendlySignature(rawBody: string, header: string | null, signingKey: string): boolean`. Header format is Calendly's `t=<unix>,v1=<hex hmac of "<t>.<rawBody>">`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// lib/crm/calendar/__tests__/calendly-signature.test.ts
+import { createHmac } from "crypto";
+import { verifyCalendlySignature } from "../calendly-signature";
+
+const KEY = "test-signing-key";
+
+function sign(body: string, t = "1721400000", key = KEY) {
+  const v1 = createHmac("sha256", key).update(`${t}.${body}`).digest("hex");
+  return `t=${t},v1=${v1}`;
+}
+
+describe("verifyCalendlySignature", () => {
+  it("accepts a valid signature", () => {
+    const body = JSON.stringify({ event: "invitee.created" });
+    expect(verifyCalendlySignature(body, sign(body), KEY)).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    expect(verifyCalendlySignature('{"a":2}', sign('{"a":1}'), KEY)).toBe(false);
+  });
+
+  it("rejects a wrong key", () => {
+    const body = "{}";
+    expect(verifyCalendlySignature(body, sign(body, "1721400000", "other"), KEY)).toBe(false);
+  });
+
+  it("rejects missing or malformed headers", () => {
+    expect(verifyCalendlySignature("{}", null, KEY)).toBe(false);
+    expect(verifyCalendlySignature("{}", "garbage", KEY)).toBe(false);
+    expect(verifyCalendlySignature("{}", "t=123", KEY)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/calendly-signature.test.ts`
+Expected: FAIL — cannot find module `../calendly-signature`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// lib/crm/calendar/calendly-signature.ts
+import { createHmac, timingSafeEqual } from "crypto";
+
+// Calendly signs webhooks with: Calendly-Webhook-Signature: t=<unix>,v1=<hex>
+// where v1 = HMAC-SHA256(signingKey, `${t}.${rawBody}`).
+export function verifyCalendlySignature(
+  rawBody: string,
+  header: string | null,
+  signingKey: string
+): boolean {
+  if (!header || !signingKey) return false;
+  const parts = Object.fromEntries(
+    header.split(",").map((p) => p.trim().split("=", 2) as [string, string])
+  );
+  const t = parts["t"];
+  const v1 = parts["v1"];
+  if (!t || !v1) return false;
+
+  const expected = createHmac("sha256", signingKey)
+    .update(`${t}.${rawBody}`)
+    .digest("hex");
+  const a = Buffer.from(v1, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/calendly-signature.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/crm/calendar
+git commit -m "feat(calendar): Calendly webhook HMAC signature verification"
+```
+
+---
+
+### Task 3: Shared types + attendee matcher
+
+**Files:**
+- Create: `lib/crm/calendar/types.ts`
+- Create: `lib/crm/calendar/match.ts`
+- Test: `lib/crm/calendar/__tests__/match.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```typescript
+// types.ts
+export type CalendarSource = "calendly" | "google";
+export type CalendarEventInput = {
+  source: CalendarSource;
+  externalId: string;
+  iCalUID?: string | null;
+  connectionId?: string | null;
+  title: string;
+  startAt: Date;
+  endAt?: Date | null;
+  counterpartyEmails: string[];
+  hostEmail?: string | null;
+  status: "scheduled" | "cancelled";
+  rawPayload?: unknown;
+};
+export type EntityLink = { entityType: string; entityId: string };
+export type UpsertResult = {
+  action: "created" | "updated" | "cancelled" | "skipped";
+  reason?: string;
+  activityId?: string;
+};
+```
+
+- `matchCounterparty(emails: string[]): Promise<EntityLink[]>` — returns `[]` when nothing matches. Priority: contact (+ its account + single open opportunity) → target → lead.
+
+- [ ] **Step 1: Create `lib/crm/calendar/types.ts`** with exactly the code block above.
+
+- [ ] **Step 2: Write the failing matcher test**
+
+```typescript
+// lib/crm/calendar/__tests__/match.test.ts
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contacts: { findFirst: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+    crm_Leads: { findFirst: jest.fn() },
+    crm_Opportunities: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { matchCounterparty } from "../match";
+
+const contacts = prismadb.crm_Contacts.findFirst as jest.Mock;
+const targets = prismadb.crm_Targets.findFirst as jest.Mock;
+const leads = prismadb.crm_Leads.findFirst as jest.Mock;
+const opps = prismadb.crm_Opportunities.findMany as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("matchCounterparty", () => {
+  it("returns [] for empty input without querying", async () => {
+    expect(await matchCounterparty([])).toEqual([]);
+    expect(contacts).not.toHaveBeenCalled();
+  });
+
+  it("matches contact and links account + single open opportunity", async () => {
+    contacts.mockResolvedValue({ id: "c1", accountsIDs: "a1" });
+    opps.mockResolvedValue([{ id: "o1" }]);
+    const links = await matchCounterparty(["jane@client.com"]);
+    expect(links).toEqual([
+      { entityType: "contact", entityId: "c1" },
+      { entityType: "account", entityId: "a1" },
+      { entityType: "opportunity", entityId: "o1" },
+    ]);
+  });
+
+  it("skips opportunity link when the account has several open deals", async () => {
+    contacts.mockResolvedValue({ id: "c1", accountsIDs: "a1" });
+    opps.mockResolvedValue([{ id: "o1" }, { id: "o2" }]);
+    const links = await matchCounterparty(["jane@client.com"]);
+    expect(links).toEqual([
+      { entityType: "contact", entityId: "c1" },
+      { entityType: "account", entityId: "a1" },
+    ]);
+  });
+
+  it("falls back to target, then lead", async () => {
+    contacts.mockResolvedValue(null);
+    targets.mockResolvedValue({ id: "t1" });
+    expect(await matchCounterparty(["x@y.com"])).toEqual([
+      { entityType: "target", entityId: "t1" },
+    ]);
+
+    targets.mockResolvedValue(null);
+    leads.mockResolvedValue({ id: "l1" });
+    expect(await matchCounterparty(["x@y.com"])).toEqual([
+      { entityType: "lead", entityId: "l1" },
+    ]);
+  });
+
+  it("returns [] when nothing matches", async () => {
+    contacts.mockResolvedValue(null);
+    targets.mockResolvedValue(null);
+    leads.mockResolvedValue(null);
+    expect(await matchCounterparty(["x@y.com"])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/match.test.ts`
+Expected: FAIL — cannot find module `../match`.
+
+- [ ] **Step 4: Implement the matcher**
+
+```typescript
+// lib/crm/calendar/match.ts
+import { prismadb } from "@/lib/prisma";
+import type { EntityLink } from "./types";
+
+// Spec matching order: contact (+account +single open opp) -> target -> lead.
+export async function matchCounterparty(emails: string[]): Promise<EntityLink[]> {
+  const normalized = emails.map((e) => e.trim().toLowerCase()).filter(Boolean);
+  if (normalized.length === 0) return [];
+
+  const contact = await prismadb.crm_Contacts.findFirst({
+    where: {
+      OR: [
+        { email: { in: normalized, mode: "insensitive" } },
+        { personal_email: { in: normalized, mode: "insensitive" } },
+      ],
+    },
+    select: { id: true, accountsIDs: true },
+  });
+  if (contact) {
+    const links: EntityLink[] = [{ entityType: "contact", entityId: contact.id }];
+    if (contact.accountsIDs) {
+      links.push({ entityType: "account", entityId: contact.accountsIDs });
+      const open = await prismadb.crm_Opportunities.findMany({
+        where: { account: contact.accountsIDs, status: "ACTIVE", deletedAt: null },
+        select: { id: true },
+        take: 2,
+      });
+      if (open.length === 1) {
+        links.push({ entityType: "opportunity", entityId: open[0].id });
+      }
+    }
+    return links;
+  }
+
+  const target = await prismadb.crm_Targets.findFirst({
+    where: {
+      deletedAt: null,
+      OR: [
+        { email: { in: normalized, mode: "insensitive" } },
+        { personal_email: { in: normalized, mode: "insensitive" } },
+        { company_email: { in: normalized, mode: "insensitive" } },
+      ],
+    },
+    select: { id: true },
+  });
+  if (target) return [{ entityType: "target", entityId: target.id }];
+
+  const lead = await prismadb.crm_Leads.findFirst({
+    where: { email: { in: normalized, mode: "insensitive" } },
+    select: { id: true },
+  });
+  if (lead) return [{ entityType: "lead", entityId: lead.id }];
+
+  return [];
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/match.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/crm/calendar
+git commit -m "feat(calendar): counterparty email matcher (contact > target > lead)"
+```
+
+---
+
+### Task 4: Shared processor `upsertCalendarEvent`
+
+**Files:**
+- Create: `lib/crm/calendar/sync.ts`
+- Test: `lib/crm/calendar/__tests__/sync.test.ts`
+
+**Interfaces:**
+- Consumes: `matchCounterparty` (Task 3), `CalendarEventInput`/`UpsertResult` (Task 3).
+- Produces: `upsertCalendarEvent(input: CalendarEventInput): Promise<UpsertResult>` — the single write path both pipelines call. Idempotent on `(source, externalId)`.
+
+Behavior matrix (from the spec):
+1. Existing mapping + incoming `cancelled` → set mapping + activity to cancelled → `{action:"cancelled"}`.
+2. Existing mapping + changed `startAt` → update mapping + activity date → `{action:"updated"}`.
+3. Existing mapping, no relevant change → `{action:"skipped", reason:"unchanged"}`.
+4. New + `cancelled` → `{action:"skipped", reason:"cancel-for-unknown"}`.
+5. New google event that duplicates a Calendly booking (same `startAt` + overlapping attendee email in a `source:"calendly"` row) → `{action:"skipped", reason:"duplicate-of-calendly"}`.
+6. New, no match: google → `{action:"skipped", reason:"no-match"}`; calendly → create `crm_Targets` (invitee name/email, tag `book-a-call`, `created_by` = host user when resolvable) and link to it.
+7. New, matched (or target created) → create `crm_Activities` (`type:"meeting"`, `status:"scheduled"`, `date:startAt`, `duration` = minutes between start/end, `metadata:{calendarSource: source}`, `createdBy` = host user id if resolvable, `links.create` = entity links) + `crm_CalendarEvents` mapping row → `{action:"created", activityId}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// lib/crm/calendar/__tests__/sync.test.ts
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_CalendarEvents: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    crm_Activities: { create: jest.fn(), update: jest.fn() },
+    crm_Targets: { create: jest.fn() },
+    users: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("../match", () => ({ matchCounterparty: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { matchCounterparty } from "../match";
+import { upsertCalendarEvent } from "../sync";
+import type { CalendarEventInput } from "../types";
+
+const mapping = prismadb.crm_CalendarEvents;
+const findUnique = mapping.findUnique as jest.Mock;
+const findMany = mapping.findMany as jest.Mock;
+const createMapping = mapping.create as jest.Mock;
+const updateMapping = mapping.update as jest.Mock;
+const createActivity = prismadb.crm_Activities.create as jest.Mock;
+const updateActivity = prismadb.crm_Activities.update as jest.Mock;
+const createTarget = prismadb.crm_Targets.create as jest.Mock;
+const findUser = prismadb.users.findFirst as jest.Mock;
+const match = matchCounterparty as jest.Mock;
+
+function input(overrides: Partial<CalendarEventInput> = {}): CalendarEventInput {
+  return {
+    source: "calendly",
+    externalId: "https://api.calendly.com/scheduled_events/EV1/invitees/INV1",
+    title: "Intro call",
+    startAt: new Date("2026-07-21T10:00:00Z"),
+    endAt: new Date("2026-07-21T10:30:00Z"),
+    counterpartyEmails: ["jane@client.com"],
+    hostEmail: "rep@aqunama.com",
+    status: "scheduled",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findUnique.mockResolvedValue(null);
+  findMany.mockResolvedValue([]);
+  findUser.mockResolvedValue(null);
+  createActivity.mockResolvedValue({ id: "act1" });
+  createMapping.mockResolvedValue({ id: "map1" });
+});
+
+describe("upsertCalendarEvent", () => {
+  it("creates activity + mapping for a matched event", async () => {
+    match.mockResolvedValue([{ entityType: "contact", entityId: "c1" }]);
+    const res = await upsertCalendarEvent(input());
+    expect(res).toEqual({ action: "created", activityId: "act1" });
+    expect(createActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "meeting",
+          status: "scheduled",
+          duration: 30,
+          links: { create: [{ entityType: "contact", entityId: "c1" }] },
+        }),
+      })
+    );
+    expect(createMapping).toHaveBeenCalled();
+  });
+
+  it("cancels an existing mapping + activity", async () => {
+    findUnique.mockResolvedValue({
+      id: "map1", activityId: "act1", status: "scheduled",
+      startAt: new Date("2026-07-21T10:00:00Z"),
+    });
+    const res = await upsertCalendarEvent(input({ status: "cancelled" }));
+    expect(res.action).toBe("cancelled");
+    expect(updateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "act1" },
+        data: expect.objectContaining({ status: "cancelled" }),
+      })
+    );
+  });
+
+  it("updates activity date on reschedule", async () => {
+    findUnique.mockResolvedValue({
+      id: "map1", activityId: "act1", status: "scheduled",
+      startAt: new Date("2026-07-21T10:00:00Z"),
+    });
+    const res = await upsertCalendarEvent(
+      input({ startAt: new Date("2026-07-22T09:00:00Z") })
+    );
+    expect(res.action).toBe("updated");
+    expect(updateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ date: new Date("2026-07-22T09:00:00Z") }),
+      })
+    );
+  });
+
+  it("skips unchanged existing events", async () => {
+    findUnique.mockResolvedValue({
+      id: "map1", activityId: "act1", status: "scheduled",
+      startAt: new Date("2026-07-21T10:00:00Z"),
+    });
+    const res = await upsertCalendarEvent(input());
+    expect(res).toEqual({ action: "skipped", reason: "unchanged" });
+  });
+
+  it("skips a cancel for an unknown event", async () => {
+    const res = await upsertCalendarEvent(input({ status: "cancelled" }));
+    expect(res).toEqual({ action: "skipped", reason: "cancel-for-unknown" });
+  });
+
+  it("skips a google event that duplicates a calendly booking", async () => {
+    findMany.mockResolvedValue([
+      { attendeeEmails: ["jane@client.com"] },
+    ]);
+    const res = await upsertCalendarEvent(
+      input({ source: "google", externalId: "gev1", connectionId: "conn1" })
+    );
+    expect(res).toEqual({ action: "skipped", reason: "duplicate-of-calendly" });
+    expect(createActivity).not.toHaveBeenCalled();
+  });
+
+  it("skips unmatched google events", async () => {
+    match.mockResolvedValue([]);
+    const res = await upsertCalendarEvent(
+      input({ source: "google", externalId: "gev1", connectionId: "conn1" })
+    );
+    expect(res).toEqual({ action: "skipped", reason: "no-match" });
+    expect(createTarget).not.toHaveBeenCalled();
+  });
+
+  it("creates a Target for unmatched calendly invitees, assigned to the host rep", async () => {
+    match.mockResolvedValue([]);
+    findUser.mockResolvedValue({ id: "rep1" });
+    createTarget.mockResolvedValue({ id: "t-new" });
+    const res = await upsertCalendarEvent(
+      input({ rawPayload: { payload: { name: "Jane Doe" } } })
+    );
+    expect(res.action).toBe("created");
+    expect(createTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          first_name: "Jane",
+          last_name: "Doe",
+          email: "jane@client.com",
+          tags: ["book-a-call"],
+          created_by: "rep1",
+        }),
+      })
+    );
+    expect(createActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          links: { create: [{ entityType: "target", entityId: "t-new" }] },
+        }),
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/sync.test.ts`
+Expected: FAIL — cannot find module `../sync`.
+
+- [ ] **Step 3: Implement the processor**
+
+```typescript
+// lib/crm/calendar/sync.ts
+import { prismadb } from "@/lib/prisma";
+import { matchCounterparty } from "./match";
+import type { CalendarEventInput, EntityLink, UpsertResult } from "./types";
+
+function inviteeName(input: CalendarEventInput): { first: string | null; last: string } {
+  const raw =
+    (input.rawPayload as { payload?: { name?: string } } | undefined)?.payload?.name ??
+    input.counterpartyEmails[0] ??
+    "Unknown";
+  const parts = raw.trim().split(/\s+/);
+  if (parts.length === 1) return { first: null, last: parts[0] };
+  return { first: parts.slice(0, -1).join(" "), last: parts[parts.length - 1] };
+}
+
+async function resolveHostUserId(hostEmail: string | null | undefined): Promise<string | null> {
+  if (!hostEmail) return null;
+  const user = await prismadb.users.findFirst({
+    where: { email: hostEmail },
+    select: { id: true },
+  });
+  return user?.id ?? null;
+}
+
+export async function upsertCalendarEvent(input: CalendarEventInput): Promise<UpsertResult> {
+  const existing = await prismadb.crm_CalendarEvents.findUnique({
+    where: { source_externalId: { source: input.source, externalId: input.externalId } },
+  });
+
+  if (existing) {
+    if (input.status === "cancelled" && existing.status !== "cancelled") {
+      await prismadb.crm_CalendarEvents.update({
+        where: { id: existing.id },
+        data: { status: "cancelled", rawPayload: (input.rawPayload as object) ?? undefined },
+      });
+      await prismadb.crm_Activities.update({
+        where: { id: existing.activityId },
+        data: { status: "cancelled" },
+      });
+      return { action: "cancelled", activityId: existing.activityId };
+    }
+    if (
+      input.status === "scheduled" &&
+      existing.startAt.getTime() !== input.startAt.getTime()
+    ) {
+      await prismadb.crm_CalendarEvents.update({
+        where: { id: existing.id },
+        data: {
+          startAt: input.startAt,
+          endAt: input.endAt ?? null,
+          status: "scheduled",
+          rawPayload: (input.rawPayload as object) ?? undefined,
+        },
+      });
+      await prismadb.crm_Activities.update({
+        where: { id: existing.activityId },
+        data: { date: input.startAt, status: "scheduled" },
+      });
+      return { action: "updated", activityId: existing.activityId };
+    }
+    return { action: "skipped", reason: "unchanged" };
+  }
+
+  if (input.status === "cancelled") {
+    return { action: "skipped", reason: "cancel-for-unknown" };
+  }
+
+  // Cross-source dedup: a Calendly booking also appears on the rep's Google
+  // Calendar. Skip google events whose start time + attendee already exist
+  // as a calendly-sourced row.
+  if (input.source === "google") {
+    const sameSlot = await prismadb.crm_CalendarEvents.findMany({
+      where: { source: "calendly", startAt: input.startAt },
+      select: { attendeeEmails: true },
+    });
+    const mine = new Set(input.counterpartyEmails.map((e) => e.toLowerCase()));
+    const duplicate = sameSlot.some((row) =>
+      (row.attendeeEmails as string[]).some((e) => mine.has(e.toLowerCase()))
+    );
+    if (duplicate) return { action: "skipped", reason: "duplicate-of-calendly" };
+  }
+
+  const hostUserId = await resolveHostUserId(input.hostEmail);
+  let links: EntityLink[] = await matchCounterparty(input.counterpartyEmails);
+
+  if (links.length === 0) {
+    if (input.source === "google") return { action: "skipped", reason: "no-match" };
+    // Calendly no-match: a booking from an unknown person is a new lead ->
+    // auto-create a Target (spec: source "Book-a-call").
+    const { first, last } = inviteeName(input);
+    const target = await prismadb.crm_Targets.create({
+      data: {
+        first_name: first,
+        last_name: last,
+        email: input.counterpartyEmails[0] ?? null,
+        tags: ["book-a-call"],
+        created_by: hostUserId,
+      },
+    });
+    links = [{ entityType: "target", entityId: target.id }];
+  }
+
+  const durationMinutes =
+    input.endAt != null
+      ? Math.max(0, Math.round((input.endAt.getTime() - input.startAt.getTime()) / 60000))
+      : null;
+
+  const activity = await prismadb.crm_Activities.create({
+    data: {
+      type: "meeting",
+      title: input.title,
+      date: input.startAt,
+      duration: durationMinutes,
+      status: "scheduled",
+      metadata: { calendarSource: input.source },
+      createdBy: hostUserId,
+      links: { create: links },
+    },
+  });
+
+  await prismadb.crm_CalendarEvents.create({
+    data: {
+      source: input.source,
+      externalId: input.externalId,
+      iCalUID: input.iCalUID ?? null,
+      connectionId: input.connectionId ?? null,
+      activityId: activity.id,
+      startAt: input.startAt,
+      endAt: input.endAt ?? null,
+      attendeeEmails: input.counterpartyEmails,
+      status: "scheduled",
+      rawPayload: (input.rawPayload as object) ?? undefined,
+    },
+  });
+
+  return { action: "created", activityId: activity.id };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/sync.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/crm/calendar
+git commit -m "feat(calendar): shared idempotent calendar-event processor"
+```
+
+---
+
+### Task 5: Inngest processing function + registration
+
+**Files:**
+- Create: `inngest/functions/calendar/process-event.ts`
+- Modify: `app/api/inngest/route.ts` (import + register)
+
+**Interfaces:**
+- Consumes: `upsertCalendarEvent` (Task 4).
+- Produces: Inngest function `calendarProcessEvent` triggered by `"crm/calendar.event.received"`. Event `data` is a JSON-serialized `CalendarEventInput` (dates as ISO strings — this function revives them).
+
+- [ ] **Step 1: Implement the function**
+
+```typescript
+// inngest/functions/calendar/process-event.ts
+import { inngest } from "@/inngest/client";
+import { upsertCalendarEvent } from "@/lib/crm/calendar/sync";
+import type { CalendarEventInput, CalendarSource } from "@/lib/crm/calendar/types";
+
+type WireEvent = Omit<CalendarEventInput, "startAt" | "endAt" | "source"> & {
+  source: CalendarSource;
+  startAt: string;
+  endAt?: string | null;
+};
+
+export const calendarProcessEvent = inngest.createFunction(
+  { id: "crm-calendar-process-event", name: "CRM: Process calendar event" },
+  { event: "crm/calendar.event.received" },
+  async ({ event, step }) => {
+    const data = event.data as WireEvent;
+    return step.run("upsert", () =>
+      upsertCalendarEvent({
+        ...data,
+        startAt: new Date(data.startAt),
+        endAt: data.endAt ? new Date(data.endAt) : null,
+      })
+    );
+  }
+);
+```
+
+- [ ] **Step 2: Register in `app/api/inngest/route.ts`**
+
+Add import after the existing crm imports and append to the `functions` array:
+
+```typescript
+import { calendarProcessEvent } from "@/inngest/functions/calendar/process-event";
+// ...in functions array, after renewalReminders:
+    calendarProcessEvent,
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add inngest app/api/inngest/route.ts
+git commit -m "feat(calendar): inngest processor for crm/calendar.event.received"
+```
+
+---
+
+### Task 6: Calendly settings storage + webhook route
+
+**Files:**
+- Create: `lib/crm/calendar/calendly-settings.ts`
+- Create: `app/api/crm/calendar/webhooks/calendly/route.ts`
+- Test: `app/api/crm/calendar/webhooks/calendly/__tests__/route.test.ts`
+
+**Interfaces:**
+- Consumes: `verifyCalendlySignature` (Task 2), `crm_SystemSettings` key-value table, `encrypt`/`decrypt` from `@/lib/email-crypto`.
+- Produces:
+  - `getCalendlySettings(): Promise<{ apiToken: string | null; signingKey: string | null; webhookUri: string | null }>`
+  - `saveCalendlySettings(input: { apiToken?: string; signingKey?: string }): Promise<void>`
+  - `setCalendlyWebhookUri(uri: string): Promise<void>`
+  - `POST /api/crm/calendar/webhooks/calendly` — 401 bad signature; 200 + Inngest event for `invitee.created`/`invitee.canceled`; 200 no-op otherwise.
+- System-settings keys (values encrypted where noted): `calendly_api_token` (encrypted), `calendly_signing_key` (encrypted), `calendly_webhook_uri` (plain).
+
+- [ ] **Step 1: Implement settings helper**
+
+```typescript
+// lib/crm/calendar/calendly-settings.ts
+import { prismadb } from "@/lib/prisma";
+import { encrypt, decrypt } from "@/lib/email-crypto";
+
+const KEYS = {
+  apiToken: "calendly_api_token",
+  signingKey: "calendly_signing_key",
+  webhookUri: "calendly_webhook_uri",
+} as const;
+
+async function read(key: string): Promise<string | null> {
+  const row = await prismadb.crm_SystemSettings.findUnique({ where: { key } });
+  return row?.value ?? null;
+}
+
+async function write(key: string, value: string): Promise<void> {
+  await prismadb.crm_SystemSettings.upsert({
+    where: { key },
+    update: { value },
+    create: { key, value },
+  });
+}
+
+export async function getCalendlySettings() {
+  const [token, signing, uri] = await Promise.all([
+    read(KEYS.apiToken),
+    read(KEYS.signingKey),
+    read(KEYS.webhookUri),
+  ]);
+  return {
+    apiToken: token ? decrypt(token) : null,
+    signingKey: signing ? decrypt(signing) : null,
+    webhookUri: uri,
+  };
+}
+
+export async function saveCalendlySettings(input: {
+  apiToken?: string;
+  signingKey?: string;
+}): Promise<void> {
+  if (input.apiToken) await write(KEYS.apiToken, encrypt(input.apiToken));
+  if (input.signingKey) await write(KEYS.signingKey, encrypt(input.signingKey));
+}
+
+export async function setCalendlyWebhookUri(uri: string): Promise<void> {
+  await write(KEYS.webhookUri, uri);
+}
+```
+
+- [ ] **Step 2: Write the failing route test**
+
+```typescript
+// app/api/crm/calendar/webhooks/calendly/__tests__/route.test.ts
+jest.mock("@/lib/crm/calendar/calendly-settings", () => ({
+  getCalendlySettings: jest.fn(),
+}));
+jest.mock("@/inngest/client", () => ({
+  inngest: { send: jest.fn().mockResolvedValue({ ids: ["1"] }) },
+}));
+
+import { createHmac } from "crypto";
+import { NextRequest } from "next/server";
+import { getCalendlySettings } from "@/lib/crm/calendar/calendly-settings";
+import { inngest } from "@/inngest/client";
+import { POST } from "../route";
+
+const settings = getCalendlySettings as jest.Mock;
+const send = inngest.send as jest.Mock;
+const KEY = "sk";
+
+function sign(body: string) {
+  const t = "1721400000";
+  const v1 = createHmac("sha256", KEY).update(`${t}.${body}`).digest("hex");
+  return `t=${t},v1=${v1}`;
+}
+
+function makeReq(body: object, signature?: string) {
+  const raw = JSON.stringify(body);
+  return new NextRequest("http://localhost/api/crm/calendar/webhooks/calendly", {
+    method: "POST",
+    body: raw,
+    headers: {
+      "content-type": "application/json",
+      ...(signature !== undefined
+        ? { "calendly-webhook-signature": signature }
+        : { "calendly-webhook-signature": sign(raw) }),
+    },
+  });
+}
+
+const CREATED = {
+  event: "invitee.created",
+  payload: {
+    uri: "https://api.calendly.com/scheduled_events/EV1/invitees/INV1",
+    email: "jane@client.com",
+    name: "Jane Doe",
+    scheduled_event: {
+      uri: "https://api.calendly.com/scheduled_events/EV1",
+      name: "Intro call",
+      start_time: "2026-07-21T10:00:00.000000Z",
+      end_time: "2026-07-21T10:30:00.000000Z",
+      event_memberships: [{ user_email: "rep@aqunama.com" }],
+    },
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  settings.mockResolvedValue({ apiToken: "tok", signingKey: KEY, webhookUri: null });
+});
+
+describe("POST /api/crm/calendar/webhooks/calendly", () => {
+  it("401 on bad signature", async () => {
+    const res = await POST(makeReq(CREATED, "t=1,v1=bad"));
+    expect(res.status).toBe(401);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("401 when no signing key is configured", async () => {
+    settings.mockResolvedValue({ apiToken: null, signingKey: null, webhookUri: null });
+    const res = await POST(makeReq(CREATED));
+    expect(res.status).toBe(401);
+  });
+
+  it("forwards invitee.created to inngest and ACKs", async () => {
+    const res = await POST(makeReq(CREATED));
+    expect(res.status).toBe(200);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "crm/calendar.event.received",
+        data: expect.objectContaining({
+          source: "calendly",
+          externalId: CREATED.payload.uri,
+          title: "Intro call",
+          counterpartyEmails: ["jane@client.com"],
+          hostEmail: "rep@aqunama.com",
+          status: "scheduled",
+        }),
+      })
+    );
+  });
+
+  it("maps invitee.canceled to status cancelled", async () => {
+    const res = await POST(makeReq({ ...CREATED, event: "invitee.canceled" }));
+    expect(res.status).toBe(200);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "cancelled" }),
+      })
+    );
+  });
+
+  it("ACKs 200 for unhandled event types without sending", async () => {
+    const res = await POST(makeReq({ event: "routing_form_submission.created", payload: {} }));
+    expect(res.status).toBe(200);
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm jest app/api/crm/calendar/webhooks/calendly/__tests__/route.test.ts`
+Expected: FAIL — cannot find module `../route`.
+
+- [ ] **Step 4: Implement the route**
+
+```typescript
+// app/api/crm/calendar/webhooks/calendly/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { verifyCalendlySignature } from "@/lib/crm/calendar/calendly-signature";
+import { getCalendlySettings } from "@/lib/crm/calendar/calendly-settings";
+import { inngest } from "@/inngest/client";
+
+type CalendlyWebhookBody = {
+  event: string;
+  payload: {
+    uri?: string;
+    email?: string;
+    name?: string;
+    scheduled_event?: {
+      uri?: string;
+      name?: string;
+      start_time?: string;
+      end_time?: string;
+      event_memberships?: Array<{ user_email?: string }>;
+    };
+  };
+};
+
+export async function POST(req: NextRequest) {
+  const rawBody = await req.text();
+  const { signingKey } = await getCalendlySettings();
+
+  if (
+    !signingKey ||
+    !verifyCalendlySignature(
+      rawBody,
+      req.headers.get("calendly-webhook-signature"),
+      signingKey
+    )
+  ) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  let body: CalendlyWebhookBody;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    // Never bounce Calendly into disabling the subscription over a bad payload.
+    return NextResponse.json({ ok: true });
+  }
+
+  if (body.event !== "invitee.created" && body.event !== "invitee.canceled") {
+    return NextResponse.json({ ok: true });
+  }
+
+  const p = body.payload;
+  const ev = p.scheduled_event;
+  if (!p.uri || !ev?.start_time) return NextResponse.json({ ok: true });
+
+  await inngest.send({
+    name: "crm/calendar.event.received",
+    data: {
+      source: "calendly",
+      externalId: p.uri,
+      iCalUID: null,
+      connectionId: null,
+      title: ev.name ?? "Calendly meeting",
+      startAt: ev.start_time,
+      endAt: ev.end_time ?? null,
+      counterpartyEmails: p.email ? [p.email] : [],
+      hostEmail: ev.event_memberships?.[0]?.user_email ?? null,
+      status: body.event === "invitee.canceled" ? "cancelled" : "scheduled",
+      rawPayload: body,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm jest app/api/crm/calendar/webhooks/calendly/__tests__/route.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/crm/calendar app/api/crm/calendar
+git commit -m "feat(calendar): Calendly settings storage + signed webhook endpoint"
+```
+
+---
+
+### Task 7: Calendly admin page + webhook subscription action
+
+**Files:**
+- Create: `app/[locale]/(routes)/admin/calendar-settings/_actions/calendly.ts`
+- Create: `app/[locale]/(routes)/admin/calendar-settings/page.tsx`
+- Create: `app/[locale]/(routes)/admin/calendar-settings/_components/CalendlyForm.tsx`
+
+**Interfaces:**
+- Consumes: `saveCalendlySettings`, `getCalendlySettings`, `setCalendlyWebhookUri` (Task 6).
+- Produces: admin-only page at `/admin/calendar-settings` with a form (API token + signing key) and a "Subscribe webhook" button. Server action `subscribeCalendlyWebhook()` calls Calendly: `GET /users/me` → `current_organization`, then `POST /webhook_subscriptions` with `{url, events: ["invitee.created","invitee.canceled"], organization, scope: "organization"}`.
+
+- [ ] **Step 1: Implement server actions**
+
+```typescript
+// app/[locale]/(routes)/admin/calendar-settings/_actions/calendly.ts
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import {
+  getCalendlySettings,
+  saveCalendlySettings,
+  setCalendlyWebhookUri,
+} from "@/lib/crm/calendar/calendly-settings";
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.user?.id) throw new Error("Unauthorized");
+  const user = await prismadb.users.findUnique({
+    where: { id: session.user.id },
+    select: { role: true },
+  });
+  if (user?.role !== "admin") throw new Error("Forbidden");
+}
+
+export async function saveCalendlyAction(formData: FormData) {
+  await requireAdmin();
+  const apiToken = String(formData.get("apiToken") ?? "").trim();
+  const signingKey = String(formData.get("signingKey") ?? "").trim();
+  await saveCalendlySettings({
+    ...(apiToken ? { apiToken } : {}),
+    ...(signingKey ? { signingKey } : {}),
+  });
+  revalidatePath("/admin/calendar-settings");
+}
+
+export async function subscribeCalendlyWebhook(): Promise<{ ok: boolean; error?: string }> {
+  await requireAdmin();
+  const { apiToken } = await getCalendlySettings();
+  if (!apiToken) return { ok: false, error: "Save the API token first." };
+
+  const headers = {
+    Authorization: `Bearer ${apiToken}`,
+    "Content-Type": "application/json",
+  };
+
+  const meRes = await fetch("https://api.calendly.com/users/me", { headers });
+  if (!meRes.ok) return { ok: false, error: `Calendly /users/me failed (${meRes.status})` };
+  const me = (await meRes.json()) as { resource: { current_organization: string } };
+
+  const subRes = await fetch("https://api.calendly.com/webhook_subscriptions", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      url: `${process.env.NEXT_PUBLIC_APP_URL}/api/crm/calendar/webhooks/calendly`,
+      events: ["invitee.created", "invitee.canceled"],
+      organization: me.resource.current_organization,
+      scope: "organization",
+    }),
+  });
+  if (!subRes.ok) {
+    const detail = await subRes.text();
+    return { ok: false, error: `Subscription failed (${subRes.status}): ${detail.slice(0, 200)}` };
+  }
+  const sub = (await subRes.json()) as { resource: { uri: string } };
+  await setCalendlyWebhookUri(sub.resource.uri);
+  revalidatePath("/admin/calendar-settings");
+  return { ok: true };
+}
+```
+
+- [ ] **Step 2: Implement the page (server component)**
+
+```tsx
+// app/[locale]/(routes)/admin/calendar-settings/page.tsx
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import { getCalendlySettings } from "@/lib/crm/calendar/calendly-settings";
+import { CalendlyForm } from "./_components/CalendlyForm";
+
+export default async function CalendarSettingsPage() {
+  const session = await getSession();
+  if (!session?.user?.id) redirect("/sign-in");
+  const user = await prismadb.users.findUnique({
+    where: { id: session.user.id },
+    select: { role: true },
+  });
+  if (user?.role !== "admin") redirect("/");
+
+  const settings = await getCalendlySettings();
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Calendar settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Calendly organization webhook for booked-call capture.
+        </p>
+      </div>
+      <CalendlyForm
+        hasToken={Boolean(settings.apiToken)}
+        hasSigningKey={Boolean(settings.signingKey)}
+        webhookUri={settings.webhookUri}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Implement the form (client component)**
+
+```tsx
+// app/[locale]/(routes)/admin/calendar-settings/_components/CalendlyForm.tsx
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { saveCalendlyAction, subscribeCalendlyWebhook } from "../_actions/calendly";
+
+export function CalendlyForm(props: {
+  hasToken: boolean;
+  hasSigningKey: boolean;
+  webhookUri: string | null;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  return (
+    <div className="max-w-xl space-y-4 rounded-lg border p-4">
+      <form action={saveCalendlyAction} className="space-y-3">
+        <div>
+          <label className="text-sm font-medium">
+            API token {props.hasToken ? "(saved)" : ""}
+          </label>
+          <Input name="apiToken" type="password" placeholder="Calendly personal access token" />
+        </div>
+        <div>
+          <label className="text-sm font-medium">
+            Webhook signing key {props.hasSigningKey ? "(saved)" : ""}
+          </label>
+          <Input name="signingKey" type="password" placeholder="Webhook signing key" />
+        </div>
+        <Button type="submit">Save</Button>
+      </form>
+
+      <div className="border-t pt-4">
+        <Button
+          variant="secondary"
+          disabled={pending || !props.hasToken}
+          onClick={() =>
+            startTransition(async () => {
+              const res = await subscribeCalendlyWebhook();
+              setMessage(res.ok ? "Webhook subscribed." : res.error ?? "Failed.");
+            })
+          }
+        >
+          {props.webhookUri ? "Re-subscribe webhook" : "Subscribe webhook"}
+        </Button>
+        {props.webhookUri && (
+          <p className="mt-2 break-all text-xs text-muted-foreground">
+            Active subscription: {props.webhookUri}
+          </p>
+        )}
+        {message && <p className="mt-2 text-sm">{message}</p>}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Typecheck + build the page**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors. (If `@/components/ui/input` or `button` paths differ, match the imports used by `app/[locale]/(routes)/admin/crm-settings/_components/ConfigAddDialog.tsx`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/[locale]/(routes)/admin/calendar-settings"
+git commit -m "feat(calendar): Calendly admin settings page + org webhook subscription"
+```
+
+---
+
+### Task 8: Google OAuth — client helper + authorize/callback routes
+
+**Files:**
+- Create: `lib/crm/calendar/google.ts`
+- Create: `app/api/profile/calendar-connections/google/authorize/route.ts`
+- Create: `app/api/profile/calendar-connections/google/callback/route.ts`
+- Modify: `package.json` (add `googleapis`)
+- Modify: `.env.example` if present (document `GOOGLE_CALENDAR_CLIENT_ID`, `GOOGLE_CALENDAR_CLIENT_SECRET`)
+
+**Interfaces:**
+- Produces:
+  - `getGoogleOAuthClient(): OAuth2Client` — configured from `GOOGLE_CALENDAR_CLIENT_ID` / `GOOGLE_CALENDAR_CLIENT_SECRET` / redirect `${NEXT_PUBLIC_APP_URL}/api/profile/calendar-connections/google/callback`.
+  - `getGoogleAuthUrl(): string` — offline access, scope `calendar.readonly`, `prompt: "consent"`.
+  - `getCalendarClientForConnection(connection: { refreshTokenEncrypted: string }): calendar_v3.Calendar` — decrypts the refresh token; googleapis auto-refreshes access tokens.
+  - `GET /api/profile/calendar-connections/google/authorize` → 302 to Google consent (session required).
+  - `GET /api/profile/calendar-connections/google/callback` → exchanges `code`, resolves the calendar's email via `calendarList.get("primary")`, upserts `CalendarConnection`, redirects to `/profile`.
+
+- [ ] **Step 1: Add dependency**
+
+```bash
+pnpm add googleapis
+```
+
+- [ ] **Step 2: Implement the helper**
+
+```typescript
+// lib/crm/calendar/google.ts
+import { google, calendar_v3 } from "googleapis";
+import type { OAuth2Client } from "google-auth-library";
+import { decrypt } from "@/lib/email-crypto";
+
+const SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"];
+
+export function getGoogleOAuthClient(): OAuth2Client {
+  return new google.auth.OAuth2(
+    process.env.GOOGLE_CALENDAR_CLIENT_ID,
+    process.env.GOOGLE_CALENDAR_CLIENT_SECRET,
+    `${process.env.NEXT_PUBLIC_APP_URL}/api/profile/calendar-connections/google/callback`
+  );
+}
+
+export function getGoogleAuthUrl(): string {
+  return getGoogleOAuthClient().generateAuthUrl({
+    access_type: "offline",
+    prompt: "consent",
+    scope: SCOPES,
+  });
+}
+
+export function getCalendarClientForConnection(connection: {
+  refreshTokenEncrypted: string;
+}): calendar_v3.Calendar {
+  const auth = getGoogleOAuthClient();
+  auth.setCredentials({ refresh_token: decrypt(connection.refreshTokenEncrypted) });
+  return google.calendar({ version: "v3", auth });
+}
+```
+
+- [ ] **Step 3: Implement the authorize route**
+
+```typescript
+// app/api/profile/calendar-connections/google/authorize/route.ts
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { getGoogleAuthUrl } from "@/lib/crm/calendar/google";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return NextResponse.redirect(getGoogleAuthUrl());
+}
+```
+
+- [ ] **Step 4: Implement the callback route**
+
+```typescript
+// app/api/profile/calendar-connections/google/callback/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { google } from "googleapis";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { encrypt } from "@/lib/email-crypto";
+import { getGoogleOAuthClient } from "@/lib/crm/calendar/google";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const code = req.nextUrl.searchParams.get("code");
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL!;
+  if (!code) return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+
+  try {
+    const auth = getGoogleOAuthClient();
+    const { tokens } = await auth.getToken(code);
+    if (!tokens.refresh_token) {
+      return NextResponse.redirect(`${appUrl}/profile?calendar=no-refresh-token`);
+    }
+    auth.setCredentials(tokens);
+
+    const calendar = google.calendar({ version: "v3", auth });
+    const primary = await calendar.calendarList.get({ calendarId: "primary" });
+    const accountEmail = primary.data.id;
+    if (!accountEmail) {
+      return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+    }
+
+    await prismadb.calendarConnection.upsert({
+      where: {
+        userId_provider_accountEmail: {
+          userId: session.user.id,
+          provider: "google",
+          accountEmail,
+        },
+      },
+      update: {
+        refreshTokenEncrypted: encrypt(tokens.refresh_token),
+        accessTokenEncrypted: tokens.access_token ? encrypt(tokens.access_token) : null,
+        tokenExpiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+        isActive: true,
+        lastSyncError: null,
+        syncToken: null, // force a fresh full-window sync
+      },
+      create: {
+        userId: session.user.id,
+        provider: "google",
+        accountEmail,
+        refreshTokenEncrypted: encrypt(tokens.refresh_token),
+        accessTokenEncrypted: tokens.access_token ? encrypt(tokens.access_token) : null,
+        tokenExpiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+      },
+    });
+
+    return NextResponse.redirect(`${appUrl}/profile?calendar=connected`);
+  } catch (error) {
+    console.error("[google-calendar-callback]", error);
+    return NextResponse.redirect(`${appUrl}/profile?calendar=error`);
+  }
+}
+```
+
+- [ ] **Step 5: Document env vars**
+
+If `.env.example` exists, add:
+
+```
+# Google Calendar sync (AQUNAMA Phase 4) — Workspace-internal OAuth app
+GOOGLE_CALENDAR_CLIENT_ID=
+GOOGLE_CALENDAR_CLIENT_SECRET=
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml lib/crm/calendar app/api/profile .env.example 2>/dev/null; git commit -m "feat(calendar): Google Calendar OAuth connect flow (readonly scope)"
+```
+
+---
+
+### Task 9: Google event normalizer + polling Inngest functions
+
+**Files:**
+- Create: `lib/crm/calendar/google-normalize.ts`
+- Test: `lib/crm/calendar/__tests__/google-normalize.test.ts`
+- Create: `inngest/functions/calendar/google-sync-all.ts`
+- Create: `inngest/functions/calendar/google-sync-connection.ts`
+- Modify: `app/api/inngest/route.ts` (register both)
+
+**Interfaces:**
+- Consumes: `getCalendarClientForConnection` (Task 8), `upsertCalendarEvent` (Task 4), `CalendarEventInput` (Task 3).
+- Produces:
+  - `normalizeGoogleEvent(ev: calendar_v3.Schema$Event, opts: { connectionId: string; accountEmail: string }): CalendarEventInput | { skip: string }` — pure, fully unit-tested.
+  - `googleCalendarSyncAll` — cron `*/15 * * * *`, fans out `"crm/calendar.google-sync"` per active google connection (mirrors `emailSyncAll`).
+  - `googleCalendarSyncConnection` — event `"crm/calendar.google-sync"` (`data: { connectionId: string }`); incremental `events.list` with `syncToken`, full ±60-day window on first run or `410`; deactivates the connection after auth failure.
+
+Skip rules (Google): no `start.dateTime` (all-day) → `{skip:"all-day"}`; rep declined (`attendees[].self === true && responseStatus === "declined"`) → `{skip:"declined"}`; no counterparty after removing the rep's own address and same-domain colleagues → `{skip:"no-counterparty"}`; `status === "cancelled"` → a minimal cancelled input (only `externalId`/`status` matter downstream).
+
+- [ ] **Step 1: Write the failing normalizer test**
+
+```typescript
+// lib/crm/calendar/__tests__/google-normalize.test.ts
+import { normalizeGoogleEvent } from "../google-normalize";
+
+const OPTS = { connectionId: "conn1", accountEmail: "rep@aqunama.com" };
+
+function ev(overrides: object = {}) {
+  return {
+    id: "gev1",
+    iCalUID: "uid1@google.com",
+    status: "confirmed",
+    summary: "Client sync",
+    start: { dateTime: "2026-07-21T10:00:00+02:00" },
+    end: { dateTime: "2026-07-21T10:30:00+02:00" },
+    attendees: [
+      { email: "rep@aqunama.com", self: true, responseStatus: "accepted" },
+      { email: "jane@client.com", responseStatus: "accepted" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("normalizeGoogleEvent", () => {
+  it("normalizes a client meeting", () => {
+    const res = normalizeGoogleEvent(ev(), OPTS);
+    expect(res).toMatchObject({
+      source: "google",
+      externalId: "gev1",
+      iCalUID: "uid1@google.com",
+      connectionId: "conn1",
+      title: "Client sync",
+      counterpartyEmails: ["jane@client.com"],
+      hostEmail: "rep@aqunama.com",
+      status: "scheduled",
+    });
+    expect((res as { startAt: Date }).startAt.toISOString()).toBe("2026-07-21T08:00:00.000Z");
+  });
+
+  it("skips all-day events", () => {
+    expect(normalizeGoogleEvent(ev({ start: { date: "2026-07-21" }, end: { date: "2026-07-22" } }), OPTS))
+      .toEqual({ skip: "all-day" });
+  });
+
+  it("skips events the rep declined", () => {
+    const declined = ev({
+      attendees: [
+        { email: "rep@aqunama.com", self: true, responseStatus: "declined" },
+        { email: "jane@client.com" },
+      ],
+    });
+    expect(normalizeGoogleEvent(declined, OPTS)).toEqual({ skip: "declined" });
+  });
+
+  it("skips internal meetings (same-domain attendees only)", () => {
+    const internal = ev({
+      attendees: [
+        { email: "rep@aqunama.com", self: true },
+        { email: "colleague@aqunama.com" },
+      ],
+    });
+    expect(normalizeGoogleEvent(internal, OPTS)).toEqual({ skip: "no-counterparty" });
+  });
+
+  it("skips events without attendees", () => {
+    expect(normalizeGoogleEvent(ev({ attendees: undefined }), OPTS))
+      .toEqual({ skip: "no-counterparty" });
+  });
+
+  it("maps cancelled events to a cancelled input", () => {
+    const res = normalizeGoogleEvent(
+      { id: "gev1", status: "cancelled" }, OPTS
+    );
+    expect(res).toMatchObject({ source: "google", externalId: "gev1", status: "cancelled" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/google-normalize.test.ts`
+Expected: FAIL — cannot find module `../google-normalize`.
+
+- [ ] **Step 3: Implement the normalizer**
+
+```typescript
+// lib/crm/calendar/google-normalize.ts
+import type { calendar_v3 } from "googleapis";
+import type { CalendarEventInput } from "./types";
+
+export type NormalizeResult = CalendarEventInput | { skip: string };
+
+export function normalizeGoogleEvent(
+  ev: calendar_v3.Schema$Event,
+  opts: { connectionId: string; accountEmail: string }
+): NormalizeResult {
+  if (!ev.id) return { skip: "no-id" };
+
+  if (ev.status === "cancelled") {
+    // Cancelled payloads are sparse; downstream only needs the identity.
+    return {
+      source: "google",
+      externalId: ev.id,
+      iCalUID: ev.iCalUID ?? null,
+      connectionId: opts.connectionId,
+      title: ev.summary ?? "Meeting",
+      startAt: ev.start?.dateTime ? new Date(ev.start.dateTime) : new Date(0),
+      endAt: null,
+      counterpartyEmails: [],
+      hostEmail: opts.accountEmail,
+      status: "cancelled",
+      rawPayload: ev,
+    };
+  }
+
+  if (!ev.start?.dateTime) return { skip: "all-day" };
+
+  const attendees = ev.attendees ?? [];
+  const self = attendees.find((a) => a.self);
+  if (self?.responseStatus === "declined") return { skip: "declined" };
+
+  const repDomain = opts.accountEmail.split("@")[1]?.toLowerCase();
+  const counterparty = attendees
+    .map((a) => a.email?.toLowerCase())
+    .filter((e): e is string => Boolean(e))
+    .filter((e) => e !== opts.accountEmail.toLowerCase())
+    .filter((e) => e.split("@")[1] !== repDomain);
+  if (counterparty.length === 0) return { skip: "no-counterparty" };
+
+  return {
+    source: "google",
+    externalId: ev.id,
+    iCalUID: ev.iCalUID ?? null,
+    connectionId: opts.connectionId,
+    title: ev.summary ?? "Meeting",
+    startAt: new Date(ev.start.dateTime),
+    endAt: ev.end?.dateTime ? new Date(ev.end.dateTime) : null,
+    counterpartyEmails: counterparty,
+    hostEmail: opts.accountEmail,
+    status: "scheduled",
+    rawPayload: ev,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm jest lib/crm/calendar/__tests__/google-normalize.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Implement the fan-out cron**
+
+```typescript
+// inngest/functions/calendar/google-sync-all.ts
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+
+export const googleCalendarSyncAll = inngest.createFunction(
+  {
+    id: "crm-google-calendar-sync-all",
+    name: "CRM: Google Calendar sync (all connections)",
+    triggers: [{ cron: "*/15 * * * *" }],
+  },
+  async () => {
+    const connections = await prismadb.calendarConnection.findMany({
+      where: { isActive: true, provider: "google" },
+      select: { id: true },
+    });
+    if (connections.length === 0) return { synced: 0 };
+
+    await inngest.send(
+      connections.map((c) => ({
+        name: "crm/calendar.google-sync" as const,
+        data: { connectionId: c.id },
+      }))
+    );
+    return { synced: connections.length };
+  }
+);
+```
+
+- [ ] **Step 6: Implement the per-connection sync**
+
+```typescript
+// inngest/functions/calendar/google-sync-connection.ts
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+import { getCalendarClientForConnection } from "@/lib/crm/calendar/google";
+import { normalizeGoogleEvent } from "@/lib/crm/calendar/google-normalize";
+import { upsertCalendarEvent } from "@/lib/crm/calendar/sync";
+import type { calendar_v3 } from "googleapis";
+
+const WINDOW_DAYS = 60;
+const AUTH_ERROR_CODES = new Set([401, 403]);
+
+export const googleCalendarSyncConnection = inngest.createFunction(
+  {
+    id: "crm-google-calendar-sync-connection",
+    name: "CRM: Google Calendar sync (one connection)",
+    retries: 3,
+  },
+  { event: "crm/calendar.google-sync" },
+  async ({ event, step }) => {
+    const { connectionId } = event.data as { connectionId: string };
+
+    const result = await step.run("sync", async () => {
+      const connection = await prismadb.calendarConnection.findUnique({
+        where: { id: connectionId },
+      });
+      if (!connection || !connection.isActive) return { skipped: true };
+
+      const calendar = getCalendarClientForConnection(connection);
+      const items: calendar_v3.Schema$Event[] = [];
+      let syncToken = connection.syncToken;
+      let nextSyncToken: string | null | undefined;
+
+      const list = async (params: calendar_v3.Params$Resource$Events$List) => {
+        let pageToken: string | undefined;
+        do {
+          const res = await calendar.events.list({ ...params, pageToken, maxResults: 250 });
+          items.push(...(res.data.items ?? []));
+          pageToken = res.data.nextPageToken ?? undefined;
+          nextSyncToken = res.data.nextSyncToken ?? nextSyncToken;
+        } while (pageToken);
+      };
+
+      try {
+        if (syncToken) {
+          try {
+            await list({ calendarId: "primary", singleEvents: true, syncToken });
+          } catch (error) {
+            const code = (error as { code?: number }).code;
+            if (code !== 410) throw error;
+            // Sync token expired: fall back to a full window sync.
+            syncToken = null;
+            items.length = 0;
+          }
+        }
+        if (!syncToken) {
+          const now = Date.now();
+          await list({
+            calendarId: "primary",
+            singleEvents: true,
+            timeMin: new Date(now - WINDOW_DAYS * 86400000).toISOString(),
+            timeMax: new Date(now + WINDOW_DAYS * 86400000).toISOString(),
+          });
+        }
+      } catch (error) {
+        const code = (error as { code?: number }).code;
+        const message = error instanceof Error ? error.message : String(error);
+        await prismadb.calendarConnection.update({
+          where: { id: connection.id },
+          data: {
+            lastSyncError: message.slice(0, 500),
+            ...(code !== undefined && AUTH_ERROR_CODES.has(code) ? { isActive: false } : {}),
+          },
+        });
+        throw error;
+      }
+
+      const counts = { created: 0, updated: 0, cancelled: 0, skipped: 0 };
+      for (const ev of items) {
+        const normalized = normalizeGoogleEvent(ev, {
+          connectionId: connection.id,
+          accountEmail: connection.accountEmail,
+        });
+        if ("skip" in normalized) {
+          counts.skipped += 1;
+          continue;
+        }
+        const res = await upsertCalendarEvent(normalized);
+        counts[res.action] += 1;
+      }
+
+      await prismadb.calendarConnection.update({
+        where: { id: connection.id },
+        data: {
+          syncToken: nextSyncToken ?? syncToken,
+          lastSyncedAt: new Date(),
+          lastSyncError: null,
+        },
+      });
+
+      return { events: items.length, ...counts };
+    });
+
+    return result;
+  }
+);
+```
+
+- [ ] **Step 7: Register both in `app/api/inngest/route.ts`**
+
+```typescript
+import { googleCalendarSyncAll } from "@/inngest/functions/calendar/google-sync-all";
+import { googleCalendarSyncConnection } from "@/inngest/functions/calendar/google-sync-connection";
+// ...append to functions array after calendarProcessEvent:
+    googleCalendarSyncAll,
+    googleCalendarSyncConnection,
+```
+
+- [ ] **Step 8: Typecheck + run calendar tests**
+
+```bash
+pnpm exec tsc --noEmit && pnpm jest lib/crm/calendar
+```
+
+Expected: no type errors; all calendar tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/crm/calendar inngest app/api/inngest/route.ts
+git commit -m "feat(calendar): Google Calendar incremental polling sync via Inngest"
+```
+
+---
+
+### Task 10: Profile UI — calendar connections list + disconnect
+
+**Files:**
+- Create: `app/api/profile/calendar-connections/route.ts` (GET list)
+- Create: `app/api/profile/calendar-connections/[id]/route.ts` (DELETE)
+- Create: `app/[locale]/(routes)/profile/components/CalendarConnectionsList.tsx`
+- Modify: `app/[locale]/(routes)/profile/components/tabs/EmailAccountsTabContent.tsx` **or** the profile tabs container — add the calendar section beside the email accounts (inspect `app/[locale]/(routes)/profile/page.tsx` to place it the same way `EmailAccountsList` is placed).
+
+**Interfaces:**
+- Consumes: `CalendarConnection` model (Task 1); authorize route (Task 8).
+- Produces: `GET /api/profile/calendar-connections` → `{ connections: Array<{ id, provider, accountEmail, isActive, lastSyncedAt, lastSyncError }> }` (session user's only); `DELETE /api/profile/calendar-connections/:id` → 204 (owner only).
+
+- [ ] **Step 1: Implement list route**
+
+```typescript
+// app/api/profile/calendar-connections/route.ts
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const connections = await prismadb.calendarConnection.findMany({
+    where: { userId: session.user.id },
+    select: {
+      id: true,
+      provider: true,
+      accountEmail: true,
+      isActive: true,
+      lastSyncedAt: true,
+      lastSyncError: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+  return NextResponse.json({ connections });
+}
+```
+
+- [ ] **Step 2: Implement delete route**
+
+```typescript
+// app/api/profile/calendar-connections/[id]/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  const connection = await prismadb.calendarConnection.findUnique({ where: { id } });
+  if (!connection || connection.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  await prismadb.calendarConnection.delete({ where: { id } });
+  return new NextResponse(null, { status: 204 });
+}
+```
+
+- [ ] **Step 3: Implement the list component**
+
+```tsx
+// app/[locale]/(routes)/profile/components/CalendarConnectionsList.tsx
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+type Connection = {
+  id: string;
+  provider: string;
+  accountEmail: string;
+  isActive: boolean;
+  lastSyncedAt: string | null;
+  lastSyncError: string | null;
+};
+
+export function CalendarConnectionsList() {
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const res = await fetch("/api/profile/calendar-connections");
+    if (res.ok) setConnections((await res.json()).connections);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function disconnect(id: string) {
+    await fetch(`/api/profile/calendar-connections/${id}`, { method: "DELETE" });
+    await load();
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">Calendar connections</h3>
+        <Button asChild size="sm">
+          <a href="/api/profile/calendar-connections/google/authorize">
+            Connect Google Calendar
+          </a>
+        </Button>
+      </div>
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : connections.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No calendars connected.</p>
+      ) : (
+        <ul className="space-y-2">
+          {connections.map((c) => (
+            <li key={c.id} className="flex items-center justify-between rounded border p-2">
+              <div>
+                <p className="text-sm font-medium">{c.accountEmail}</p>
+                <p className="text-xs text-muted-foreground">
+                  {c.isActive
+                    ? c.lastSyncedAt
+                      ? `Synced ${new Date(c.lastSyncedAt).toLocaleString()}`
+                      : "Waiting for first sync"
+                    : `Needs reconnect${c.lastSyncError ? `: ${c.lastSyncError}` : ""}`}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                {!c.isActive && (
+                  <Button asChild size="sm" variant="secondary">
+                    <a href="/api/profile/calendar-connections/google/authorize">Reconnect</a>
+                  </Button>
+                )}
+                <Button size="sm" variant="destructive" onClick={() => disconnect(c.id)}>
+                  Disconnect
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Mount it on the profile page**
+
+Read `app/[locale]/(routes)/profile/page.tsx` and add `<CalendarConnectionsList />` in the same section/tab where `EmailAccountsList` is rendered (import from `./components/CalendarConnectionsList`). Follow the file's existing layout structure exactly.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/profile "app/[locale]/(routes)/profile"
+git commit -m "feat(calendar): profile UI for Google Calendar connections"
+```
+
+---
+
+### Task 11: Full verification gate + roadmap update
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-16-aqunama-roadmap.md` (mark Plan 4 A+B implemented)
+
+**Interfaces:** none — verification and bookkeeping.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `pnpm test`
+Expected: all tests pass (921 baseline + new calendar tests, 0 failures).
+
+- [ ] **Step 2: Typecheck + production build**
+
+```bash
+pnpm exec tsc --noEmit && pnpm build
+```
+
+Expected: both succeed.
+
+- [ ] **Step 3: Update the roadmap**
+
+In `docs/superpowers/plans/2026-07-16-aqunama-roadmap.md`, change the Plan 4 heading to:
+
+```markdown
+## Plan 4 — Calendar Sync ✅ Milestones A+B implemented (2026-07-19)
+
+Full plan: `docs/superpowers/plans/2026-07-19-aqunama-p4-calendar-sync.md` — spec: `docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md`. Decisions: A+B only (outbound two-way deferred); org-scope Calendly webhook; Workspace-internal Google OAuth, readonly scope, 15-min Inngest polling; unmatched Calendly invitees auto-create Targets; synced meetings restart the 45-day kill clock.
+```
+
+(Keep the original stub below it for reference, as Plans 2–3 did.)
+
+- [ ] **Step 4: Deployment checklist note**
+
+Manual steps that code cannot do (record in the commit message body or runbook):
+1. Create the Google Cloud OAuth client (Internal consent screen, Workspace domain), set `GOOGLE_CALENDAR_CLIENT_ID`/`GOOGLE_CALENDAR_CLIENT_SECRET` in Coolify env.
+2. In `/admin/calendar-settings`, save the Calendly org API token + signing key, then click "Subscribe webhook" (requires paid Calendly plan).
+3. Each rep connects Google Calendar from `/profile`.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add docs/superpowers/plans/2026-07-16-aqunama-roadmap.md
+git commit -m "docs: mark AQUNAMA Plan 4 milestones A+B implemented"
+git push origin dev
+```
+
+Then follow the standard flow: verify remote dev, PR `dev` → `main`.

--- a/docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md
+++ b/docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md
@@ -11,7 +11,7 @@
 - Google: reps are on a **Google Workspace domain** → OAuth consent screen is "Internal", `calendar.readonly` scope, no Google verification review needed.
 - Google inbound uses **Inngest polling** (15-min cron, incremental `syncToken`), mirroring `email-sync-all`. No push watch channels.
 - Unmatched attendee email: **Calendly → auto-create a Target** (source "Book-a-call"); **Google → skip the event entirely** (reps' internal/personal meetings must not pollute the CRM).
-- Synced meetings are `crm_Activities` rows, so they **restart the Phase 2 45-day kill clock** via `getLastClientActivity` with no Phase 2 changes.
+- Synced meetings are `crm_Activities` rows, so they **restart the Phase 2 45-day kill clock** via `getLastClientActivity` with no Phase 2 changes. (amended at final review: `getLastClientActivity` gained a `status != cancelled` filter so cancelled bookings don't suppress the kill clock)
 
 ## Architecture
 

--- a/docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md
+++ b/docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md
@@ -1,0 +1,127 @@
+# AQUNAMA Phase 4 — Calendar Sync (Calendly + Google Calendar inbound) — Design
+
+**Date:** 2026-07-19
+**Gap:** G-05 (`docs/internal/aqunama-sales-process-gap-analysis.md`)
+**Roadmap:** Plan 4 in `docs/superpowers/plans/2026-07-16-aqunama-roadmap.md`
+
+## Scope decisions (2026-07-19)
+
+- This spec covers **Milestones A + B**: Calendly inbound webhook capture and Google Calendar OAuth + inbound polling sync. **Milestone C (outbound / true two-way) is deferred** to a follow-up plan; nothing here blocks it.
+- Calendly: one **paid organization account** → a single organization-scope webhook subscription covers all reps.
+- Google: reps are on a **Google Workspace domain** → OAuth consent screen is "Internal", `calendar.readonly` scope, no Google verification review needed.
+- Google inbound uses **Inngest polling** (15-min cron, incremental `syncToken`), mirroring `email-sync-all`. No push watch channels.
+- Unmatched attendee email: **Calendly → auto-create a Target** (source "Book-a-call"); **Google → skip the event entirely** (reps' internal/personal meetings must not pollute the CRM).
+- Synced meetings are `crm_Activities` rows, so they **restart the Phase 2 45-day kill clock** via `getLastClientActivity` with no Phase 2 changes.
+
+## Architecture
+
+Two inbound pipelines converging on one shared processor:
+
+```
+Calendly org webhook ──▶ POST /api/crm/calendar/webhooks/calendly ──▶ inngest "crm/calendar.event.received"
+                                                                          │
+Google Calendar ◀── events.list + syncToken (Inngest cron */15,           │
+                    fan-out per active CalendarConnection) ───────────────┤
+                                                                          ▼
+                                                            lib/crm/calendar-sync.ts
+                                                            upsertCalendarEvent():
+                                                            match → dedup → meeting activity
+```
+
+- The webhook route verifies the Calendly HMAC signature (pattern: `app/api/campaigns/webhooks/resend/route.ts`), ACKs 200 fast, and hands the payload to Inngest for durable, retried processing.
+- The Google poller fans out one Inngest event per active connection (pattern: `inngest/functions/emails/sync-all.ts`), performs incremental sync, and emits the same processing event per relevant change.
+- All business rules (matching, dedup, activity writes) live in one module: `lib/crm/calendar-sync.ts`.
+
+## Data model
+
+Three additions; no changes to existing models.
+
+```prisma
+enum CalendarProvider { google }
+
+model CalendarConnection {          // mirrors EmailAccount
+  id                    String   @id @default(uuid()) @db.Uuid
+  userId                String   @db.Uuid            // → Users, onDelete Cascade
+  provider              CalendarProvider
+  accountEmail          String                        // rep's calendar email
+  accessTokenEncrypted  String
+  refreshTokenEncrypted String
+  tokenExpiresAt        DateTime?
+  syncToken             String?                       // Google incremental cursor
+  isActive              Boolean  @default(true)
+  lastSyncedAt          DateTime?
+  lastSyncError         String?
+  createdAt / updatedAt
+  @@unique([userId, provider, accountEmail])
+}
+
+model crm_CalendarEvents {          // sync mapping / idempotency / dedup
+  id             String   @id @default(uuid()) @db.Uuid
+  source         String                                // "calendly" | "google"
+  externalId     String                                // Calendly invitee URI / Google event id
+  iCalUID        String?                               // cross-source dedup key
+  connectionId   String?  @db.Uuid                     // → CalendarConnection (google only)
+  activityId     String   @db.Uuid                     // → crm_Activities (the meeting)
+  startAt        DateTime
+  endAt          DateTime?
+  attendeeEmails Json     @default("[]")
+  status         String                                // scheduled | cancelled
+  rawPayload     Json?                                 // last payload, debugging
+  createdAt / updatedAt
+  @@unique([source, externalId])
+  @@index([iCalUID])
+  @@index([activityId])
+}
+```
+
+The meeting itself is a plain `crm_Activities` row (`type: meeting`, status `scheduled`/`cancelled`) linked via `crm_ActivityLinks` to the matched entities. Encryption reuses the existing `passwordEncrypted` crypto helper used by `EmailAccount`.
+
+## Matching & processing rules (shared processor)
+
+Counterparty email selection — Calendly: the invitee email; Google: attendees minus any email on the rep's own Workspace domain.
+
+Match in priority order; first hit wins:
+
+1. **`crm_Contacts.email`** → link activity to the contact and its account; if the account has exactly one open (ACTIVE, not deleted) opportunity, link that too. Multiple open opportunities → link contact + account only.
+2. **`crm_Targets`** (by email) → link to the target.
+3. **`crm_Leads.email`** → link to the lead.
+4. **No match:**
+   - Calendly → create a `crm_Targets` row: source "Book-a-call", name/email from the invitee, assigned to the rep whose `Users.email` matches the Calendly event host (fallback: unassigned); link the meeting activity to it.
+   - Google → skip; store nothing.
+
+Additional Google skip rules: all-day events, events the rep has declined, and events already captured from Calendly — detected by matching `iCalUID`, or same `startAt` + counterparty email, against `crm_CalendarEvents` (Calendly bookings replicate onto the rep's Google Calendar).
+
+**Reschedules/cancellations:** Calendly `invitee.canceled` (a reschedule arrives as cancel + new `invitee.created`) and Google `status: cancelled` / changed `start` update the mapped activity — set status `cancelled` or update `date` — never create duplicates. All writes are idempotent upserts keyed on `(source, externalId)`.
+
+## Per-source specifics
+
+### Calendly (Milestone A)
+
+- Admin setup page under CRM settings: store the organization API token + webhook signing key; a "Subscribe webhook" action calls Calendly's API to register `invitee.created` / `invitee.canceled` at organization scope and stores the subscription URI.
+- `POST /api/crm/calendar/webhooks/calendly`: verify `Calendly-Webhook-Signature` (HMAC-SHA256 with the signing key), return 401 on failure; on success ACK 200 immediately and emit the Inngest event.
+- Host → rep resolution: Calendly event host email matched to `Users.email`.
+
+### Google Calendar (Milestone B)
+
+- "Connect Google Calendar" on the same settings surface as email accounts → OAuth (offline access, `calendar.readonly`) → tokens encrypted → `CalendarConnection` row.
+- Cron `*/15 * * * *` fans out per active connection. Each run: refresh access token if expired; `events.list` with stored `syncToken` (first run or `410 GONE`: full re-fetch of a ±60-day window and new token); feed changes to the shared processor; update `lastSyncedAt`/`syncToken`.
+- Repeated auth failures → `isActive = false` + `lastSyncError` set → settings UI shows a "reconnect" prompt.
+
+## Error handling
+
+- Bad webhook signature → 401, nothing processed.
+- Valid-but-unparseable payloads → ACK 200 + log (never let repeated 4xx/5xx responses cause Calendly to disable the subscription); processing failures after ACK retry via Inngest.
+- Token refresh failure → connection flagged as above; no silent data loss (next successful sync re-fetches via syncToken or full window).
+
+## Testing
+
+- Jest unit tests: matcher priority tiers and no-match branches (both sources), cross-source dedup, reschedule/cancel upsert behavior, Calendly signature verification — with fixture payloads for both providers.
+- Route tests for the webhook endpoint following the existing `__tests__/route.test.ts` pattern.
+- Migration authored with `prisma migrate diff` (dev-DB drift rule); CI replays migrations fresh.
+
+## Risks
+
+- Calendly webhook API requires a paid plan — org account confirmed paid; verify tier grants webhook access before implementation starts.
+- Polling delay: bookings appear in CRM within ≤15 min. Accepted for this process.
+- Google quota: `events.list` incremental polling per rep every 15 min is far below default quotas.
+- Milestone C (outbound) later needs the `calendar.events` write scope — a consent re-grant per rep, but no schema change.

--- a/docs/superpowers/specs/2026-07-19-profile-calendar-tab-design.md
+++ b/docs/superpowers/specs/2026-07-19-profile-calendar-tab-design.md
@@ -1,0 +1,16 @@
+# Profile "Calendar" Tab — Design
+
+**Date:** 2026-07-19 · Follow-up to AQUNAMA Phase 4 (`2026-07-19-aqunama-p4-calendar-sync-design.md`)
+
+Calendar connections move out of the Email Accounts tab into their own profile tab (`/profile?tab=calendar`), shown in the profile's left-hand tab nav. Approved by user 2026-07-19.
+
+## Changes
+
+1. **`components/tabs/CalendarTabContent.tsx`** (new) — renders `CalendarConnectionsList`.
+2. **`ProfileTabs.tsx`** — `calendar` added to `Tab` type, `TAB_IDS`, `TAB_ICONS` (lucide `CalendarClock`), `tabs` array (`t("tabs.calendar")`/`t("tabs.calendarDesc")`), `contentMap`, new `calendarContent` prop; `page.tsx` passes it. Tab order: after `emails`, before `llms`.
+3. **`EmailAccountsTabContent.tsx`** — `CalendarConnectionsList` mount removed.
+4. **`CalendarConnectionsList.tsx`** — gains (a) a status banner reading the OAuth callback's `?calendar=` param (`connected` → success; `error` / `state-mismatch` / `no-refresh-token` → specific guidance), fixing the silent-failure gap found while debugging the API-not-enabled issue; (b) try/catch + `res.ok` handling on both fetches with a visible error state (deferred Phase 4 review finding).
+5. **Google OAuth callback route** — all `/profile?calendar=...` redirects become `/profile?tab=calendar&calendar=...` so the user lands on the new tab with the banner visible.
+6. **Locales** — `ProfilePage.tabs.calendar` + `calendarDesc` added to `en`, `cz`, `de`, `uk`. Banner strings stay hardcoded English, matching the component's existing copy.
+
+No schema, API-shape, or sync-logic changes. Verification: `tsc --noEmit`, existing jest suites, manual re-run of the connect flow (validated working earlier today).

--- a/inngest/functions/calendar/__tests__/google-sync-classify.test.ts
+++ b/inngest/functions/calendar/__tests__/google-sync-classify.test.ts
@@ -1,0 +1,54 @@
+import { isAuthRevocationError } from "../google-sync-connection";
+
+describe("isAuthRevocationError", () => {
+  it("returns true for a token-endpoint 400 invalid_grant (revoked/expired refresh token)", () => {
+    const error = {
+      code: 400,
+      message: "invalid_grant",
+      response: { data: { error: "invalid_grant" } },
+    };
+    expect(isAuthRevocationError(error)).toBe(true);
+  });
+
+  it("returns true for a plain 401", () => {
+    const error = { code: 401, message: "Invalid Credentials" };
+    expect(isAuthRevocationError(error)).toBe(true);
+  });
+
+  it("returns false for a 403 rateLimitExceeded (transient, must not deactivate)", () => {
+    const error = {
+      code: 403,
+      message: "Rate Limit Exceeded",
+      response: {
+        data: {
+          error: {
+            message: "Rate Limit Exceeded",
+            errors: [{ reason: "rateLimitExceeded" }],
+          },
+        },
+      },
+    };
+    expect(isAuthRevocationError(error)).toBe(false);
+  });
+
+  it("returns true for a 403 without a rate-limit marker (genuine auth revocation)", () => {
+    const error = {
+      code: 403,
+      message: "Insufficient Permission",
+      response: {
+        data: {
+          error: {
+            message: "Insufficient Permission",
+            errors: [{ reason: "insufficientPermissions" }],
+          },
+        },
+      },
+    };
+    expect(isAuthRevocationError(error)).toBe(true);
+  });
+
+  it("returns false for an unrelated 500 error", () => {
+    const error = { code: 500, message: "Internal Server Error" };
+    expect(isAuthRevocationError(error)).toBe(false);
+  });
+});

--- a/inngest/functions/calendar/google-sync-all.ts
+++ b/inngest/functions/calendar/google-sync-all.ts
@@ -1,0 +1,25 @@
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+
+export const googleCalendarSyncAll = inngest.createFunction(
+  {
+    id: "crm-google-calendar-sync-all",
+    name: "CRM: Google Calendar sync (all connections)",
+    triggers: [{ cron: "*/15 * * * *" }],
+  },
+  async () => {
+    const connections = await prismadb.calendarConnection.findMany({
+      where: { isActive: true, provider: "google" },
+      select: { id: true },
+    });
+    if (connections.length === 0) return { synced: 0 };
+
+    await inngest.send(
+      connections.map((c) => ({
+        name: "crm/calendar.google-sync" as const,
+        data: { connectionId: c.id },
+      }))
+    );
+    return { synced: connections.length };
+  }
+);

--- a/inngest/functions/calendar/google-sync-connection.ts
+++ b/inngest/functions/calendar/google-sync-connection.ts
@@ -1,0 +1,104 @@
+import { inngest } from "@/inngest/client";
+import { prismadb } from "@/lib/prisma";
+import { getCalendarClientForConnection } from "@/lib/crm/calendar/google";
+import { normalizeGoogleEvent } from "@/lib/crm/calendar/google-normalize";
+import { upsertCalendarEvent } from "@/lib/crm/calendar/sync";
+import type { calendar_v3 } from "googleapis";
+
+const WINDOW_DAYS = 60;
+const AUTH_ERROR_CODES = new Set([401, 403]);
+
+export const googleCalendarSyncConnection = inngest.createFunction(
+  {
+    id: "crm-google-calendar-sync-connection",
+    name: "CRM: Google Calendar sync (one connection)",
+    retries: 3,
+    triggers: [{ event: "crm/calendar.google-sync" }],
+  },
+  async ({ event, step }) => {
+    const { connectionId } = event.data as { connectionId: string };
+
+    const result = await step.run("sync", async () => {
+      const connection = await prismadb.calendarConnection.findUnique({
+        where: { id: connectionId },
+      });
+      if (!connection || !connection.isActive) return { skipped: true };
+
+      const calendar = getCalendarClientForConnection(connection);
+      const items: calendar_v3.Schema$Event[] = [];
+      let syncToken = connection.syncToken;
+      let nextSyncToken: string | null | undefined;
+
+      const list = async (params: calendar_v3.Params$Resource$Events$List) => {
+        let pageToken: string | undefined;
+        do {
+          const res = await calendar.events.list({ ...params, pageToken, maxResults: 250 });
+          items.push(...(res.data.items ?? []));
+          pageToken = res.data.nextPageToken ?? undefined;
+          nextSyncToken = res.data.nextSyncToken ?? nextSyncToken;
+        } while (pageToken);
+      };
+
+      try {
+        if (syncToken) {
+          try {
+            await list({ calendarId: "primary", singleEvents: true, syncToken });
+          } catch (error) {
+            const code = (error as { code?: number }).code;
+            if (code !== 410) throw error;
+            // Sync token expired: fall back to a full window sync.
+            syncToken = null;
+            items.length = 0;
+          }
+        }
+        if (!syncToken) {
+          const now = Date.now();
+          await list({
+            calendarId: "primary",
+            singleEvents: true,
+            timeMin: new Date(now - WINDOW_DAYS * 86400000).toISOString(),
+            timeMax: new Date(now + WINDOW_DAYS * 86400000).toISOString(),
+          });
+        }
+      } catch (error) {
+        const code = (error as { code?: number }).code;
+        const message = error instanceof Error ? error.message : String(error);
+        await prismadb.calendarConnection.update({
+          where: { id: connection.id },
+          data: {
+            lastSyncError: message.slice(0, 500),
+            ...(code !== undefined && AUTH_ERROR_CODES.has(code) ? { isActive: false } : {}),
+          },
+        });
+        throw error;
+      }
+
+      const counts = { created: 0, updated: 0, cancelled: 0, skipped: 0 };
+      for (const ev of items) {
+        const normalized = normalizeGoogleEvent(ev, {
+          connectionId: connection.id,
+          accountEmail: connection.accountEmail,
+        });
+        if ("skip" in normalized) {
+          counts.skipped += 1;
+          continue;
+        }
+        const res = await upsertCalendarEvent(normalized);
+        counts[res.action] += 1;
+      }
+
+      await prismadb.calendarConnection.update({
+        where: { id: connection.id },
+        data: {
+          syncToken: nextSyncToken ?? syncToken,
+          lastSyncedAt: new Date(),
+          lastSyncError: null,
+        },
+      });
+
+      return { events: items.length, ...counts };
+    });
+
+    return result;
+  }
+);

--- a/inngest/functions/calendar/google-sync-connection.ts
+++ b/inngest/functions/calendar/google-sync-connection.ts
@@ -6,6 +6,8 @@ import { upsertCalendarEvent } from "@/lib/crm/calendar/sync";
 import type { calendar_v3 } from "googleapis";
 
 const WINDOW_DAYS = 60;
+// `error.code` as a numeric HTTP status comes from gaxios error construction
+// (verified against gaxios@7), which is what googleapis uses under the hood.
 const AUTH_ERROR_CODES = new Set([401, 403]);
 
 export const googleCalendarSyncConnection = inngest.createFunction(
@@ -39,6 +41,8 @@ export const googleCalendarSyncConnection = inngest.createFunction(
         } while (pageToken);
       };
 
+      const counts = { created: 0, updated: 0, cancelled: 0, skipped: 0 };
+
       try {
         if (syncToken) {
           try {
@@ -60,6 +64,22 @@ export const googleCalendarSyncConnection = inngest.createFunction(
             timeMax: new Date(now + WINDOW_DAYS * 86400000).toISOString(),
           });
         }
+
+        // A retry after a mid-loop failure re-processes already-synced events from
+        // scratch, which is safe because upsertCalendarEvent is idempotent per
+        // (source, externalId).
+        for (const ev of items) {
+          const normalized = normalizeGoogleEvent(ev, {
+            connectionId: connection.id,
+            accountEmail: connection.accountEmail,
+          });
+          if ("skip" in normalized) {
+            counts.skipped += 1;
+            continue;
+          }
+          const res = await upsertCalendarEvent(normalized);
+          counts[res.action] += 1;
+        }
       } catch (error) {
         const code = (error as { code?: number }).code;
         const message = error instanceof Error ? error.message : String(error);
@@ -71,20 +91,6 @@ export const googleCalendarSyncConnection = inngest.createFunction(
           },
         });
         throw error;
-      }
-
-      const counts = { created: 0, updated: 0, cancelled: 0, skipped: 0 };
-      for (const ev of items) {
-        const normalized = normalizeGoogleEvent(ev, {
-          connectionId: connection.id,
-          accountEmail: connection.accountEmail,
-        });
-        if ("skip" in normalized) {
-          counts.skipped += 1;
-          continue;
-        }
-        const res = await upsertCalendarEvent(normalized);
-        counts[res.action] += 1;
       }
 
       await prismadb.calendarConnection.update({

--- a/inngest/functions/calendar/google-sync-connection.ts
+++ b/inngest/functions/calendar/google-sync-connection.ts
@@ -6,9 +6,53 @@ import { upsertCalendarEvent } from "@/lib/crm/calendar/sync";
 import type { calendar_v3 } from "googleapis";
 
 const WINDOW_DAYS = 60;
+
+const RATE_LIMIT_MARKERS = [
+  "ratelimitexceeded",
+  "userratelimitexceeded",
+  "quotaexceeded",
+];
+const REVOCATION_MARKERS = ["invalid_grant", "unauthorized_client"];
+
 // `error.code` as a numeric HTTP status comes from gaxios error construction
 // (verified against gaxios@7), which is what googleapis uses under the hood.
-const AUTH_ERROR_CODES = new Set([401, 403]);
+// Google's error surfaces vary by endpoint:
+// - The token endpoint returns HTTP 400 with `error: "invalid_grant"` (or
+//   "unauthorized_client") for a revoked/expired refresh token — that must
+//   deactivate the connection, even though 400 isn't an auth status.
+// - The Calendar API itself uses 401 for a rejected access token.
+// - The Calendar API also uses 403 for both real auth revocations (e.g.
+//   insufficientPermissions) AND transient rate-limit errors
+//   (rateLimitExceeded / userRateLimitExceeded / quotaExceeded), which must
+//   NOT deactivate the connection.
+export function isAuthRevocationError(error: unknown): boolean {
+  const err = error as {
+    code?: number;
+    status?: number;
+    message?: string;
+    response?: { data?: { error?: string | { message?: string; errors?: Array<{ reason?: string }> } } };
+  };
+
+  const status = err?.code ?? err?.status;
+  const message = (err?.message ?? "").toLowerCase();
+
+  const responseError = err?.response?.data?.error;
+  const responseErrorText =
+    typeof responseError === "string"
+      ? responseError
+      : [
+          responseError?.message ?? "",
+          ...(responseError?.errors?.map((e) => e.reason ?? "") ?? []),
+        ].join(" ");
+  const combined = `${message} ${responseErrorText}`.toLowerCase();
+
+  if (REVOCATION_MARKERS.some((marker) => combined.includes(marker))) return true;
+  if (status === 401) return true;
+  if (status === 403) {
+    return !RATE_LIMIT_MARKERS.some((marker) => combined.includes(marker));
+  }
+  return false;
+}
 
 export const googleCalendarSyncConnection = inngest.createFunction(
   {
@@ -81,13 +125,12 @@ export const googleCalendarSyncConnection = inngest.createFunction(
           counts[res.action] += 1;
         }
       } catch (error) {
-        const code = (error as { code?: number }).code;
         const message = error instanceof Error ? error.message : String(error);
         await prismadb.calendarConnection.update({
           where: { id: connection.id },
           data: {
             lastSyncError: message.slice(0, 500),
-            ...(code !== undefined && AUTH_ERROR_CODES.has(code) ? { isActive: false } : {}),
+            ...(isAuthRevocationError(error) ? { isActive: false } : {}),
           },
         });
         throw error;

--- a/inngest/functions/calendar/process-event.ts
+++ b/inngest/functions/calendar/process-event.ts
@@ -1,0 +1,23 @@
+import { inngest } from "@/inngest/client";
+import { upsertCalendarEvent } from "@/lib/crm/calendar/sync";
+import type { CalendarEventInput, CalendarSource } from "@/lib/crm/calendar/types";
+
+type WireEvent = Omit<CalendarEventInput, "startAt" | "endAt" | "source"> & {
+  source: CalendarSource;
+  startAt: string;
+  endAt?: string | null;
+};
+
+export const calendarProcessEvent = inngest.createFunction(
+  { id: "crm-calendar-process-event", name: "CRM: Process calendar event", triggers: [{ event: "crm/calendar.event.received" }] },
+  async ({ event, step }) => {
+    const data = event.data as WireEvent;
+    return step.run("upsert", () =>
+      upsertCalendarEvent({
+        ...data,
+        startAt: new Date(data.startAt),
+        endAt: data.endAt ? new Date(data.endAt) : null,
+      })
+    );
+  }
+);

--- a/lib/crm/calendar/__tests__/calendly-signature.test.ts
+++ b/lib/crm/calendar/__tests__/calendly-signature.test.ts
@@ -1,0 +1,31 @@
+import { createHmac } from "crypto";
+import { verifyCalendlySignature } from "../calendly-signature";
+
+const KEY = "test-signing-key";
+
+function sign(body: string, t = "1721400000", key = KEY) {
+  const v1 = createHmac("sha256", key).update(`${t}.${body}`).digest("hex");
+  return `t=${t},v1=${v1}`;
+}
+
+describe("verifyCalendlySignature", () => {
+  it("accepts a valid signature", () => {
+    const body = JSON.stringify({ event: "invitee.created" });
+    expect(verifyCalendlySignature(body, sign(body), KEY)).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    expect(verifyCalendlySignature('{"a":2}', sign('{"a":1}'), KEY)).toBe(false);
+  });
+
+  it("rejects a wrong key", () => {
+    const body = "{}";
+    expect(verifyCalendlySignature(body, sign(body, "1721400000", "other"), KEY)).toBe(false);
+  });
+
+  it("rejects missing or malformed headers", () => {
+    expect(verifyCalendlySignature("{}", null, KEY)).toBe(false);
+    expect(verifyCalendlySignature("{}", "garbage", KEY)).toBe(false);
+    expect(verifyCalendlySignature("{}", "t=123", KEY)).toBe(false);
+  });
+});

--- a/lib/crm/calendar/__tests__/google-normalize.test.ts
+++ b/lib/crm/calendar/__tests__/google-normalize.test.ts
@@ -1,0 +1,73 @@
+import { normalizeGoogleEvent } from "../google-normalize";
+
+const OPTS = { connectionId: "conn1", accountEmail: "rep@aqunama.com" };
+
+function ev(overrides: object = {}) {
+  return {
+    id: "gev1",
+    iCalUID: "uid1@google.com",
+    status: "confirmed",
+    summary: "Client sync",
+    start: { dateTime: "2026-07-21T10:00:00+02:00" },
+    end: { dateTime: "2026-07-21T10:30:00+02:00" },
+    attendees: [
+      { email: "rep@aqunama.com", self: true, responseStatus: "accepted" },
+      { email: "jane@client.com", responseStatus: "accepted" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("normalizeGoogleEvent", () => {
+  it("normalizes a client meeting", () => {
+    const res = normalizeGoogleEvent(ev(), OPTS);
+    expect(res).toMatchObject({
+      source: "google",
+      externalId: "gev1",
+      iCalUID: "uid1@google.com",
+      connectionId: "conn1",
+      title: "Client sync",
+      counterpartyEmails: ["jane@client.com"],
+      hostEmail: "rep@aqunama.com",
+      status: "scheduled",
+    });
+    expect((res as { startAt: Date }).startAt.toISOString()).toBe("2026-07-21T08:00:00.000Z");
+  });
+
+  it("skips all-day events", () => {
+    expect(normalizeGoogleEvent(ev({ start: { date: "2026-07-21" }, end: { date: "2026-07-22" } }), OPTS))
+      .toEqual({ skip: "all-day" });
+  });
+
+  it("skips events the rep declined", () => {
+    const declined = ev({
+      attendees: [
+        { email: "rep@aqunama.com", self: true, responseStatus: "declined" },
+        { email: "jane@client.com" },
+      ],
+    });
+    expect(normalizeGoogleEvent(declined, OPTS)).toEqual({ skip: "declined" });
+  });
+
+  it("skips internal meetings (same-domain attendees only)", () => {
+    const internal = ev({
+      attendees: [
+        { email: "rep@aqunama.com", self: true },
+        { email: "colleague@aqunama.com" },
+      ],
+    });
+    expect(normalizeGoogleEvent(internal, OPTS)).toEqual({ skip: "no-counterparty" });
+  });
+
+  it("skips events without attendees", () => {
+    expect(normalizeGoogleEvent(ev({ attendees: undefined }), OPTS))
+      .toEqual({ skip: "no-counterparty" });
+  });
+
+  it("maps cancelled events to a cancelled input", () => {
+    const res = normalizeGoogleEvent(
+      { id: "gev1", status: "cancelled" }, OPTS
+    );
+    expect(res).toMatchObject({ source: "google", externalId: "gev1", status: "cancelled" });
+  });
+});

--- a/lib/crm/calendar/__tests__/match.test.ts
+++ b/lib/crm/calendar/__tests__/match.test.ts
@@ -1,0 +1,67 @@
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contacts: { findFirst: jest.fn() },
+    crm_Targets: { findFirst: jest.fn() },
+    crm_Leads: { findFirst: jest.fn() },
+    crm_Opportunities: { findMany: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { matchCounterparty } from "../match";
+
+const contacts = prismadb.crm_Contacts.findFirst as jest.Mock;
+const targets = prismadb.crm_Targets.findFirst as jest.Mock;
+const leads = prismadb.crm_Leads.findFirst as jest.Mock;
+const opps = prismadb.crm_Opportunities.findMany as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("matchCounterparty", () => {
+  it("returns [] for empty input without querying", async () => {
+    expect(await matchCounterparty([])).toEqual([]);
+    expect(contacts).not.toHaveBeenCalled();
+  });
+
+  it("matches contact and links account + single open opportunity", async () => {
+    contacts.mockResolvedValue({ id: "c1", accountsIDs: "a1" });
+    opps.mockResolvedValue([{ id: "o1" }]);
+    const links = await matchCounterparty(["jane@client.com"]);
+    expect(links).toEqual([
+      { entityType: "contact", entityId: "c1" },
+      { entityType: "account", entityId: "a1" },
+      { entityType: "opportunity", entityId: "o1" },
+    ]);
+  });
+
+  it("skips opportunity link when the account has several open deals", async () => {
+    contacts.mockResolvedValue({ id: "c1", accountsIDs: "a1" });
+    opps.mockResolvedValue([{ id: "o1" }, { id: "o2" }]);
+    const links = await matchCounterparty(["jane@client.com"]);
+    expect(links).toEqual([
+      { entityType: "contact", entityId: "c1" },
+      { entityType: "account", entityId: "a1" },
+    ]);
+  });
+
+  it("falls back to target, then lead", async () => {
+    contacts.mockResolvedValue(null);
+    targets.mockResolvedValue({ id: "t1" });
+    expect(await matchCounterparty(["x@y.com"])).toEqual([
+      { entityType: "target", entityId: "t1" },
+    ]);
+
+    targets.mockResolvedValue(null);
+    leads.mockResolvedValue({ id: "l1" });
+    expect(await matchCounterparty(["x@y.com"])).toEqual([
+      { entityType: "lead", entityId: "l1" },
+    ]);
+  });
+
+  it("returns [] when nothing matches", async () => {
+    contacts.mockResolvedValue(null);
+    targets.mockResolvedValue(null);
+    leads.mockResolvedValue(null);
+    expect(await matchCounterparty(["x@y.com"])).toEqual([]);
+  });
+});

--- a/lib/crm/calendar/__tests__/match.test.ts
+++ b/lib/crm/calendar/__tests__/match.test.ts
@@ -32,6 +32,11 @@ describe("matchCounterparty", () => {
       { entityType: "account", entityId: "a1" },
       { entityType: "opportunity", entityId: "o1" },
     ]);
+    expect(contacts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ deletedAt: null }),
+      })
+    );
   });
 
   it("skips opportunity link when the account has several open deals", async () => {
@@ -56,6 +61,11 @@ describe("matchCounterparty", () => {
     expect(await matchCounterparty(["x@y.com"])).toEqual([
       { entityType: "lead", entityId: "l1" },
     ]);
+    expect(leads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ deletedAt: null }),
+      })
+    );
   });
 
   it("returns [] when nothing matches", async () => {

--- a/lib/crm/calendar/__tests__/sync.test.ts
+++ b/lib/crm/calendar/__tests__/sync.test.ts
@@ -1,0 +1,166 @@
+// lib/crm/calendar/__tests__/sync.test.ts
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_CalendarEvents: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    crm_Activities: { create: jest.fn(), update: jest.fn() },
+    crm_Targets: { create: jest.fn() },
+    users: { findFirst: jest.fn() },
+  },
+}));
+jest.mock("../match", () => ({ matchCounterparty: jest.fn() }));
+
+import { prismadb } from "@/lib/prisma";
+import { matchCounterparty } from "../match";
+import { upsertCalendarEvent } from "../sync";
+import type { CalendarEventInput } from "../types";
+
+const mapping = prismadb.crm_CalendarEvents;
+const findUnique = mapping.findUnique as jest.Mock;
+const findMany = mapping.findMany as jest.Mock;
+const createMapping = mapping.create as jest.Mock;
+const updateMapping = mapping.update as jest.Mock;
+const createActivity = prismadb.crm_Activities.create as jest.Mock;
+const updateActivity = prismadb.crm_Activities.update as jest.Mock;
+const createTarget = prismadb.crm_Targets.create as jest.Mock;
+const findUser = prismadb.users.findFirst as jest.Mock;
+const match = matchCounterparty as jest.Mock;
+
+function input(overrides: Partial<CalendarEventInput> = {}): CalendarEventInput {
+  return {
+    source: "calendly",
+    externalId: "https://api.calendly.com/scheduled_events/EV1/invitees/INV1",
+    title: "Intro call",
+    startAt: new Date("2026-07-21T10:00:00Z"),
+    endAt: new Date("2026-07-21T10:30:00Z"),
+    counterpartyEmails: ["jane@client.com"],
+    hostEmail: "rep@aqunama.com",
+    status: "scheduled",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findUnique.mockResolvedValue(null);
+  findMany.mockResolvedValue([]);
+  findUser.mockResolvedValue(null);
+  createActivity.mockResolvedValue({ id: "act1" });
+  createMapping.mockResolvedValue({ id: "map1" });
+});
+
+describe("upsertCalendarEvent", () => {
+  it("creates activity + mapping for a matched event", async () => {
+    match.mockResolvedValue([{ entityType: "contact", entityId: "c1" }]);
+    const res = await upsertCalendarEvent(input());
+    expect(res).toEqual({ action: "created", activityId: "act1" });
+    expect(createActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "meeting",
+          status: "scheduled",
+          duration: 30,
+          links: { create: [{ entityType: "contact", entityId: "c1" }] },
+        }),
+      })
+    );
+    expect(createMapping).toHaveBeenCalled();
+  });
+
+  it("cancels an existing mapping + activity", async () => {
+    findUnique.mockResolvedValue({
+      id: "map1", activityId: "act1", status: "scheduled",
+      startAt: new Date("2026-07-21T10:00:00Z"),
+    });
+    const res = await upsertCalendarEvent(input({ status: "cancelled" }));
+    expect(res.action).toBe("cancelled");
+    expect(updateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "act1" },
+        data: expect.objectContaining({ status: "cancelled" }),
+      })
+    );
+  });
+
+  it("updates activity date on reschedule", async () => {
+    findUnique.mockResolvedValue({
+      id: "map1", activityId: "act1", status: "scheduled",
+      startAt: new Date("2026-07-21T10:00:00Z"),
+    });
+    const res = await upsertCalendarEvent(
+      input({ startAt: new Date("2026-07-22T09:00:00Z") })
+    );
+    expect(res.action).toBe("updated");
+    expect(updateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ date: new Date("2026-07-22T09:00:00Z") }),
+      })
+    );
+  });
+
+  it("skips unchanged existing events", async () => {
+    findUnique.mockResolvedValue({
+      id: "map1", activityId: "act1", status: "scheduled",
+      startAt: new Date("2026-07-21T10:00:00Z"),
+    });
+    const res = await upsertCalendarEvent(input());
+    expect(res).toEqual({ action: "skipped", reason: "unchanged" });
+  });
+
+  it("skips a cancel for an unknown event", async () => {
+    const res = await upsertCalendarEvent(input({ status: "cancelled" }));
+    expect(res).toEqual({ action: "skipped", reason: "cancel-for-unknown" });
+  });
+
+  it("skips a google event that duplicates a calendly booking", async () => {
+    findMany.mockResolvedValue([
+      { attendeeEmails: ["jane@client.com"] },
+    ]);
+    const res = await upsertCalendarEvent(
+      input({ source: "google", externalId: "gev1", connectionId: "conn1" })
+    );
+    expect(res).toEqual({ action: "skipped", reason: "duplicate-of-calendly" });
+    expect(createActivity).not.toHaveBeenCalled();
+  });
+
+  it("skips unmatched google events", async () => {
+    match.mockResolvedValue([]);
+    const res = await upsertCalendarEvent(
+      input({ source: "google", externalId: "gev1", connectionId: "conn1" })
+    );
+    expect(res).toEqual({ action: "skipped", reason: "no-match" });
+    expect(createTarget).not.toHaveBeenCalled();
+  });
+
+  it("creates a Target for unmatched calendly invitees, assigned to the host rep", async () => {
+    match.mockResolvedValue([]);
+    findUser.mockResolvedValue({ id: "rep1" });
+    createTarget.mockResolvedValue({ id: "t-new" });
+    const res = await upsertCalendarEvent(
+      input({ rawPayload: { payload: { name: "Jane Doe" } } })
+    );
+    expect(res.action).toBe("created");
+    expect(createTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          first_name: "Jane",
+          last_name: "Doe",
+          email: "jane@client.com",
+          tags: ["book-a-call"],
+          created_by: "rep1",
+        }),
+      })
+    );
+    expect(createActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          links: { create: [{ entityType: "target", entityId: "t-new" }] },
+        }),
+      })
+    );
+  });
+});

--- a/lib/crm/calendar/__tests__/sync.test.ts
+++ b/lib/crm/calendar/__tests__/sync.test.ts
@@ -1,6 +1,6 @@
 // lib/crm/calendar/__tests__/sync.test.ts
-jest.mock("@/lib/prisma", () => ({
-  prismadb: {
+jest.mock("@/lib/prisma", () => {
+  const mock: Record<string, unknown> = {
     crm_CalendarEvents: {
       findUnique: jest.fn(),
       findMany: jest.fn(),
@@ -10,8 +10,10 @@ jest.mock("@/lib/prisma", () => ({
     crm_Activities: { create: jest.fn(), update: jest.fn() },
     crm_Targets: { create: jest.fn() },
     users: { findFirst: jest.fn() },
-  },
-}));
+  };
+  mock.$transaction = jest.fn(async (fn: (tx: unknown) => unknown) => fn(mock));
+  return { prismadb: mock };
+});
 jest.mock("../match", () => ({ matchCounterparty: jest.fn() }));
 
 import { prismadb } from "@/lib/prisma";
@@ -29,6 +31,7 @@ const updateActivity = prismadb.crm_Activities.update as jest.Mock;
 const createTarget = prismadb.crm_Targets.create as jest.Mock;
 const findUser = prismadb.users.findFirst as jest.Mock;
 const match = matchCounterparty as jest.Mock;
+const transaction = prismadb.$transaction as jest.Mock;
 
 function input(overrides: Partial<CalendarEventInput> = {}): CalendarEventInput {
   return {
@@ -84,6 +87,11 @@ describe("upsertCalendarEvent", () => {
         data: expect.objectContaining({ status: "cancelled" }),
       })
     );
+    expect(updateMapping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "cancelled" }),
+      })
+    );
   });
 
   it("updates activity date on reschedule", async () => {
@@ -98,6 +106,11 @@ describe("upsertCalendarEvent", () => {
     expect(updateActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ date: new Date("2026-07-22T09:00:00Z") }),
+      })
+    );
+    expect(updateMapping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ startAt: new Date("2026-07-22T09:00:00Z") }),
       })
     );
   });
@@ -162,5 +175,12 @@ describe("upsertCalendarEvent", () => {
         }),
       })
     );
+  });
+
+  it("treats a concurrent duplicate-create race as benign (P2002)", async () => {
+    match.mockResolvedValue([{ entityType: "contact", entityId: "c1" }]);
+    transaction.mockRejectedValueOnce(Object.assign(new Error("dup"), { code: "P2002" }));
+    const res = await upsertCalendarEvent(input());
+    expect(res).toEqual({ action: "skipped", reason: "concurrent-duplicate" });
   });
 });

--- a/lib/crm/calendar/calendly-settings.ts
+++ b/lib/crm/calendar/calendly-settings.ts
@@ -1,0 +1,46 @@
+import { prismadb } from "@/lib/prisma";
+import { encrypt, decrypt } from "@/lib/email-crypto";
+
+const KEYS = {
+  apiToken: "calendly_api_token",
+  signingKey: "calendly_signing_key",
+  webhookUri: "calendly_webhook_uri",
+} as const;
+
+async function read(key: string): Promise<string | null> {
+  const row = await prismadb.crm_SystemSettings.findUnique({ where: { key } });
+  return row?.value ?? null;
+}
+
+async function write(key: string, value: string): Promise<void> {
+  await prismadb.crm_SystemSettings.upsert({
+    where: { key },
+    update: { value },
+    create: { key, value },
+  });
+}
+
+export async function getCalendlySettings() {
+  const [token, signing, uri] = await Promise.all([
+    read(KEYS.apiToken),
+    read(KEYS.signingKey),
+    read(KEYS.webhookUri),
+  ]);
+  return {
+    apiToken: token ? decrypt(token) : null,
+    signingKey: signing ? decrypt(signing) : null,
+    webhookUri: uri,
+  };
+}
+
+export async function saveCalendlySettings(input: {
+  apiToken?: string;
+  signingKey?: string;
+}): Promise<void> {
+  if (input.apiToken) await write(KEYS.apiToken, encrypt(input.apiToken));
+  if (input.signingKey) await write(KEYS.signingKey, encrypt(input.signingKey));
+}
+
+export async function setCalendlyWebhookUri(uri: string): Promise<void> {
+  await write(KEYS.webhookUri, uri);
+}

--- a/lib/crm/calendar/calendly-signature.ts
+++ b/lib/crm/calendar/calendly-signature.ts
@@ -1,0 +1,24 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+// Calendly signs webhooks with: Calendly-Webhook-Signature: t=<unix>,v1=<hex>
+// where v1 = HMAC-SHA256(signingKey, `${t}.${rawBody}`).
+export function verifyCalendlySignature(
+  rawBody: string,
+  header: string | null,
+  signingKey: string
+): boolean {
+  if (!header || !signingKey) return false;
+  const parts = Object.fromEntries(
+    header.split(",").map((p) => p.trim().split("=", 2) as [string, string])
+  );
+  const t = parts["t"];
+  const v1 = parts["v1"];
+  if (!t || !v1) return false;
+
+  const expected = createHmac("sha256", signingKey)
+    .update(`${t}.${rawBody}`)
+    .digest("hex");
+  const a = Buffer.from(v1, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/lib/crm/calendar/google-normalize.ts
+++ b/lib/crm/calendar/google-normalize.ts
@@ -1,0 +1,56 @@
+import type { calendar_v3 } from "googleapis";
+import type { CalendarEventInput } from "./types";
+
+export type NormalizeResult = CalendarEventInput | { skip: string };
+
+export function normalizeGoogleEvent(
+  ev: calendar_v3.Schema$Event,
+  opts: { connectionId: string; accountEmail: string }
+): NormalizeResult {
+  if (!ev.id) return { skip: "no-id" };
+
+  if (ev.status === "cancelled") {
+    // Cancelled payloads are sparse; downstream only needs the identity.
+    return {
+      source: "google",
+      externalId: ev.id,
+      iCalUID: ev.iCalUID ?? null,
+      connectionId: opts.connectionId,
+      title: ev.summary ?? "Meeting",
+      startAt: ev.start?.dateTime ? new Date(ev.start.dateTime) : new Date(0),
+      endAt: null,
+      counterpartyEmails: [],
+      hostEmail: opts.accountEmail,
+      status: "cancelled",
+      rawPayload: ev,
+    };
+  }
+
+  if (!ev.start?.dateTime) return { skip: "all-day" };
+
+  const attendees = ev.attendees ?? [];
+  const self = attendees.find((a) => a.self);
+  if (self?.responseStatus === "declined") return { skip: "declined" };
+
+  const repDomain = opts.accountEmail.split("@")[1]?.toLowerCase();
+  const counterparty = attendees
+    .map((a) => a.email?.toLowerCase())
+    .filter((e): e is string => Boolean(e))
+    .filter((e) => e !== opts.accountEmail.toLowerCase())
+    .filter((e) => e.split("@")[1] !== repDomain);
+  if (counterparty.length === 0) return { skip: "no-counterparty" };
+
+  return {
+    source: "google",
+    externalId: ev.id,
+    iCalUID: ev.iCalUID ?? null,
+    connectionId: opts.connectionId,
+    title: ev.summary ?? "Meeting",
+    startAt: new Date(ev.start.dateTime),
+    endAt: ev.end?.dateTime ? new Date(ev.end.dateTime) : null,
+    counterpartyEmails: counterparty,
+    hostEmail: opts.accountEmail,
+    status: "scheduled",
+    rawPayload: ev,
+  };
+}

--- a/lib/crm/calendar/google.ts
+++ b/lib/crm/calendar/google.ts
@@ -19,11 +19,12 @@ export function getGoogleOAuthClient(): OAuth2Client {
   );
 }
 
-export function getGoogleAuthUrl(): string {
+export function getGoogleAuthUrl(state: string): string {
   return getGoogleOAuthClient().generateAuthUrl({
     access_type: "offline",
     prompt: "consent",
     scope: SCOPES,
+    state,
   });
 }
 

--- a/lib/crm/calendar/google.ts
+++ b/lib/crm/calendar/google.ts
@@ -1,0 +1,36 @@
+import { google, calendar_v3 } from "googleapis";
+import { decrypt } from "@/lib/email-crypto";
+
+// `google-auth-library` is a transitive dependency of `googleapis` (not a
+// direct package.json dependency), and under pnpm's strict node_modules
+// layout its types are not directly importable — and two disjoint copies
+// (10.5.0 / 10.9.0) can be present transitively, so an `OAuth2Client` type
+// imported from one is not assignable to the other. Deriving the type from
+// `google.auth.OAuth2` itself sidesteps both problems.
+type OAuth2Client = InstanceType<typeof google.auth.OAuth2>;
+
+const SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"];
+
+export function getGoogleOAuthClient(): OAuth2Client {
+  return new google.auth.OAuth2(
+    process.env.GOOGLE_CALENDAR_CLIENT_ID,
+    process.env.GOOGLE_CALENDAR_CLIENT_SECRET,
+    `${process.env.NEXT_PUBLIC_APP_URL}/api/profile/calendar-connections/google/callback`
+  );
+}
+
+export function getGoogleAuthUrl(): string {
+  return getGoogleOAuthClient().generateAuthUrl({
+    access_type: "offline",
+    prompt: "consent",
+    scope: SCOPES,
+  });
+}
+
+export function getCalendarClientForConnection(connection: {
+  refreshTokenEncrypted: string;
+}): calendar_v3.Calendar {
+  const auth = getGoogleOAuthClient();
+  auth.setCredentials({ refresh_token: decrypt(connection.refreshTokenEncrypted) });
+  return google.calendar({ version: "v3", auth });
+}

--- a/lib/crm/calendar/match.ts
+++ b/lib/crm/calendar/match.ts
@@ -8,6 +8,7 @@ export async function matchCounterparty(emails: string[]): Promise<EntityLink[]>
 
   const contact = await prismadb.crm_Contacts.findFirst({
     where: {
+      deletedAt: null,
       OR: [
         { email: { in: normalized, mode: "insensitive" } },
         { personal_email: { in: normalized, mode: "insensitive" } },
@@ -45,7 +46,7 @@ export async function matchCounterparty(emails: string[]): Promise<EntityLink[]>
   if (target) return [{ entityType: "target", entityId: target.id }];
 
   const lead = await prismadb.crm_Leads.findFirst({
-    where: { email: { in: normalized, mode: "insensitive" } },
+    where: { deletedAt: null, email: { in: normalized, mode: "insensitive" } },
     select: { id: true },
   });
   if (lead) return [{ entityType: "lead", entityId: lead.id }];

--- a/lib/crm/calendar/match.ts
+++ b/lib/crm/calendar/match.ts
@@ -1,0 +1,54 @@
+import { prismadb } from "@/lib/prisma";
+import type { EntityLink } from "./types";
+
+// Spec matching order: contact (+account +single open opp) -> target -> lead.
+export async function matchCounterparty(emails: string[]): Promise<EntityLink[]> {
+  const normalized = emails.map((e) => e.trim().toLowerCase()).filter(Boolean);
+  if (normalized.length === 0) return [];
+
+  const contact = await prismadb.crm_Contacts.findFirst({
+    where: {
+      OR: [
+        { email: { in: normalized, mode: "insensitive" } },
+        { personal_email: { in: normalized, mode: "insensitive" } },
+      ],
+    },
+    select: { id: true, accountsIDs: true },
+  });
+  if (contact) {
+    const links: EntityLink[] = [{ entityType: "contact", entityId: contact.id }];
+    if (contact.accountsIDs) {
+      links.push({ entityType: "account", entityId: contact.accountsIDs });
+      const open = await prismadb.crm_Opportunities.findMany({
+        where: { account: contact.accountsIDs, status: "ACTIVE", deletedAt: null },
+        select: { id: true },
+        take: 2,
+      });
+      if (open.length === 1) {
+        links.push({ entityType: "opportunity", entityId: open[0].id });
+      }
+    }
+    return links;
+  }
+
+  const target = await prismadb.crm_Targets.findFirst({
+    where: {
+      deletedAt: null,
+      OR: [
+        { email: { in: normalized, mode: "insensitive" } },
+        { personal_email: { in: normalized, mode: "insensitive" } },
+        { company_email: { in: normalized, mode: "insensitive" } },
+      ],
+    },
+    select: { id: true },
+  });
+  if (target) return [{ entityType: "target", entityId: target.id }];
+
+  const lead = await prismadb.crm_Leads.findFirst({
+    where: { email: { in: normalized, mode: "insensitive" } },
+    select: { id: true },
+  });
+  if (lead) return [{ entityType: "lead", entityId: lead.id }];
+
+  return [];
+}

--- a/lib/crm/calendar/sync.ts
+++ b/lib/crm/calendar/sync.ts
@@ -1,0 +1,137 @@
+// lib/crm/calendar/sync.ts
+import { prismadb } from "@/lib/prisma";
+import { matchCounterparty } from "./match";
+import type { CalendarEventInput, EntityLink, UpsertResult } from "./types";
+
+function inviteeName(input: CalendarEventInput): { first: string | null; last: string } {
+  const raw =
+    (input.rawPayload as { payload?: { name?: string } } | undefined)?.payload?.name ??
+    input.counterpartyEmails[0] ??
+    "Unknown";
+  const parts = raw.trim().split(/\s+/);
+  if (parts.length === 1) return { first: null, last: parts[0] };
+  return { first: parts.slice(0, -1).join(" "), last: parts[parts.length - 1] };
+}
+
+async function resolveHostUserId(hostEmail: string | null | undefined): Promise<string | null> {
+  if (!hostEmail) return null;
+  const user = await prismadb.users.findFirst({
+    where: { email: hostEmail },
+    select: { id: true },
+  });
+  return user?.id ?? null;
+}
+
+export async function upsertCalendarEvent(input: CalendarEventInput): Promise<UpsertResult> {
+  const existing = await prismadb.crm_CalendarEvents.findUnique({
+    where: { source_externalId: { source: input.source, externalId: input.externalId } },
+  });
+
+  if (existing) {
+    if (input.status === "cancelled" && existing.status !== "cancelled") {
+      await prismadb.crm_CalendarEvents.update({
+        where: { id: existing.id },
+        data: { status: "cancelled", rawPayload: (input.rawPayload as object) ?? undefined },
+      });
+      await prismadb.crm_Activities.update({
+        where: { id: existing.activityId },
+        data: { status: "cancelled" },
+      });
+      return { action: "cancelled", activityId: existing.activityId };
+    }
+    if (
+      input.status === "scheduled" &&
+      existing.startAt.getTime() !== input.startAt.getTime()
+    ) {
+      await prismadb.crm_CalendarEvents.update({
+        where: { id: existing.id },
+        data: {
+          startAt: input.startAt,
+          endAt: input.endAt ?? null,
+          status: "scheduled",
+          rawPayload: (input.rawPayload as object) ?? undefined,
+        },
+      });
+      await prismadb.crm_Activities.update({
+        where: { id: existing.activityId },
+        data: { date: input.startAt, status: "scheduled" },
+      });
+      return { action: "updated", activityId: existing.activityId };
+    }
+    return { action: "skipped", reason: "unchanged" };
+  }
+
+  if (input.status === "cancelled") {
+    return { action: "skipped", reason: "cancel-for-unknown" };
+  }
+
+  // Cross-source dedup: a Calendly booking also appears on the rep's Google
+  // Calendar. Skip google events whose start time + attendee already exist
+  // as a calendly-sourced row.
+  if (input.source === "google") {
+    const sameSlot = await prismadb.crm_CalendarEvents.findMany({
+      where: { source: "calendly", startAt: input.startAt },
+      select: { attendeeEmails: true },
+    });
+    const mine = new Set(input.counterpartyEmails.map((e) => e.toLowerCase()));
+    const duplicate = sameSlot.some((row) =>
+      (row.attendeeEmails as string[]).some((e) => mine.has(e.toLowerCase()))
+    );
+    if (duplicate) return { action: "skipped", reason: "duplicate-of-calendly" };
+  }
+
+  const hostUserId = await resolveHostUserId(input.hostEmail);
+  let links: EntityLink[] = await matchCounterparty(input.counterpartyEmails);
+
+  if (links.length === 0) {
+    if (input.source === "google") return { action: "skipped", reason: "no-match" };
+    // Calendly no-match: a booking from an unknown person is a new lead ->
+    // auto-create a Target (spec: source "Book-a-call").
+    const { first, last } = inviteeName(input);
+    const target = await prismadb.crm_Targets.create({
+      data: {
+        first_name: first,
+        last_name: last,
+        email: input.counterpartyEmails[0] ?? null,
+        tags: ["book-a-call"],
+        created_by: hostUserId,
+      },
+    });
+    links = [{ entityType: "target", entityId: target.id }];
+  }
+
+  const durationMinutes =
+    input.endAt != null
+      ? Math.max(0, Math.round((input.endAt.getTime() - input.startAt.getTime()) / 60000))
+      : null;
+
+  const activity = await prismadb.crm_Activities.create({
+    data: {
+      type: "meeting",
+      title: input.title,
+      date: input.startAt,
+      duration: durationMinutes,
+      status: "scheduled",
+      metadata: { calendarSource: input.source },
+      createdBy: hostUserId,
+      links: { create: links },
+    },
+  });
+
+  await prismadb.crm_CalendarEvents.create({
+    data: {
+      source: input.source,
+      externalId: input.externalId,
+      iCalUID: input.iCalUID ?? null,
+      connectionId: input.connectionId ?? null,
+      activityId: activity.id,
+      startAt: input.startAt,
+      endAt: input.endAt ?? null,
+      attendeeEmails: input.counterpartyEmails,
+      status: "scheduled",
+      rawPayload: (input.rawPayload as object) ?? undefined,
+    },
+  });
+
+  return { action: "created", activityId: activity.id };
+}

--- a/lib/crm/calendar/sync.ts
+++ b/lib/crm/calendar/sync.ts
@@ -29,13 +29,15 @@ export async function upsertCalendarEvent(input: CalendarEventInput): Promise<Up
 
   if (existing) {
     if (input.status === "cancelled" && existing.status !== "cancelled") {
-      await prismadb.crm_CalendarEvents.update({
-        where: { id: existing.id },
-        data: { status: "cancelled", rawPayload: (input.rawPayload as object) ?? undefined },
-      });
-      await prismadb.crm_Activities.update({
-        where: { id: existing.activityId },
-        data: { status: "cancelled" },
+      await prismadb.$transaction(async (tx) => {
+        await tx.crm_CalendarEvents.update({
+          where: { id: existing.id },
+          data: { status: "cancelled", rawPayload: (input.rawPayload as object) ?? undefined },
+        });
+        await tx.crm_Activities.update({
+          where: { id: existing.activityId },
+          data: { status: "cancelled" },
+        });
       });
       return { action: "cancelled", activityId: existing.activityId };
     }
@@ -43,18 +45,20 @@ export async function upsertCalendarEvent(input: CalendarEventInput): Promise<Up
       input.status === "scheduled" &&
       existing.startAt.getTime() !== input.startAt.getTime()
     ) {
-      await prismadb.crm_CalendarEvents.update({
-        where: { id: existing.id },
-        data: {
-          startAt: input.startAt,
-          endAt: input.endAt ?? null,
-          status: "scheduled",
-          rawPayload: (input.rawPayload as object) ?? undefined,
-        },
-      });
-      await prismadb.crm_Activities.update({
-        where: { id: existing.activityId },
-        data: { date: input.startAt, status: "scheduled" },
+      await prismadb.$transaction(async (tx) => {
+        await tx.crm_CalendarEvents.update({
+          where: { id: existing.id },
+          data: {
+            startAt: input.startAt,
+            endAt: input.endAt ?? null,
+            status: "scheduled",
+            rawPayload: (input.rawPayload as object) ?? undefined,
+          },
+        });
+        await tx.crm_Activities.update({
+          where: { id: existing.activityId },
+          data: { date: input.startAt, status: "scheduled" },
+        });
       });
       return { action: "updated", activityId: existing.activityId };
     }
@@ -81,23 +85,10 @@ export async function upsertCalendarEvent(input: CalendarEventInput): Promise<Up
   }
 
   const hostUserId = await resolveHostUserId(input.hostEmail);
-  let links: EntityLink[] = await matchCounterparty(input.counterpartyEmails);
+  const matched: EntityLink[] = await matchCounterparty(input.counterpartyEmails);
 
-  if (links.length === 0) {
-    if (input.source === "google") return { action: "skipped", reason: "no-match" };
-    // Calendly no-match: a booking from an unknown person is a new lead ->
-    // auto-create a Target (spec: source "Book-a-call").
-    const { first, last } = inviteeName(input);
-    const target = await prismadb.crm_Targets.create({
-      data: {
-        first_name: first,
-        last_name: last,
-        email: input.counterpartyEmails[0] ?? null,
-        tags: ["book-a-call"],
-        created_by: hostUserId,
-      },
-    });
-    links = [{ entityType: "target", entityId: target.id }];
+  if (matched.length === 0 && input.source === "google") {
+    return { action: "skipped", reason: "no-match" };
   }
 
   const durationMinutes =
@@ -105,33 +96,61 @@ export async function upsertCalendarEvent(input: CalendarEventInput): Promise<Up
       ? Math.max(0, Math.round((input.endAt.getTime() - input.startAt.getTime()) / 60000))
       : null;
 
-  const activity = await prismadb.crm_Activities.create({
-    data: {
-      type: "meeting",
-      title: input.title,
-      date: input.startAt,
-      duration: durationMinutes,
-      status: "scheduled",
-      metadata: { calendarSource: input.source },
-      createdBy: hostUserId,
-      links: { create: links },
-    },
-  });
+  try {
+    const activityId = await prismadb.$transaction(async (tx) => {
+      let links = matched;
+      if (links.length === 0) {
+        // Calendly no-match: a booking from an unknown person is a new lead ->
+        // auto-create a Target (spec: source "Book-a-call").
+        const { first, last } = inviteeName(input);
+        const target = await tx.crm_Targets.create({
+          data: {
+            first_name: first,
+            last_name: last,
+            email: input.counterpartyEmails[0] ?? null,
+            tags: ["book-a-call"],
+            created_by: hostUserId,
+          },
+        });
+        links = [{ entityType: "target", entityId: target.id }];
+      }
 
-  await prismadb.crm_CalendarEvents.create({
-    data: {
-      source: input.source,
-      externalId: input.externalId,
-      iCalUID: input.iCalUID ?? null,
-      connectionId: input.connectionId ?? null,
-      activityId: activity.id,
-      startAt: input.startAt,
-      endAt: input.endAt ?? null,
-      attendeeEmails: input.counterpartyEmails,
-      status: "scheduled",
-      rawPayload: (input.rawPayload as object) ?? undefined,
-    },
-  });
+      const activity = await tx.crm_Activities.create({
+        data: {
+          type: "meeting",
+          title: input.title,
+          date: input.startAt,
+          duration: durationMinutes,
+          status: "scheduled",
+          metadata: { calendarSource: input.source },
+          createdBy: hostUserId,
+          links: { create: links },
+        },
+      });
 
-  return { action: "created", activityId: activity.id };
+      await tx.crm_CalendarEvents.create({
+        data: {
+          source: input.source,
+          externalId: input.externalId,
+          iCalUID: input.iCalUID ?? null,
+          connectionId: input.connectionId ?? null,
+          activityId: activity.id,
+          startAt: input.startAt,
+          endAt: input.endAt ?? null,
+          attendeeEmails: input.counterpartyEmails,
+          status: "scheduled",
+          rawPayload: (input.rawPayload as object) ?? undefined,
+        },
+      });
+
+      return activity.id;
+    });
+
+    return { action: "created", activityId };
+  } catch (error) {
+    if ((error as { code?: string }).code === "P2002") {
+      return { action: "skipped", reason: "concurrent-duplicate" };
+    }
+    throw error;
+  }
 }

--- a/lib/crm/calendar/types.ts
+++ b/lib/crm/calendar/types.ts
@@ -1,0 +1,20 @@
+export type CalendarSource = "calendly" | "google";
+export type CalendarEventInput = {
+  source: CalendarSource;
+  externalId: string;
+  iCalUID?: string | null;
+  connectionId?: string | null;
+  title: string;
+  startAt: Date;
+  endAt?: Date | null;
+  counterpartyEmails: string[];
+  hostEmail?: string | null;
+  status: "scheduled" | "cancelled";
+  rawPayload?: unknown;
+};
+export type EntityLink = { entityType: string; entityId: string };
+export type UpsertResult = {
+  action: "created" | "updated" | "cancelled" | "skipped";
+  reason?: string;
+  activityId?: string;
+};

--- a/lib/crm/client-activity.ts
+++ b/lib/crm/client-activity.ts
@@ -26,6 +26,7 @@ export async function getLastClientActivity(opp: {
   const lastActivity = await prismadb.crm_Activities.findFirst({
     where: {
       deletedAt: null,
+      status: { not: "cancelled" },
       links: { some: { entityType: "opportunity", entityId: opp.id } },
     },
     orderBy: { date: "desc" },

--- a/locales/cz.json
+++ b/locales/cz.json
@@ -281,6 +281,8 @@
     "tabs": {
       "emails": "Email Accounts",
       "emailsDesc": "Manage your connected IMAP mailboxes",
+      "calendar": "Kalendář",
+      "calendarDesc": "Správa připojených kalendářů",
       "llms": "LLMs",
       "llmsDesc": "Spravujte své klíče LLM API"
     }

--- a/locales/de.json
+++ b/locales/de.json
@@ -277,6 +277,8 @@
     "tabs": {
       "emails": "Email Accounts",
       "emailsDesc": "Manage your connected IMAP mailboxes",
+      "calendar": "Kalender",
+      "calendarDesc": "Verbundene Kalender verwalten",
       "llms": "LLMs",
       "llmsDesc": "LLM API-Schlüssel verwalten"
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -287,6 +287,8 @@
       "preferencesDesc": "Customize your language and display settings",
       "developerDesc": "Manage API keys and developer integrations",
       "emailsDesc": "Manage your connected IMAP mailboxes",
+      "calendar": "Calendar",
+      "calendarDesc": "Manage your connected calendars",
       "llms": "LLMs",
       "llmsDesc": "Manage your LLM API keys"
     },

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -277,6 +277,8 @@
     "tabs": {
       "emails": "Email Accounts",
       "emailsDesc": "Manage your connected IMAP mailboxes",
+      "calendar": "Календар",
+      "calendarDesc": "Керування підключеними календарями",
       "llms": "LLMs",
       "llmsDesc": "Керуйте своїми LLM API-ключами"
     }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "exceljs": "^4.4.0",
     "form-data": "^4.0.6",
     "geist": "^1.7.0",
+    "googleapis": "^173.0.0",
     "imap": "^0.8.19",
     "inngest": "^4.0.2",
     "input-otp": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       geist:
         specifier: ^1.7.0
         version: 1.7.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      googleapis:
+        specifier: ^173.0.0
+        version: 173.0.0
       imap:
         specifier: ^0.8.19
         version: 0.8.19
@@ -423,7 +426,7 @@ importers:
         version: 7.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(types-react-dom@19.0.0-rc.1)(types-react@19.0.0-rc.1)(typescript@5.9.3)
       shadcn:
         specifier: ^3.8.5
-        version: 3.8.5(@types/node@25.5.0)(supports-color@5.5.0)(typescript@5.9.3)
+        version: 3.8.5(@types/node@25.5.0)(typescript@5.9.3)
       ts-jest:
         specifier: ^29.4.6
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
@@ -4864,6 +4867,9 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -5409,6 +5415,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   eciesjs@0.4.17:
     resolution: {integrity: sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -5899,6 +5908,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
 
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
@@ -6017,9 +6030,25 @@ packages:
     peerDependencies:
       csstype: ^3.0.10
 
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
+
+  googleapis-common@8.0.2:
+    resolution: {integrity: sha512-5MXeQzIZaqCH7B+HJWqhQm946VARpZep6acbWSr/fcgF2cQANq7allgX+i/G0EqF0WyUxB277gtWMzRYHMl9tg==}
+    engines: {node: '>=18.0.0'}
+
+  googleapis@173.0.0:
+    resolution: {integrity: sha512-xEJJYLZ4qeenVyfzispNfRjCe9bsv7CzBv5zYFLvScOze9snJ8S9W6hjQ729CWPQt5mvn/JrcRaCHzQiukt0ng==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -6037,6 +6066,10 @@ packages:
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -6717,6 +6750,12 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -8102,6 +8141,10 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -8745,6 +8788,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -14297,6 +14343,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-from@1.1.2: {}
 
   buffer-indexof-polyfill@1.0.2: {}
@@ -14794,6 +14842,10 @@ snapshots:
       tar: 7.5.11
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   eciesjs@0.4.17:
     dependencies:
@@ -15511,10 +15563,19 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
@@ -15645,7 +15706,48 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      qs: 6.15.0
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@173.0.0:
+    dependencies:
+      google-auth-library: 10.9.0
+      googleapis-common: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -15656,6 +15758,13 @@ snapshots:
   graphmatch@1.1.1: {}
 
   graphql@16.12.0: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.4
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   handlebars@4.7.9:
     dependencies:
@@ -15760,7 +15869,7 @@ snapshots:
       - supports-color
     optional: true
 
-  https-proxy-agent@7.0.6(supports-color@5.5.0):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
@@ -16498,6 +16607,17 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -17919,6 +18039,10 @@ snapshots:
       glob: 7.2.3
     optional: true
 
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
+
   rope-sequence@1.3.4: {}
 
   rou3@0.7.12: {}
@@ -18040,7 +18164,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.8.5(@types/node@25.5.0)(supports-color@5.5.0)(typescript@5.9.3):
+  shadcn@3.8.5(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.29.0
@@ -18060,7 +18184,7 @@ snapshots:
       fast-glob: 3.3.3
       fs-extra: 11.3.3
       fuzzysort: 3.1.0
-      https-proxy-agent: 7.0.6(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6
       kleur: 4.1.5
       msw: 2.12.10(@types/node@25.5.0)(typescript@5.9.3)
       node-fetch: 3.3.2
@@ -18710,6 +18834,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-template@2.0.8: {}
 
   use-callback-ref@1.3.3(react@19.2.4)(types-react@19.0.0-rc.1):
     dependencies:

--- a/prisma/migrations/20260719130047_aqunama_p4_calendar_sync/migration.sql
+++ b/prisma/migrations/20260719130047_aqunama_p4_calendar_sync/migration.sql
@@ -1,0 +1,71 @@
+-- CreateEnum
+CREATE TYPE "CalendarProvider" AS ENUM ('google');
+
+-- CreateTable
+CREATE TABLE "CalendarConnection" (
+    "id" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "provider" "CalendarProvider" NOT NULL,
+    "accountEmail" TEXT NOT NULL,
+    "accessTokenEncrypted" TEXT,
+    "refreshTokenEncrypted" TEXT NOT NULL,
+    "tokenExpiresAt" TIMESTAMP(3),
+    "syncToken" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastSyncedAt" TIMESTAMP(3),
+    "lastSyncError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CalendarConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "crm_CalendarEvents" (
+    "id" UUID NOT NULL,
+    "source" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "iCalUID" TEXT,
+    "connectionId" UUID,
+    "activityId" UUID NOT NULL,
+    "startAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3),
+    "attendeeEmails" JSONB NOT NULL DEFAULT '[]',
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "rawPayload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "crm_CalendarEvents_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CalendarConnection_userId_idx" ON "CalendarConnection"("userId");
+
+-- CreateIndex
+CREATE INDEX "CalendarConnection_isActive_idx" ON "CalendarConnection"("isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CalendarConnection_userId_provider_accountEmail_key" ON "CalendarConnection"("userId", "provider", "accountEmail");
+
+-- CreateIndex
+CREATE INDEX "crm_CalendarEvents_iCalUID_idx" ON "crm_CalendarEvents"("iCalUID");
+
+-- CreateIndex
+CREATE INDEX "crm_CalendarEvents_activityId_idx" ON "crm_CalendarEvents"("activityId");
+
+-- CreateIndex
+CREATE INDEX "crm_CalendarEvents_startAt_idx" ON "crm_CalendarEvents"("startAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "crm_CalendarEvents_source_externalId_key" ON "crm_CalendarEvents"("source", "externalId");
+
+-- AddForeignKey
+ALTER TABLE "CalendarConnection" ADD CONSTRAINT "CalendarConnection_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "crm_CalendarEvents" ADD CONSTRAINT "crm_CalendarEvents_connectionId_fkey" FOREIGN KEY ("connectionId") REFERENCES "CalendarConnection"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "crm_CalendarEvents" ADD CONSTRAINT "crm_CalendarEvents_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "crm_Activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -673,6 +673,7 @@ model crm_Activities {
   created_by_user Users?              @relation("activity_created_by", fields: [createdBy], references: [id])
   updated_by_user Users?              @relation("activity_updated_by", fields: [updatedBy], references: [id])
   links       crm_ActivityLinks[]
+  calendar_events crm_CalendarEvents[]
 
   @@index([date])
   @@index([type])
@@ -1006,6 +1007,7 @@ model Users {
   created_target_lists crm_TargetLists[]     @relation("created_target_lists")
   apiTokens            ApiToken[]
   emailAccounts        EmailAccount[]
+  calendarConnections  CalendarConnection[]
   emails               Email[]
   enrichments_triggered          crm_Contact_Enrichment[]  @relation("enrichment_triggered_by")
   target_enrichments_triggered   crm_Target_Enrichment[]   @relation("target_enrichment_triggered_by")
@@ -1525,6 +1527,61 @@ model EmailEmbedding {
   email Email @relation(fields: [emailId], references: [id], onDelete: Cascade)
 
   @@map("EmailEmbedding")
+}
+
+// ============================================
+// CALENDAR SYNC (AQUNAMA Phase 4)
+// ============================================
+
+enum CalendarProvider {
+  google
+}
+
+model CalendarConnection {
+  id                    String           @id @default(uuid()) @db.Uuid
+  userId                String           @db.Uuid
+  provider              CalendarProvider
+  accountEmail          String
+  accessTokenEncrypted  String?
+  refreshTokenEncrypted String
+  tokenExpiresAt        DateTime?
+  syncToken             String?
+  isActive              Boolean          @default(true)
+  lastSyncedAt          DateTime?
+  lastSyncError         String?
+  createdAt             DateTime         @default(now())
+  updatedAt             DateTime         @updatedAt
+
+  user           Users               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  calendarEvents crm_CalendarEvents[]
+
+  @@unique([userId, provider, accountEmail])
+  @@index([userId])
+  @@index([isActive])
+}
+
+model crm_CalendarEvents {
+  id             String    @id @default(uuid()) @db.Uuid
+  source         String
+  externalId     String
+  iCalUID        String?
+  connectionId   String?   @db.Uuid
+  activityId     String    @db.Uuid
+  startAt        DateTime
+  endAt          DateTime?
+  attendeeEmails Json      @default("[]")
+  status         String    @default("scheduled")
+  rawPayload     Json?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  connection CalendarConnection? @relation(fields: [connectionId], references: [id], onDelete: SetNull)
+  activity   crm_Activities      @relation(fields: [activityId], references: [id], onDelete: Cascade)
+
+  @@unique([source, externalId])
+  @@index([iCalUID])
+  @@index([activityId])
+  @@index([startAt])
 }
 
 model EmailsToContacts {


### PR DESCRIPTION
## Summary

Implements AQUNAMA Phase 4, Milestones A + B (gap G-05): booked calls land in the CRM automatically.

- **Calendly inbound (Milestone A):** HMAC-signed organization-scope webhook endpoint (`/api/crm/calendar/webhooks/calendly`), admin setup page at `/admin/calendar-settings` (encrypted org token + signing key in `crm_SystemSettings`, one-click webhook subscription), registered in the admin sidebar.
- **Google Calendar inbound (Milestone B):** per-rep OAuth connect (readonly scope, CSRF state cookie, tokens encrypted at rest), 15-minute Inngest polling with incremental `syncToken` + 410 full-window fallback, auth-revocation detection that distinguishes `invalid_grant` from rate-limit 403s.
- **Shared processor** (`lib/crm/calendar/sync.ts`): transactional, idempotent on `(source, externalId)` with P2002 race handling; matches contact → target → lead; unmatched Calendly invitees auto-create a Target tagged `book-a-call`; unmatched Google events are skipped; Calendly↔Google copies deduped; reschedules/cancellations update in place.
- **Kill-clock integration:** synced meetings restart the Phase 2 45-day clock; `getLastClientActivity` now excludes cancelled activities so cancelled bookings don't suppress the kill rule.
- **Profile UX:** dedicated "Calendar" tab (`/profile?tab=calendar`) with an OAuth-result banner; calendar connections separated from Email Accounts.
- **Data:** additive-only migration adding `CalendarConnection` + `crm_CalendarEvents` (fresh-replay verified).

Spec: `docs/superpowers/specs/2026-07-19-aqunama-p4-calendar-sync-design.md` · Plan: `docs/superpowers/plans/2026-07-19-aqunama-p4-calendar-sync.md`

## Verification

- Full jest suite green (197 suites / 1014+ tests, incl. 29 new calendar tests), `tsc --noEmit` clean, production build green.
- End-to-end validated on dev: Google OAuth connect → first sync completed with stored sync cursor, no errors.
- Every task passed an independent review; final whole-branch review verdict READY after a three-item fix wave.

## Deploy notes

- Requires `GOOGLE_CALENDAR_CLIENT_ID` / `GOOGLE_CALENDAR_CLIENT_SECRET` env vars and the production callback URI registered on the OAuth client (Google Calendar API must be enabled in the project).
- Calendly: enter org API token + signing key at `/admin/calendar-settings` and subscribe the webhook (paid tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)