### PR TITLE
security: object-level authz + SSRF hardening (4 advisories)

### DIFF
--- a/__tests__/actions/admin/system/set-resend-key.test.ts
+++ b/__tests__/actions/admin/system/set-resend-key.test.ts
@@ -1,0 +1,67 @@
+jest.mock("@/lib/authz", () => {
+  class AuthorizationError extends Error {}
+  return {
+    requireRole: jest.fn(),
+    AuthorizationError,
+  };
+});
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    systemServices: {
+      create: jest.fn().mockResolvedValue({ id: "svc-1" }),
+      update: jest.fn().mockResolvedValue({ id: "svc-1" }),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { requireRole, AuthorizationError } from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { setResendKey } from "@/actions/admin/system/set-resend-key";
+
+const mockRequireRole = requireRole as jest.MockedFunction<typeof requireRole>;
+
+function form(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("setResendKey authorization", () => {
+  it("does not write the credential when the caller is not an admin", async () => {
+    mockRequireRole.mockRejectedValue(new AuthorizationError());
+
+    await expect(
+      setResendKey(form({ id: "svc-1", serviceKey: "attacker-key" }))
+    ).rejects.toBeInstanceOf(AuthorizationError);
+
+    expect(mockRequireRole).toHaveBeenCalledWith(["admin"]);
+    expect(prismadb.systemServices.update).not.toHaveBeenCalled();
+    expect(prismadb.systemServices.create).not.toHaveBeenCalled();
+  });
+
+  it("updates the existing row for an admin", async () => {
+    mockRequireRole.mockResolvedValue({ id: "admin-1", role: "admin" } as any);
+
+    await setResendKey(form({ id: "svc-1", serviceKey: "new-key" }));
+
+    expect(prismadb.systemServices.update).toHaveBeenCalledWith({
+      where: { id: "svc-1" },
+      data: { serviceKey: "new-key" },
+    });
+    expect(prismadb.systemServices.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a row for an admin when no id is present", async () => {
+    mockRequireRole.mockResolvedValue({ id: "admin-1", role: "admin" } as any);
+
+    await setResendKey(form({ id: "", serviceKey: "first-key" }));
+
+    expect(prismadb.systemServices.create).toHaveBeenCalledWith({
+      data: { v: 0, name: "resend_smtp", serviceKey: "first-key" },
+    });
+    expect(prismadb.systemServices.update).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/actions/emails/accounts.test.ts
+++ b/__tests__/actions/emails/accounts.test.ts
@@ -90,6 +90,23 @@ describe("createEmailAccount", () => {
       createEmailAccount({ ...input, imapHost: "" })
     ).rejects.toThrow();
   });
+
+  it("rejects a non-mail IMAP port (SSRF port-scan hardening)", async () => {
+    mockGetSession.mockResolvedValue(AUTHED_SESSION);
+    // 5432 = internal Postgres. Old code accepted any 1..65535.
+    await expect(
+      createEmailAccount({ ...input, imapPort: 5432 })
+    ).rejects.toThrow("Unsupported IMAP port");
+    expect(prismadb.emailAccount.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-mail SMTP port (SSRF port-scan hardening)", async () => {
+    mockGetSession.mockResolvedValue(AUTHED_SESSION);
+    await expect(
+      createEmailAccount({ ...input, smtpPort: 9000 })
+    ).rejects.toThrow("Unsupported SMTP port");
+    expect(prismadb.emailAccount.create).not.toHaveBeenCalled();
+  });
 });
 
 describe("deleteEmailAccount", () => {
@@ -141,5 +158,19 @@ describe("testEmailConnection", () => {
     await expect(
       testEmailConnection({ imapHost: "imap.example.com", imapPort: 993, imapSsl: true, username: "u", password: "p" })
     ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects a non-mail port without attempting a connection", async () => {
+    mockGetSession.mockResolvedValue(AUTHED_SESSION);
+    // 5432 = internal Postgres; must be refused before any TCP dial so the
+    // action cannot be used as an internal port scanner.
+    const result = await testEmailConnection({
+      imapHost: "127.0.0.1",
+      imapPort: 5432,
+      imapSsl: false,
+      username: "u",
+      password: "p",
+    });
+    expect(result).toEqual({ ok: false, error: "Unsupported IMAP port" });
   });
 });

--- a/__tests__/actions/import-targets-suppression.test.ts
+++ b/__tests__/actions/import-targets-suppression.test.ts
@@ -1,4 +1,10 @@
 jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+// importTargets now resolves the caller via requireAuthenticated; auth behavior
+// is out of this suite's scope, so pass it through.
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+}));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     crm_Targets: { createMany: jest.fn(), findMany: jest.fn() },
@@ -7,12 +13,14 @@ jest.mock("@/lib/prisma", () => ({
 
 import { prismadb } from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
+import { requireAuthenticated } from "@/lib/authz";
 import { importTargets } from "@/actions/crm/targets/import-targets";
 
 describe("importTargets suppression inheritance", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getSession as jest.Mock).mockResolvedValue({ user: { id: "u1" } });
+    (requireAuthenticated as jest.Mock).mockResolvedValue({ id: "u1", role: "admin" });
     (prismadb.crm_Targets.createMany as jest.Mock).mockResolvedValue({ count: 2 });
   });
 

--- a/__tests__/lib/email/imap-safety.test.ts
+++ b/__tests__/lib/email/imap-safety.test.ts
@@ -1,0 +1,78 @@
+import {
+  isAllowedImapPort,
+  isAllowedSmtpPort,
+  classifyMailError,
+  ALLOWED_IMAP_PORTS,
+  ALLOWED_SMTP_PORTS,
+} from "@/lib/email/imap-safety";
+
+describe("isAllowedImapPort", () => {
+  it("accepts standard IMAP ports", () => {
+    expect(isAllowedImapPort(143)).toBe(true);
+    expect(isAllowedImapPort(993)).toBe(true);
+  });
+
+  it("rejects internal-service ports used for SSRF scanning", () => {
+    for (const p of [5432, 9000, 9001, 8288, 6379, 80, 443, 22, 25]) {
+      expect(isAllowedImapPort(p)).toBe(false);
+    }
+  });
+
+  it("rejects non-integers and out-of-range values", () => {
+    expect(isAllowedImapPort(993.5)).toBe(false);
+    expect(isAllowedImapPort(NaN)).toBe(false);
+    expect(isAllowedImapPort(0)).toBe(false);
+    expect(isAllowedImapPort(70000)).toBe(false);
+  });
+});
+
+describe("isAllowedSmtpPort", () => {
+  it("accepts standard SMTP submission ports", () => {
+    for (const p of ALLOWED_SMTP_PORTS) expect(isAllowedSmtpPort(p)).toBe(true);
+  });
+
+  it("rejects internal-service ports", () => {
+    for (const p of [5432, 9000, 8288, 993]) {
+      expect(isAllowedSmtpPort(p)).toBe(false);
+    }
+  });
+});
+
+describe("classifyMailError", () => {
+  it("never returns the original error text (no banner/protocol leak)", () => {
+    const secret = "220 nextcrm-postgres PostgreSQL 16.2 ready on 10.0.0.5";
+    const out = classifyMailError(secret);
+    expect(out).not.toContain("PostgreSQL");
+    expect(out).not.toContain("10.0.0.5");
+    expect(out).not.toContain("220");
+  });
+
+  it("maps auth failures to a generic auth message", () => {
+    expect(classifyMailError("Invalid credentials (LOGIN failed)")).toMatch(
+      /authentication failed/i
+    );
+    expect(classifyMailError({ message: "bad password" })).toMatch(
+      /authentication failed/i
+    );
+  });
+
+  it("maps connection failures to a generic connect message", () => {
+    expect(classifyMailError("connect ECONNREFUSED 127.0.0.1:5432")).toMatch(
+      /could not connect/i
+    );
+    expect(classifyMailError("getaddrinfo ENOTFOUND nope.invalid")).toMatch(
+      /could not connect/i
+    );
+  });
+
+  it("maps timeouts and TLS errors distinctly", () => {
+    expect(classifyMailError("ETIMEDOUT")).toMatch(/timed out/i);
+    expect(classifyMailError("self-signed certificate")).toMatch(/tls error/i);
+  });
+
+  it("has a safe fallback for unknown errors", () => {
+    expect(classifyMailError(null)).toMatch(/could not complete/i);
+    expect(classifyMailError(undefined)).toMatch(/could not complete/i);
+    expect(classifyMailError("")).toMatch(/could not complete/i);
+  });
+});

--- a/actions/admin/system/set-resend-key.ts
+++ b/actions/admin/system/set-resend-key.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { prismadb } from "@/lib/prisma";
+import { requireRole } from "@/lib/authz";
+
+const schema = z.object({
+  id: z.string(),
+  serviceKey: z.string(),
+});
+
+// Sets/updates the system-wide Resend API key used for all outbound mail.
+//
+// SECURITY: this is a Server Action, i.e. a POST endpoint addressed by its
+// action id — it is NOT protected by the admin page's layout guard, which only
+// runs during render. Without an explicit check here, any client that knows the
+// action id could overwrite the outbound-mail credential. `requireRole` resolves
+// the caller's role from the database and throws for non-admins.
+export async function setResendKey(formData: FormData): Promise<void> {
+  await requireRole(["admin"]);
+
+  const parsed = schema.parse({
+    id: formData.get("id"),
+    serviceKey: formData.get("serviceKey"),
+  });
+
+  if (!parsed.id) {
+    await prismadb.systemServices.create({
+      data: { v: 0, name: "resend_smtp", serviceKey: parsed.serviceKey },
+    });
+  } else {
+    await prismadb.systemServices.update({
+      where: { id: parsed.id },
+      data: { serviceKey: parsed.serviceKey },
+    });
+  }
+
+  revalidatePath("/admin");
+}

--- a/actions/crm/accounts/__tests__/accounts-write-scope.test.ts
+++ b/actions/crm/accounts/__tests__/accounts-write-scope.test.ts
@@ -1,0 +1,136 @@
+// Object-level authorization regression tests for account write actions
+// (GHSA-qwhm-9fcm-p878). Each test must fail against the pre-guard code:
+// a non-owner must be denied AND the mutation must not run.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteAccount: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Accounts: {
+      update: jest.fn().mockResolvedValue({ id: "acc-1" }),
+      findUnique: jest.fn().mockResolvedValue({ id: "acc-1" }),
+      create: jest.fn().mockResolvedValue({ id: "acc-1" }),
+    },
+    crm_Accounts_Tasks: { create: jest.fn().mockResolvedValue({ id: "task-1" }) },
+    users: { findUnique: jest.fn().mockResolvedValue({ email: "x@y.z", name: "X" }) },
+    accountWatchers: { findMany: jest.fn().mockResolvedValue([]) },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn(), diffObjects: jest.fn(() => null) }));
+jest.mock("@/inngest/client", () => ({ inngest: { send: jest.fn() } }));
+jest.mock("@/lib/junction-helpers", () => ({
+  junctionTableHelpers: { addWatcher: jest.fn(() => ({})), removeAccountWatcher: jest.fn(() => ({})) },
+}));
+jest.mock("@/lib/resend", () => ({
+  __esModule: true,
+  default: jest.fn(async () => ({ emails: { send: jest.fn().mockResolvedValue({}) } })),
+}));
+jest.mock("@/emails/NewTaskFromCRM", () => ({ __esModule: true, default: () => null }));
+jest.mock("@/emails/NewTaskFromCRMToWatchers", () => ({ __esModule: true, default: () => null }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthorizationError,
+} from "@/lib/authz";
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { updateAccount } from "@/actions/crm/accounts/update-account";
+import { deleteAccount } from "@/actions/crm/accounts/delete-account";
+import { watchAccount } from "@/actions/crm/accounts/watch-account";
+import { unwatchAccount } from "@/actions/crm/accounts/unwatch-account";
+import { createTask } from "@/actions/crm/accounts/create-task";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertAccount = assertCanWriteAccount as jest.Mock;
+const getSess = getSession as jest.Mock;
+const accUpdate = prismadb.crm_Accounts.update as jest.Mock;
+const taskCreate = prismadb.crm_Accounts_Tasks.create as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  getSess.mockResolvedValue({ user: { id: "owner", name: "Owner", userLanguage: "en" } });
+});
+
+describe("updateAccount", () => {
+  it("denies a non-owner and does not update", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await updateAccount({ id: "victim-acc" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(accUpdate).not.toHaveBeenCalled();
+  });
+
+  it("guards on data.id and updates for an owner", async () => {
+    assertAccount.mockResolvedValue(undefined);
+    await updateAccount({ id: "acc-1", name: "New" } as any);
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "acc-1");
+    expect(accUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("deleteAccount", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await deleteAccount("victim-acc");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(accUpdate).not.toHaveBeenCalled();
+  });
+
+  it("guards on the accountId and soft-deletes for an owner", async () => {
+    assertAccount.mockResolvedValue(undefined);
+    await deleteAccount("acc-1");
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "acc-1");
+    expect(accUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("watchAccount / unwatchAccount (watch requires write — escalation guard)", () => {
+  it("watch denies a non-owner and does not mutate", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await watchAccount("victim-acc");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(accUpdate).not.toHaveBeenCalled();
+  });
+
+  it("unwatch denies a non-owner and does not mutate", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await unwatchAccount("victim-acc");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(accUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("createTask", () => {
+  const input = {
+    title: "T",
+    user: "assignee-id",
+    priority: "normal",
+    content: "c",
+    account: "victim-acc",
+  };
+
+  it("denies when caller cannot write the parent account", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await createTask(input as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(taskCreate).not.toHaveBeenCalled();
+  });
+
+  it("guards on the parent account and stamps createdBy from the caller, not the input user", async () => {
+    assertAccount.mockResolvedValue(undefined);
+    await createTask({ ...input, account: "acc-1" } as any);
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "acc-1");
+    const arg = taskCreate.mock.calls[0][0].data;
+    expect(arg.createdBy).toBe("owner"); // authenticated caller, NOT "assignee-id"
+    expect(arg.user).toBe("assignee-id"); // input user is the assignee
+  });
+});

--- a/actions/crm/accounts/create-account.ts
+++ b/actions/crm/accounts/create-account.ts
@@ -1,9 +1,9 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog } from "@/lib/audit-log";
+import { requireAuthenticated, AuthenticationError } from "@/lib/authz";
 
 export const createAccount = async (data: {
   name: string;
@@ -30,8 +30,15 @@ export const createAccount = async (data: {
   member_of?: string;
   industry?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  // Plain create: the row is owned by its creator, so authentication is
+  // sufficient — no object-level write assert needed.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   const { name } = data;
   if (!name) return { error: "name is required" };
@@ -40,8 +47,8 @@ export const createAccount = async (data: {
     const account = await prismadb.crm_Accounts.create({
       data: {
         v: 0,
-        createdBy: session.user.id,
-        updatedBy: session.user.id,
+        createdBy: user.id,
+        updatedBy: user.id,
         ...data,
         status: "Active",
       },
@@ -51,7 +58,7 @@ export const createAccount = async (data: {
       entityId: account.id,
       action: "created",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/account.saved", data: { record_id: account.id } });
     revalidatePath("/[locale]/(routes)/crm/accounts", "page");

--- a/actions/crm/accounts/create-task.ts
+++ b/actions/crm/accounts/create-task.ts
@@ -5,6 +5,12 @@ import { revalidatePath } from "next/cache";
 import resendHelper from "@/lib/resend";
 import NewTaskFromCRMEmail from "@/emails/NewTaskFromCRM";
 import NewTaskFromCRMToWatchersEmail from "@/emails/NewTaskFromCRMToWatchers";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const createTask = async (data: {
   title: string;
@@ -14,6 +20,8 @@ export const createTask = async (data: {
   account: string;
   dueDateAt?: Date;
 }) => {
+  // getSession stays for the notification-email fields (name, userLanguage)
+  // that the AuthzUser does not carry.
   const session = await getSession();
   if (!session) return { error: "Unauthorized" };
 
@@ -21,6 +29,21 @@ export const createTask = async (data: {
 
   if (!title || !user || !priority || !content || !account) {
     return { error: "Missing one of the task data" };
+  }
+
+  // Parent-write: creating a task under an account requires write on that account.
+  let authUser;
+  try {
+    authUser = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteAccount(authUser, account);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   let resend;
@@ -39,8 +62,10 @@ export const createTask = async (data: {
         content,
         account,
         dueDateAt,
-        createdBy: user,
-        updatedBy: user,
+        // createdBy/updatedBy = the authenticated caller (was previously the
+        // spoofable input `user` field); `user` remains the task assignee.
+        createdBy: authUser.id,
+        updatedBy: authUser.id,
         user,
         taskStatus: "ACTIVE",
       },

--- a/actions/crm/accounts/delete-account.ts
+++ b/actions/crm/accounts/delete-account.ts
@@ -1,25 +1,42 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteAccount = async (accountId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
   if (!accountId) return { error: "accountId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_Accounts.update({
       where: { id: accountId },
-      data: { deletedAt: new Date(), deletedBy: session.user.id },
+      data: { deletedAt: new Date(), deletedBy: user.id },
     });
     await writeAuditLog({
       entityType: "account",
       entityId: accountId,
       action: "deleted",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     revalidatePath("/[locale]/(routes)/crm/accounts", "page");
     return { success: true };

--- a/actions/crm/accounts/unwatch-account.ts
+++ b/actions/crm/accounts/unwatch-account.ts
@@ -1,13 +1,30 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { junctionTableHelpers } from "@/lib/junction-helpers";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const unwatchAccount = async (accountId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!accountId) return { error: "accountId is required" };
+
+  // Symmetric with watchAccount: watcher membership is write-scoped.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_Accounts.update({
@@ -15,7 +32,7 @@ export const unwatchAccount = async (accountId: string) => {
       data: {
         watchers: junctionTableHelpers.removeAccountWatcher(
           accountId,
-          session.user.id
+          user.id
         ),
       },
     });

--- a/actions/crm/accounts/update-account.ts
+++ b/actions/crm/accounts/update-account.ts
@@ -1,9 +1,14 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog, diffObjects } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateAccount = async (data: {
   id: string;
@@ -31,11 +36,22 @@ export const updateAccount = async (data: {
   member_of?: string | null;
   industry?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { id, ...rest } = data;
   if (!id) return { error: "id is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteAccount(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const before = await prismadb.crm_Accounts.findUnique({ where: { id, deletedAt: null } });
@@ -43,7 +59,7 @@ export const updateAccount = async (data: {
       where: { id },
       data: {
         v: 0,
-        updatedBy: session.user.id,
+        updatedBy: user.id,
         ...rest,
       },
     });
@@ -56,7 +72,7 @@ export const updateAccount = async (data: {
       entityId: account.id,
       action: "updated",
       changes,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/account.saved", data: { record_id: account.id } });
     revalidatePath("/[locale]/(routes)/crm/accounts", "page");

--- a/actions/crm/accounts/watch-account.ts
+++ b/actions/crm/accounts/watch-account.ts
@@ -1,19 +1,38 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { junctionTableHelpers } from "@/lib/junction-helpers";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const watchAccount = async (accountId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!accountId) return { error: "accountId is required" };
+
+  // `watchers` is inside accountUserScopeOR, so becoming a watcher grants
+  // read+write scope — an unguarded watch would be a self-service escalation
+  // primitive. Watching therefore requires write access.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteAccount(user, accountId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_Accounts.update({
       where: { id: accountId },
       data: {
-        watchers: junctionTableHelpers.addWatcher(session.user.id),
+        watchers: junctionTableHelpers.addWatcher(user.id),
       },
     });
     return { success: true };

--- a/actions/crm/contacts/__tests__/contacts-write-scope.test.ts
+++ b/actions/crm/contacts/__tests__/contacts-write-scope.test.ts
@@ -1,0 +1,139 @@
+// Object-level authorization regression tests for contact write actions
+// (GHSA-qwhm-9fcm-p878). Each denial test must fail against the pre-guard code.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteContact: jest.fn(),
+  assertCanWriteAccount: jest.fn(),
+  assertCanWriteOpportunity: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+// Pre-guard code still imports getSession (ESM); mock so the suite loads during
+// RED. Harmless after implementation, which drops the auth-server import.
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contacts: {
+      update: jest.fn().mockResolvedValue({ id: "c-1" }),
+      findUnique: jest.fn().mockResolvedValue({ id: "c-1" }),
+      create: jest.fn().mockResolvedValue({ id: "c-1" }),
+    },
+    contactsToOpportunities: { delete: jest.fn().mockResolvedValue({}) },
+    users: { findFirst: jest.fn().mockResolvedValue(null) },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn(), diffObjects: jest.fn(() => null) }));
+jest.mock("@/inngest/client", () => ({ inngest: { send: jest.fn() } }));
+jest.mock("@/lib/sendmail", () => ({ __esModule: true, default: jest.fn() }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteContact,
+  assertCanWriteAccount,
+  assertCanWriteOpportunity,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { createContact } from "@/actions/crm/contacts/create-contact";
+import { updateContact } from "@/actions/crm/contacts/update-contact";
+import { deleteContact } from "@/actions/crm/contacts/delete-contact";
+import { unlinkOpportunity } from "@/actions/crm/contacts/unlink-opportunity";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertContact = assertCanWriteContact as jest.Mock;
+const assertAccount = assertCanWriteAccount as jest.Mock;
+const assertOpp = assertCanWriteOpportunity as jest.Mock;
+const cUpdate = prismadb.crm_Contacts.update as jest.Mock;
+const cCreate = prismadb.crm_Contacts.create as jest.Mock;
+const linkDelete = prismadb.contactsToOpportunities.delete as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertContact.mockResolvedValue(undefined);
+  assertAccount.mockResolvedValue(undefined);
+  assertOpp.mockResolvedValue(undefined);
+});
+
+describe("updateContact", () => {
+  it("denies a non-owner and does not update", async () => {
+    assertContact.mockRejectedValue(new AuthorizationError());
+    const res = await updateContact({ id: "victim" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(cUpdate).not.toHaveBeenCalled();
+  });
+
+  it("guards on data.id and updates for an owner", async () => {
+    await updateContact({ id: "c-1", first_name: "New" } as any);
+    expect(assertContact).toHaveBeenCalledWith(OWNER, "c-1");
+    expect(cUpdate).toHaveBeenCalled();
+  });
+
+  it("also requires write on a newly-linked account (parent-write)", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await updateContact({ id: "c-1", assigned_account: "foreign-acc" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "foreign-acc");
+    expect(cUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteContact", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertContact.mockRejectedValue(new AuthorizationError());
+    const res = await deleteContact("victim");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(cUpdate).not.toHaveBeenCalled();
+  });
+
+  it("guards on the contactId for an owner", async () => {
+    await deleteContact("c-1");
+    expect(assertContact).toHaveBeenCalledWith(OWNER, "c-1");
+    expect(cUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("unlinkOpportunity (both sides of the junction must be writable)", () => {
+  it("denies when the contact is not writable", async () => {
+    assertContact.mockRejectedValue(new AuthorizationError());
+    const res = await unlinkOpportunity({ contactId: "c-1", opportunityId: "o-1" });
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(linkDelete).not.toHaveBeenCalled();
+  });
+
+  it("denies when the opportunity is not writable", async () => {
+    assertOpp.mockRejectedValue(new AuthorizationError());
+    const res = await unlinkOpportunity({ contactId: "c-1", opportunityId: "o-1" });
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(linkDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes when both are writable", async () => {
+    await unlinkOpportunity({ contactId: "c-1", opportunityId: "o-1" });
+    expect(assertContact).toHaveBeenCalledWith(OWNER, "c-1");
+    expect(assertOpp).toHaveBeenCalledWith(OWNER, "o-1");
+    expect(linkDelete).toHaveBeenCalled();
+  });
+});
+
+describe("createContact", () => {
+  it("requires write on a linked account (parent-write) and does not create on denial", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await createContact({ last_name: "X", assigned_account: "foreign-acc" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "foreign-acc");
+    expect(cCreate).not.toHaveBeenCalled();
+  });
+
+  it("plain create (no linked account) needs only authentication", async () => {
+    await createContact({ last_name: "X" } as any);
+    expect(assertAccount).not.toHaveBeenCalled();
+    expect(cCreate).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/contacts/create-contact.ts
+++ b/actions/crm/contacts/create-contact.ts
@@ -1,10 +1,15 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import sendEmail from "@/lib/sendmail";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const createContact = async (data: {
   assigned_to?: string;
@@ -30,10 +35,6 @@ export const createContact = async (data: {
   social_tiktok?: string;
   contact_type_id?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
-  const userId = session.user.id;
   const {
     assigned_to,
     assigned_account,
@@ -43,6 +44,22 @@ export const createContact = async (data: {
     contact_type_id,
     ...rest
   } = data;
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    // Parent-write: linking the new contact to an account requires write on it.
+    if (assigned_account) await assertCanWriteAccount(user, assigned_account);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const contact = await prismadb.crm_Contacts.create({
@@ -87,7 +104,7 @@ export const createContact = async (data: {
       entityId: contact.id,
       action: "created",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/contact.saved", data: { record_id: contact.id } });
     revalidatePath("/[locale]/crm/contacts", "page");

--- a/actions/crm/contacts/delete-contact.ts
+++ b/actions/crm/contacts/delete-contact.ts
@@ -1,26 +1,42 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteContact,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteContact = async (contactId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!contactId) return { error: "contactId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteContact(user, contactId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_Contacts.update({
       where: { id: contactId },
-      data: { deletedAt: new Date(), deletedBy: session.user.id },
+      data: { deletedAt: new Date(), deletedBy: user.id },
     });
     await writeAuditLog({
       entityType: "contact",
       entityId: contactId,
       action: "deleted",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     revalidatePath("/[locale]/(routes)/crm/contacts", "page");
     return { success: true };

--- a/actions/crm/contacts/unlink-opportunity.ts
+++ b/actions/crm/contacts/unlink-opportunity.ts
@@ -1,19 +1,38 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteContact,
+  assertCanWriteOpportunity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const unlinkOpportunity = async (data: {
   contactId: string;
   opportunityId: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { contactId, opportunityId } = data;
 
   if (!contactId) return { error: "contactId is required" };
   if (!opportunityId) return { error: "opportunityId is required" };
+
+  // Bidirectional junction row: both endpoints must be writable by the caller.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteContact(user, contactId);
+    await assertCanWriteOpportunity(user, opportunityId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.contactsToOpportunities.delete({

--- a/actions/crm/contacts/update-contact.ts
+++ b/actions/crm/contacts/update-contact.ts
@@ -1,9 +1,15 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog, diffObjects } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteContact,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateContact = async (data: {
   id: string;
@@ -30,10 +36,6 @@ export const updateContact = async (data: {
   social_tiktok?: string | null;
   contact_type_id?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
-  const userId = session.user.id;
   const {
     id,
     assigned_to,
@@ -46,6 +48,23 @@ export const updateContact = async (data: {
   } = data;
 
   if (!id) return { error: "id is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteContact(user, id);
+    // Parent-write: relinking the contact to an account requires write on it.
+    if (assigned_account) await assertCanWriteAccount(user, assigned_account);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const before = await prismadb.crm_Contacts.findUnique({ where: { id, deletedAt: null } });
@@ -70,7 +89,7 @@ export const updateContact = async (data: {
       entityId: contact.id,
       action: "updated",
       changes,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/contact.saved", data: { record_id: contact.id } });
     revalidatePath("/[locale]/(routes)/crm/contacts", "page");

--- a/actions/crm/contract-line-items/__tests__/contract-line-items-write-scope.test.ts
+++ b/actions/crm/contract-line-items/__tests__/contract-line-items-write-scope.test.ts
@@ -1,0 +1,199 @@
+// Object-level authorization regression tests for contract line-item actions
+// (GHSA-qwhm-9fcm-p878). Line items authorize via the parent contract.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteContract: jest.fn(),
+  assertCanWriteContractLineItem: jest.fn(),
+  assertCanReadOpportunity: jest.fn(),
+  assertCanReadContract: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/create-safe-action", () => ({
+  createSafeAction: (_schema: unknown, handler: any) => handler,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contracts: {
+      findUnique: jest.fn().mockResolvedValue({ id: "ct-1", currency: "EUR", deletedAt: null }),
+      update: jest.fn().mockResolvedValue({ id: "ct-1" }),
+    },
+    crm_Opportunities: {
+      findUnique: jest.fn().mockResolvedValue({ id: "o-1", currency: "EUR", deletedAt: null }),
+    },
+    crm_ContractLineItems: {
+      create: jest.fn().mockResolvedValue({ id: "cli-1" }),
+      update: jest.fn().mockResolvedValue({ id: "cli-1" }),
+      delete: jest.fn().mockResolvedValue({ id: "cli-1" }),
+      createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      findUnique: jest.fn().mockResolvedValue({
+        id: "cli-1", contractId: "ct-1", quantity: 1, unit_price: 10,
+        discount_type: "NONE", discount_value: 0,
+      }),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    crm_OpportunityLineItems: {
+      findMany: jest.fn().mockResolvedValue([{ id: "src", sort_order: 0 }]),
+    },
+    crm_Products: { findUnique: jest.fn().mockResolvedValue(null) },
+    $transaction: jest.fn().mockResolvedValue([]),
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+jest.mock("@/lib/line-items", () => ({
+  calculateLineTotal: jest.fn(() => 10),
+  sumLineTotals: jest.fn(() => 10),
+}));
+
+import {
+  requireAuthenticated,
+  assertCanWriteContract,
+  assertCanWriteContractLineItem,
+  assertCanReadOpportunity,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { addContractLineItem } from "@/actions/crm/contract-line-items/add-line-item";
+import { copyLineItemsFromOpportunity } from "@/actions/crm/contract-line-items/copy-from-opportunity";
+import { updateContractLineItem } from "@/actions/crm/contract-line-items/update-line-item";
+import { removeContractLineItem } from "@/actions/crm/contract-line-items/remove-line-item";
+import { reorderContractLineItems } from "@/actions/crm/contract-line-items/reorder-line-items";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertContract = assertCanWriteContract as jest.Mock;
+const assertLI = assertCanWriteContractLineItem as jest.Mock;
+const assertReadOpp = assertCanReadOpportunity as jest.Mock;
+const cliCreate = prismadb.crm_ContractLineItems.create as jest.Mock;
+const cliUpdate = prismadb.crm_ContractLineItems.update as jest.Mock;
+const cliDelete = prismadb.crm_ContractLineItems.delete as jest.Mock;
+const cliCreateMany = prismadb.crm_ContractLineItems.createMany as jest.Mock;
+const cliFindMany = prismadb.crm_ContractLineItems.findMany as jest.Mock;
+const tx = prismadb.$transaction as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+const ADD_INPUT = {
+  contractId: "ct-1", name: "Item", quantity: 1, unit_price: "10",
+  discount_type: "NONE", discount_value: "0", sort_order: 0,
+} as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertContract.mockResolvedValue(undefined);
+  assertLI.mockResolvedValue(undefined);
+  assertReadOpp.mockResolvedValue(undefined);
+});
+
+describe("addContractLineItem", () => {
+  it("denies when the parent contract is not writable and does not create", async () => {
+    assertContract.mockRejectedValue(new AuthorizationError());
+    const res = await addContractLineItem(ADD_INPUT);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertContract).toHaveBeenCalledWith(OWNER, "ct-1");
+    expect(cliCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates for a writable parent", async () => {
+    const res = await addContractLineItem(ADD_INPUT);
+    expect(res).toEqual({ data: { id: "cli-1" } });
+    expect(cliCreate).toHaveBeenCalled();
+  });
+});
+
+describe("copyLineItemsFromOpportunity (dual guard: write destination, read source)", () => {
+  it("denies when the destination contract is not writable", async () => {
+    assertContract.mockRejectedValue(new AuthorizationError());
+    const res = await copyLineItemsFromOpportunity("ct-1", "o-1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(cliCreateMany).not.toHaveBeenCalled();
+  });
+
+  it("denies when the source opportunity is not readable", async () => {
+    assertReadOpp.mockRejectedValue(new AuthorizationError());
+    const res = await copyLineItemsFromOpportunity("ct-1", "o-1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(cliCreateMany).not.toHaveBeenCalled();
+  });
+
+  it("copies when destination is writable and source is readable", async () => {
+    const res = await copyLineItemsFromOpportunity("ct-1", "o-1");
+    expect(assertContract).toHaveBeenCalledWith(OWNER, "ct-1");
+    expect(assertReadOpp).toHaveBeenCalledWith(OWNER, "o-1");
+    expect(cliCreateMany).toHaveBeenCalled();
+  });
+});
+
+describe("updateContractLineItem", () => {
+  it("denies via the line-item parent guard and does not update", async () => {
+    assertLI.mockRejectedValue(new AuthorizationError());
+    const res = await updateContractLineItem({ id: "cli-1" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertLI).toHaveBeenCalledWith(OWNER, "cli-1");
+    expect(cliUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates for a writable parent", async () => {
+    await updateContractLineItem({ id: "cli-1" } as any);
+    expect(cliUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("removeContractLineItem", () => {
+  it("denies via the line-item parent guard and does not delete", async () => {
+    assertLI.mockRejectedValue(new AuthorizationError());
+    const res = await removeContractLineItem("cli-1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(cliDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes for a writable parent", async () => {
+    await removeContractLineItem("cli-1");
+    expect(cliDelete).toHaveBeenCalled();
+  });
+});
+
+describe("reorderContractLineItems (blind — resolve and authorize every parent)", () => {
+  it("denies the batch if any parent is not writable", async () => {
+    cliFindMany.mockResolvedValue([
+      { id: "a", contractId: "ct-1" },
+      { id: "b", contractId: "ct-2" },
+    ]);
+    assertContract.mockImplementation(async (_u: any, ctId: string) => {
+      if (ctId === "ct-2") throw new AuthorizationError();
+    });
+    const res = await reorderContractLineItems([
+      { id: "a", sort_order: 0 },
+      { id: "b", sort_order: 1 },
+    ]);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(tx).not.toHaveBeenCalled();
+  });
+
+  it("denies when a supplied id does not resolve", async () => {
+    cliFindMany.mockResolvedValue([{ id: "a", contractId: "ct-1" }]);
+    const res = await reorderContractLineItems([
+      { id: "a", sort_order: 0 },
+      { id: "b", sort_order: 1 },
+    ]);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(tx).not.toHaveBeenCalled();
+  });
+
+  it("reorders when every parent is writable", async () => {
+    cliFindMany.mockResolvedValue([
+      { id: "a", contractId: "ct-1" },
+      { id: "b", contractId: "ct-1" },
+    ]);
+    const res = await reorderContractLineItems([
+      { id: "a", sort_order: 0 },
+      { id: "b", sort_order: 1 },
+    ]);
+    expect(res).toEqual({ data: { success: true } });
+    expect(tx).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/contract-line-items/add-line-item/index.ts
+++ b/actions/crm/contract-line-items/add-line-item/index.ts
@@ -1,5 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { AddContractLineItem } from "./schema";
 import { InputType, ReturnType } from "./types";
@@ -7,18 +6,34 @@ import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 import { calculateLineTotal, sumLineTotals } from "@/lib/line-items";
+import {
+  requireAuthenticated,
+  assertCanWriteContract,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
-  }
-
-  const userId = session.user.id;
   const {
     contractId, productId, name, sku, description,
     quantity, unit_price, discount_type, discount_value, sort_order,
   } = data;
+
+  // Parent-write: a line item write recomputes the contract's value.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteContract(user, contractId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const contract = await prismadb.crm_Contracts.findUnique({

--- a/actions/crm/contract-line-items/copy-from-opportunity/index.ts
+++ b/actions/crm/contract-line-items/copy-from-opportunity/index.ts
@@ -1,20 +1,36 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 import { sumLineTotals } from "@/lib/line-items";
+import {
+  requireAuthenticated,
+  assertCanWriteContract,
+  assertCanReadOpportunity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const copyLineItemsFromOpportunity = async (
   contractId: string,
   opportunityId: string
 ) => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  // Dual guard: write on the destination contract, read on the source opportunity.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
   }
-
-  const userId = session.user.id;
+  try {
+    await assertCanWriteContract(user, contractId);
+    await assertCanReadOpportunity(user, opportunityId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const [contract, opportunity] = await Promise.all([

--- a/actions/crm/contract-line-items/get-line-items.ts
+++ b/actions/crm/contract-line-items/get-line-items.ts
@@ -1,7 +1,13 @@
 import { cache } from "react";
 import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, assertCanReadContract } from "@/lib/authz";
 
+// Read-scoped: the caller must be able to read the parent contract. Auth is
+// resolved inside the cache() body via next/headers (available in RSC callers);
+// both helpers throw on denial.
 export const getContractLineItems = cache(async (contractId: string) => {
+  const user = await requireAuthenticated();
+  await assertCanReadContract(user, contractId);
   return prismadb.crm_ContractLineItems.findMany({
     where: { contractId },
     include: {

--- a/actions/crm/contract-line-items/remove-line-item/index.ts
+++ b/actions/crm/contract-line-items/remove-line-item/index.ts
@@ -1,14 +1,28 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 import { sumLineTotals } from "@/lib/line-items";
+import {
+  requireAuthenticated,
+  assertCanWriteContractLineItem,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const removeContractLineItem = async (id: string) => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteContractLineItem(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {
@@ -35,7 +49,7 @@ export const removeContractLineItem = async (id: string) => {
       entityId: id,
       action: "deleted",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
 
     revalidatePath("/[locale]/(routes)/crm/contracts/[contractId]", "page");

--- a/actions/crm/contract-line-items/reorder-line-items/index.ts
+++ b/actions/crm/contract-line-items/reorder-line-items/index.ts
@@ -1,14 +1,39 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteContract,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const reorderContractLineItems = async (
   items: { id: string; sort_order: number }[]
 ) => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  // No parent id is supplied; resolve every line item's parent and require
+  // write on each. Any unresolved id or unwritable parent fails the batch.
+  const ids = items.map((i) => i.id);
+  const rows = await prismadb.crm_ContractLineItems.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, contractId: true },
+  });
+  const foundIds = new Set(rows.map((r) => r.id));
+  if (ids.some((id) => !foundIds.has(id))) return { error: "Forbidden" };
+  const parents = Array.from(new Set(rows.map((r) => r.contractId)));
+  try {
+    for (const contractId of parents) await assertCanWriteContract(user, contractId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {

--- a/actions/crm/contract-line-items/update-line-item/index.ts
+++ b/actions/crm/contract-line-items/update-line-item/index.ts
@@ -1,5 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { UpdateContractLineItem } from "./schema";
 import { InputType, ReturnType } from "./types";
@@ -7,15 +6,30 @@ import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 import { calculateLineTotal, sumLineTotals } from "@/lib/line-items";
+import {
+  requireAuthenticated,
+  assertCanWriteContractLineItem,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
-  }
-
-  const userId = session.user.id;
   const { id, ...updateData } = data;
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteContractLineItem(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const existing = await prismadb.crm_ContractLineItems.findUnique({ where: { id } });

--- a/actions/crm/contracts/__tests__/contracts-write-scope.test.ts
+++ b/actions/crm/contracts/__tests__/contracts-write-scope.test.ts
@@ -1,0 +1,104 @@
+// Object-level authorization regression tests for contract write actions
+// (GHSA-qwhm-9fcm-p878). Denial tests must fail against the pre-guard code.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteContract: jest.fn(),
+  assertCanWriteAccount: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { email: "owner@x.z" } }),
+}));
+jest.mock("@/lib/create-safe-action", () => ({
+  createSafeAction: (_schema: unknown, handler: any) => handler,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Contracts: {
+      create: jest.fn().mockResolvedValue({ id: "ct-1" }),
+      update: jest.fn().mockResolvedValue({ id: "ct-1" }),
+      findUnique: jest.fn().mockResolvedValue({ id: "ct-1" }),
+    },
+    users: { findUnique: jest.fn().mockResolvedValue({ id: "owner" }) },
+  },
+}));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn(), diffObjects: jest.fn(() => null) }));
+jest.mock("@/lib/currency", () => ({
+  getDefaultCurrency: jest.fn().mockResolvedValue("USD"),
+  getSnapshotRate: jest.fn().mockResolvedValue(null),
+}));
+
+import {
+  requireAuthenticated,
+  assertCanWriteContract,
+  assertCanWriteAccount,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { createNewContract } from "@/actions/crm/contracts/create-new-contract";
+import { updateContract } from "@/actions/crm/contracts/update-contract";
+import { deleteContract } from "@/actions/crm/contracts/delete-contract";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertContract = assertCanWriteContract as jest.Mock;
+const assertAccount = assertCanWriteAccount as jest.Mock;
+const ctCreate = prismadb.crm_Contracts.create as jest.Mock;
+const ctUpdate = prismadb.crm_Contracts.update as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertContract.mockResolvedValue(undefined);
+  assertAccount.mockResolvedValue(undefined);
+});
+
+describe("updateContract", () => {
+  it("denies a non-owner and does not update", async () => {
+    assertContract.mockRejectedValue(new AuthorizationError());
+    const res = await updateContract({ id: "victim", v: 0, title: "T", value: "100" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertContract).toHaveBeenCalledWith(OWNER, "victim");
+    expect(ctUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates for an owner", async () => {
+    await updateContract({ id: "ct-1", v: 0, title: "T", value: "100" } as any);
+    expect(assertContract).toHaveBeenCalledWith(OWNER, "ct-1");
+    expect(ctUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("deleteContract", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertContract.mockRejectedValue(new AuthorizationError());
+    const res = await deleteContract({ id: "victim" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(ctUpdate).not.toHaveBeenCalled();
+  });
+
+  it("soft-deletes for an owner", async () => {
+    await deleteContract({ id: "ct-1" } as any);
+    expect(assertContract).toHaveBeenCalledWith(OWNER, "ct-1");
+    expect(ctUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("createNewContract", () => {
+  it("requires write on a linked account (parent-write) and does not create on denial", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await createNewContract({ title: "T", value: "100", account: "foreign-acc" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "foreign-acc");
+    expect(ctCreate).not.toHaveBeenCalled();
+  });
+
+  it("plain create (no linked account) needs only authentication", async () => {
+    await createNewContract({ title: "T", value: "100" } as any);
+    expect(assertAccount).not.toHaveBeenCalled();
+    expect(ctCreate).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/contracts/create-new-contract/index.ts
+++ b/actions/crm/contracts/create-new-contract/index.ts
@@ -1,6 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
-
 import { prismadb } from "@/lib/prisma";
 import { CreateNewContract } from "./schema";
 import { InputType, ReturnType } from "./types";
@@ -8,28 +6,14 @@ import { InputType, ReturnType } from "./types";
 import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog } from "@/lib/audit-log";
 import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-
-  if (!session?.user?.email) {
-    return {
-      error: "User not logged in.",
-    };
-  }
-
-  const user = await prismadb.users.findUnique({
-    where: {
-      email: session?.user?.email,
-    },
-  });
-
-  if (!user) {
-    return {
-      error: "User not found.",
-    };
-  }
-
   const {
     title,
     value,
@@ -48,6 +32,21 @@ const handler = async (data: InputType): Promise<ReturnType> => {
     return {
       error: "Please fill in all the required fields.",
     };
+  }
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "User not logged in." };
+    throw e;
+  }
+  try {
+    // Parent-write: attaching the contract to an account requires write on it.
+    if (account) await assertCanWriteAccount(user, account);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {

--- a/actions/crm/contracts/delete-contract/index.ts
+++ b/actions/crm/contracts/delete-contract/index.ts
@@ -1,40 +1,38 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
-
 import { prismadb } from "@/lib/prisma";
 import { DeleteContract } from "./schema";
 import { InputType, ReturnType } from "./types";
 
 import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteContract,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-
-  if (!session?.user?.email) {
-    return {
-      error: "User not logged in.",
-    };
-  }
-
-  const user = await prismadb.users.findUnique({
-    where: {
-      email: session?.user?.email,
-    },
-  });
-
-  if (!user) {
-    return {
-      error: "User not found.",
-    };
-  }
-
   const { id } = data;
 
   if (!id) {
     return {
       error: "Please fill in all the required fields.",
     };
+  }
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "User not logged in." };
+    throw e;
+  }
+  try {
+    await assertCanWriteContract(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {

--- a/actions/crm/contracts/update-contract/index.ts
+++ b/actions/crm/contracts/update-contract/index.ts
@@ -1,6 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
-
 import { prismadb } from "@/lib/prisma";
 import { UpdateContract } from "./schema";
 import { InputType, ReturnType } from "./types";
@@ -8,28 +6,14 @@ import { InputType, ReturnType } from "./types";
 import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog, diffObjects } from "@/lib/audit-log";
 import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
+import {
+  requireAuthenticated,
+  assertCanWriteContract,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-
-  if (!session?.user?.email) {
-    return {
-      error: "User not logged in.",
-    };
-  }
-
-  const user = await prismadb.users.findUnique({
-    where: {
-      email: session?.user?.email,
-    },
-  });
-
-  if (!user) {
-    return {
-      error: "User not found.",
-    };
-  }
-
   const {
     id,
     v,
@@ -57,6 +41,20 @@ const handler = async (data: InputType): Promise<ReturnType> => {
     return {
       error: "Please fill in all the required fields.",
     };
+  }
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "User not logged in." };
+    throw e;
+  }
+  try {
+    await assertCanWriteContract(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   const before = await prismadb.crm_Contracts.findUnique({ where: { id, deletedAt: null } });

--- a/actions/crm/leads/__tests__/leads-write-scope.test.ts
+++ b/actions/crm/leads/__tests__/leads-write-scope.test.ts
@@ -1,0 +1,100 @@
+// Object-level authorization regression tests for lead write actions
+// (GHSA-qwhm-9fcm-p878). Denial tests must fail against the pre-guard code.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteLead: jest.fn(),
+  assertCanWriteAccount: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Leads: {
+      create: jest.fn().mockResolvedValue({ id: "l-1" }),
+      update: jest.fn().mockResolvedValue({ id: "l-1" }),
+      findUnique: jest.fn().mockResolvedValue({ id: "l-1" }),
+    },
+    users: { findFirst: jest.fn().mockResolvedValue(null) },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn(), diffObjects: jest.fn(() => null) }));
+jest.mock("@/inngest/client", () => ({ inngest: { send: jest.fn() } }));
+jest.mock("@/lib/sendmail", () => ({ __esModule: true, default: jest.fn() }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteLead,
+  assertCanWriteAccount,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { createLead } from "@/actions/crm/leads/create-lead";
+import { updateLead } from "@/actions/crm/leads/update-lead";
+import { deleteLead } from "@/actions/crm/leads/delete-lead";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertLead = assertCanWriteLead as jest.Mock;
+const assertAccount = assertCanWriteAccount as jest.Mock;
+const lCreate = prismadb.crm_Leads.create as jest.Mock;
+const lUpdate = prismadb.crm_Leads.update as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertLead.mockResolvedValue(undefined);
+  assertAccount.mockResolvedValue(undefined);
+});
+
+describe("updateLead", () => {
+  it("denies a non-owner and does not update", async () => {
+    assertLead.mockRejectedValue(new AuthorizationError());
+    const res = await updateLead({ id: "victim", lastName: "X" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertLead).toHaveBeenCalledWith(OWNER, "victim");
+    expect(lUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates for an owner", async () => {
+    await updateLead({ id: "l-1", lastName: "X" } as any);
+    expect(assertLead).toHaveBeenCalledWith(OWNER, "l-1");
+    expect(lUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("deleteLead", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertLead.mockRejectedValue(new AuthorizationError());
+    const res = await deleteLead("victim");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(lUpdate).not.toHaveBeenCalled();
+  });
+
+  it("soft-deletes for an owner", async () => {
+    await deleteLead("l-1");
+    expect(assertLead).toHaveBeenCalledWith(OWNER, "l-1");
+    expect(lUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("createLead", () => {
+  it("requires write on a linked account (parent-write) and does not create on denial", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await createLead({ last_name: "X", accountIDs: "foreign-acc" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "foreign-acc");
+    expect(lCreate).not.toHaveBeenCalled();
+  });
+
+  it("plain create (no linked account) needs only authentication", async () => {
+    await createLead({ last_name: "X" } as any);
+    expect(assertAccount).not.toHaveBeenCalled();
+    expect(lCreate).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/leads/create-lead.ts
+++ b/actions/crm/leads/create-lead.ts
@@ -1,10 +1,15 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import sendEmail from "@/lib/sendmail";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const createLead = async (data: {
   first_name?: string;
@@ -22,10 +27,6 @@ export const createLead = async (data: {
   assigned_to?: string;
   accountIDs?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
-  const userId = session.user.id;
   const {
     first_name,
     last_name,
@@ -42,6 +43,22 @@ export const createLead = async (data: {
     assigned_to,
     accountIDs,
   } = data;
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    // Parent-write: linking the new lead to an account requires write on it.
+    if (accountIDs) await assertCanWriteAccount(user, accountIDs);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const lead = await prismadb.crm_Leads.create({
@@ -92,7 +109,7 @@ export const createLead = async (data: {
       entityId: lead.id,
       action: "created",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/lead.saved", data: { record_id: lead.id } });
     revalidatePath("/[locale]/(routes)/crm/leads", "page");

--- a/actions/crm/leads/delete-lead.ts
+++ b/actions/crm/leads/delete-lead.ts
@@ -1,26 +1,42 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteLead,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteLead = async (leadId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!leadId) return { error: "leadId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteLead(user, leadId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_Leads.update({
       where: { id: leadId },
-      data: { deletedAt: new Date(), deletedBy: session.user.id },
+      data: { deletedAt: new Date(), deletedBy: user.id },
     });
     await writeAuditLog({
       entityType: "lead",
       entityId: leadId,
       action: "deleted",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     revalidatePath("/[locale]/(routes)/crm/leads", "page");
     return { success: true };

--- a/actions/crm/leads/update-lead.ts
+++ b/actions/crm/leads/update-lead.ts
@@ -1,10 +1,15 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import sendEmail from "@/lib/sendmail";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog, diffObjects } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteLead,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateLead = async (data: {
   id: string;
@@ -23,10 +28,6 @@ export const updateLead = async (data: {
   assigned_to?: string;
   accountIDs?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
-  const userId = session.user.id;
   const {
     id,
     firstName,
@@ -46,6 +47,21 @@ export const updateLead = async (data: {
   } = data;
 
   if (!id) return { error: "id is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteLead(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const before = await prismadb.crm_Leads.findUnique({ where: { id, deletedAt: null } });
@@ -98,7 +114,7 @@ export const updateLead = async (data: {
       entityId: lead.id,
       action: "updated",
       changes,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/lead.saved", data: { record_id: lead.id } });
     revalidatePath("/[locale]/(routes)/crm/leads", "page");

--- a/actions/crm/opportunities/__tests__/create-opportunity-delivery-deadline.test.ts
+++ b/actions/crm/opportunities/__tests__/create-opportunity-delivery-deadline.test.ts
@@ -1,4 +1,12 @@
 jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+// Actions now resolve the caller via requireAuthenticated + assertCanWrite*;
+// authz behavior is covered by the *-scope tests, so pass it through here.
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteAccount: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     crm_Opportunities: { create: jest.fn() },
@@ -18,12 +26,15 @@ jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 
 import { prismadb } from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
+import { requireAuthenticated, assertCanWriteAccount } from "@/lib/authz";
 import { createOpportunity } from "@/actions/crm/opportunities/create-opportunity";
 
 describe("createOpportunity delivery_deadline", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getSession as jest.Mock).mockResolvedValue({ user: { id: "u1" } });
+    (requireAuthenticated as jest.Mock).mockResolvedValue({ id: "u1", role: "admin" });
+    (assertCanWriteAccount as jest.Mock).mockResolvedValue(undefined);
     (prismadb.crm_Opportunities.create as jest.Mock).mockResolvedValue({ id: "opp-1" });
   });
 

--- a/actions/crm/opportunities/__tests__/opportunities-write-scope.test.ts
+++ b/actions/crm/opportunities/__tests__/opportunities-write-scope.test.ts
@@ -1,0 +1,105 @@
+// Object-level authorization regression tests for opportunity write actions
+// (GHSA-qwhm-9fcm-p878). Denial tests must fail against the pre-guard code.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteOpportunity: jest.fn(),
+  assertCanWriteAccount: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Opportunities: {
+      update: jest.fn().mockResolvedValue({ id: "o-1", sales_stage: null }),
+      findUnique: jest.fn().mockResolvedValue({ id: "o-1", sales_stage: null, approval_status: "NONE" }),
+      create: jest.fn().mockResolvedValue({ id: "o-1", sales_stage: null }),
+    },
+    users: { findFirst: jest.fn().mockResolvedValue(null) },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn(), diffObjects: jest.fn(() => null) }));
+jest.mock("@/inngest/client", () => ({ inngest: { send: jest.fn() } }));
+jest.mock("@/lib/sendmail", () => ({ __esModule: true, default: jest.fn() }));
+jest.mock("@/lib/currency", () => ({
+  getDefaultCurrency: jest.fn().mockResolvedValue("USD"),
+  getSnapshotRate: jest.fn().mockResolvedValue(null),
+}));
+jest.mock("@/lib/crm/stage-transition", () => ({ handleStageTransition: jest.fn() }));
+jest.mock("@/lib/crm/approval-gate", () => ({ qualifiedEntryBlockReason: jest.fn().mockResolvedValue(null) }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  assertCanWriteAccount,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { createOpportunity } from "@/actions/crm/opportunities/create-opportunity";
+import { updateOpportunity } from "@/actions/crm/opportunities/update-opportunity";
+import { deleteOpportunity } from "@/actions/crm/opportunities/delete-opportunity";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertOpp = assertCanWriteOpportunity as jest.Mock;
+const assertAccount = assertCanWriteAccount as jest.Mock;
+const oUpdate = prismadb.crm_Opportunities.update as jest.Mock;
+const oCreate = prismadb.crm_Opportunities.create as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertOpp.mockResolvedValue(undefined);
+  assertAccount.mockResolvedValue(undefined);
+});
+
+describe("updateOpportunity", () => {
+  it("denies a non-owner and does not update", async () => {
+    assertOpp.mockRejectedValue(new AuthorizationError());
+    const res = await updateOpportunity({ id: "victim" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(oUpdate).not.toHaveBeenCalled();
+  });
+
+  it("guards on data.id and updates for an owner", async () => {
+    await updateOpportunity({ id: "o-1", name: "New" } as any);
+    expect(assertOpp).toHaveBeenCalledWith(OWNER, "o-1");
+    expect(oUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("deleteOpportunity", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertOpp.mockRejectedValue(new AuthorizationError());
+    const res = await deleteOpportunity("victim");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(oUpdate).not.toHaveBeenCalled();
+  });
+
+  it("guards on the opportunityId for an owner", async () => {
+    await deleteOpportunity("o-1");
+    expect(assertOpp).toHaveBeenCalledWith(OWNER, "o-1");
+    expect(oUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("createOpportunity", () => {
+  it("requires write on a linked account (parent-write) and does not create on denial", async () => {
+    assertAccount.mockRejectedValue(new AuthorizationError());
+    const res = await createOpportunity({ name: "X", account: "foreign-acc" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertAccount).toHaveBeenCalledWith(OWNER, "foreign-acc");
+    expect(oCreate).not.toHaveBeenCalled();
+  });
+
+  it("plain create (no linked account) needs only authentication", async () => {
+    await createOpportunity({ name: "X" } as any);
+    expect(assertAccount).not.toHaveBeenCalled();
+    expect(oCreate).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/opportunities/__tests__/update-opportunity-currency.test.ts
+++ b/actions/crm/opportunities/__tests__/update-opportunity-currency.test.ts
@@ -1,4 +1,12 @@
 jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+// Actions now resolve the caller via requireAuthenticated + assertCanWrite*;
+// authz behavior is covered by the *-scope tests, so pass it through here.
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteOpportunity: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     crm_Opportunities: { update: jest.fn(), findUnique: jest.fn() },
@@ -22,12 +30,15 @@ jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 
 import { prismadb } from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
+import { requireAuthenticated, assertCanWriteOpportunity } from "@/lib/authz";
 import { updateOpportunity } from "@/actions/crm/opportunities/update-opportunity";
 
 describe("updateOpportunity currency handling", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getSession as jest.Mock).mockResolvedValue({ user: { id: "u1" } });
+    (requireAuthenticated as jest.Mock).mockResolvedValue({ id: "u1", role: "admin" });
+    (assertCanWriteOpportunity as jest.Mock).mockResolvedValue(undefined);
     (prismadb.crm_Opportunities.findUnique as jest.Mock).mockResolvedValue({ id: "opp-1" });
     (prismadb.crm_Opportunities.update as jest.Mock).mockResolvedValue({ id: "opp-1" });
   });

--- a/actions/crm/opportunities/create-opportunity.ts
+++ b/actions/crm/opportunities/create-opportunity.ts
@@ -1,5 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import sendEmail from "@/lib/sendmail";
@@ -7,6 +6,12 @@ import { inngest } from "@/inngest/client";
 import { writeAuditLog } from "@/lib/audit-log";
 import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
 import { handleStageTransition } from "@/lib/crm/stage-transition";
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const createOpportunity = async (data: {
   account?: string;
@@ -24,10 +29,6 @@ export const createOpportunity = async (data: {
   sales_stage?: string;
   type?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
-  const userId = session.user.id;
   const {
     account,
     assigned_to,
@@ -44,6 +45,22 @@ export const createOpportunity = async (data: {
     sales_stage,
     type,
   } = data;
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    // Parent-write: attaching the opportunity to an account requires write on it.
+    if (account) await assertCanWriteAccount(user, account);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const defaultCurrency = await getDefaultCurrency();
@@ -107,7 +124,7 @@ export const createOpportunity = async (data: {
       entityId: opportunity.id,
       action: "created",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/opportunity.saved", data: { record_id: opportunity.id } });
     revalidatePath("/[locale]/(routes)/crm/opportunities", "page");

--- a/actions/crm/opportunities/delete-opportunity.ts
+++ b/actions/crm/opportunities/delete-opportunity.ts
@@ -1,26 +1,42 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { writeAuditLog } from "@/lib/audit-log";
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteOpportunity = async (opportunityId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!opportunityId) return { error: "opportunityId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteOpportunity(user, opportunityId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_Opportunities.update({
       where: { id: opportunityId },
-      data: { deletedAt: new Date(), deletedBy: session.user.id },
+      data: { deletedAt: new Date(), deletedBy: user.id },
     });
     await writeAuditLog({
       entityType: "opportunity",
       entityId: opportunityId,
       action: "deleted",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
     revalidatePath("/[locale]/(routes)/crm/opportunities", "page");
     return { success: true };

--- a/actions/crm/opportunities/update-opportunity.ts
+++ b/actions/crm/opportunities/update-opportunity.ts
@@ -1,5 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
@@ -7,6 +6,12 @@ import { writeAuditLog, diffObjects } from "@/lib/audit-log";
 import { getSnapshotRate, getDefaultCurrency } from "@/lib/currency";
 import { handleStageTransition } from "@/lib/crm/stage-transition";
 import { qualifiedEntryBlockReason } from "@/lib/crm/approval-gate";
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateOpportunity = async (data: {
   id: string;
@@ -25,10 +30,6 @@ export const updateOpportunity = async (data: {
   sales_stage?: string;
   type?: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
-  const userId = session.user.id;
   const {
     id,
     account,
@@ -48,6 +49,22 @@ export const updateOpportunity = async (data: {
   } = data;
 
   if (!id) return { error: "id is required" };
+
+  // Authorization runs before the approval gate and the update.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteOpportunity(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const defaultCurrency = await getDefaultCurrency();
@@ -95,7 +112,7 @@ export const updateOpportunity = async (data: {
       entityId: opportunity.id,
       action: "updated",
       changes,
-      userId: session.user.id,
+      userId: user.id,
     });
     void inngest.send({ name: "crm/opportunity.saved", data: { record_id: opportunity.id } });
     revalidatePath("/[locale]/(routes)/crm/opportunities", "page");

--- a/actions/crm/opportunity-line-items/__tests__/opp-line-items-write-scope.test.ts
+++ b/actions/crm/opportunity-line-items/__tests__/opp-line-items-write-scope.test.ts
@@ -1,0 +1,166 @@
+// Object-level authorization regression tests for opportunity line-item actions
+// (GHSA-qwhm-9fcm-p878). Line items carry no ownership column — authority is the
+// parent opportunity. Denial tests must fail against the pre-guard code.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteOpportunity: jest.fn(),
+  assertCanWriteOpportunityLineItem: jest.fn(),
+  assertCanReadOpportunity: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+// Pass the safe-action handler through unwrapped so we can call it directly.
+jest.mock("@/lib/create-safe-action", () => ({
+  createSafeAction: (_schema: unknown, handler: any) => handler,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Opportunities: {
+      findUnique: jest.fn().mockResolvedValue({ id: "o-1", currency: "EUR", deletedAt: null }),
+      update: jest.fn().mockResolvedValue({ id: "o-1" }),
+    },
+    crm_OpportunityLineItems: {
+      create: jest.fn().mockResolvedValue({ id: "li-1" }),
+      update: jest.fn().mockResolvedValue({ id: "li-1" }),
+      delete: jest.fn().mockResolvedValue({ id: "li-1" }),
+      findUnique: jest.fn().mockResolvedValue({
+        id: "li-1", opportunityId: "o-1", quantity: 1, unit_price: 10,
+        discount_type: "NONE", discount_value: 0,
+      }),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    crm_Products: { findUnique: jest.fn().mockResolvedValue(null) },
+    $transaction: jest.fn().mockResolvedValue([]),
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+jest.mock("@/lib/line-items", () => ({
+  calculateLineTotal: jest.fn(() => 10),
+  sumLineTotals: jest.fn(() => 10),
+}));
+
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  assertCanWriteOpportunityLineItem,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { addOpportunityLineItem } from "@/actions/crm/opportunity-line-items/add-line-item";
+import { updateOpportunityLineItem } from "@/actions/crm/opportunity-line-items/update-line-item";
+import { removeOpportunityLineItem } from "@/actions/crm/opportunity-line-items/remove-line-item";
+import { reorderOpportunityLineItems } from "@/actions/crm/opportunity-line-items/reorder-line-items";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertOpp = assertCanWriteOpportunity as jest.Mock;
+const assertLI = assertCanWriteOpportunityLineItem as jest.Mock;
+const liCreate = prismadb.crm_OpportunityLineItems.create as jest.Mock;
+const liUpdate = prismadb.crm_OpportunityLineItems.update as jest.Mock;
+const liDelete = prismadb.crm_OpportunityLineItems.delete as jest.Mock;
+const liFindMany = prismadb.crm_OpportunityLineItems.findMany as jest.Mock;
+const tx = prismadb.$transaction as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+const ADD_INPUT = {
+  opportunityId: "o-1", name: "Item", quantity: 1, unit_price: "10",
+  discount_type: "NONE", discount_value: "0", sort_order: 0,
+} as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertOpp.mockResolvedValue(undefined);
+  assertLI.mockResolvedValue(undefined);
+});
+
+describe("addOpportunityLineItem", () => {
+  it("denies when the parent opportunity is not writable and does not create", async () => {
+    assertOpp.mockRejectedValue(new AuthorizationError());
+    const res = await addOpportunityLineItem(ADD_INPUT);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertOpp).toHaveBeenCalledWith(OWNER, "o-1");
+    expect(liCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates for a writable parent", async () => {
+    const res = await addOpportunityLineItem(ADD_INPUT);
+    expect(res).toEqual({ data: { id: "li-1" } });
+    expect(liCreate).toHaveBeenCalled();
+  });
+});
+
+describe("updateOpportunityLineItem", () => {
+  it("denies via the line-item parent guard and does not update", async () => {
+    assertLI.mockRejectedValue(new AuthorizationError());
+    const res = await updateOpportunityLineItem({ id: "li-1" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertLI).toHaveBeenCalledWith(OWNER, "li-1");
+    expect(liUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates for a writable parent", async () => {
+    await updateOpportunityLineItem({ id: "li-1" } as any);
+    expect(liUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("removeOpportunityLineItem", () => {
+  it("denies via the line-item parent guard and does not delete", async () => {
+    assertLI.mockRejectedValue(new AuthorizationError());
+    const res = await removeOpportunityLineItem("li-1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertLI).toHaveBeenCalledWith(OWNER, "li-1");
+    expect(liDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes for a writable parent", async () => {
+    await removeOpportunityLineItem("li-1");
+    expect(liDelete).toHaveBeenCalled();
+  });
+});
+
+describe("reorderOpportunityLineItems (blind — must resolve and authorize every parent)", () => {
+  it("denies the whole batch if any parent is not writable, and does not run the transaction", async () => {
+    liFindMany.mockResolvedValue([
+      { id: "a", opportunityId: "o-1" },
+      { id: "b", opportunityId: "o-2" },
+    ]);
+    assertOpp.mockImplementation(async (_u: any, oppId: string) => {
+      if (oppId === "o-2") throw new AuthorizationError();
+    });
+    const res = await reorderOpportunityLineItems([
+      { id: "a", sort_order: 0 },
+      { id: "b", sort_order: 1 },
+    ]);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(tx).not.toHaveBeenCalled();
+  });
+
+  it("denies when a supplied id does not resolve to a line item", async () => {
+    liFindMany.mockResolvedValue([{ id: "a", opportunityId: "o-1" }]); // "b" missing
+    const res = await reorderOpportunityLineItems([
+      { id: "a", sort_order: 0 },
+      { id: "b", sort_order: 1 },
+    ]);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(tx).not.toHaveBeenCalled();
+  });
+
+  it("reorders when every parent is writable", async () => {
+    liFindMany.mockResolvedValue([
+      { id: "a", opportunityId: "o-1" },
+      { id: "b", opportunityId: "o-1" },
+    ]);
+    const res = await reorderOpportunityLineItems([
+      { id: "a", sort_order: 0 },
+      { id: "b", sort_order: 1 },
+    ]);
+    expect(res).toEqual({ data: { success: true } });
+    expect(tx).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/opportunity-line-items/add-line-item/index.ts
+++ b/actions/crm/opportunity-line-items/add-line-item/index.ts
@@ -1,5 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { AddOpportunityLineItem } from "./schema";
 import { InputType, ReturnType } from "./types";
@@ -7,18 +6,34 @@ import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 import { calculateLineTotal, sumLineTotals } from "@/lib/line-items";
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
-  }
-
-  const userId = session.user.id;
   const {
     opportunityId, productId, name, sku, description,
     quantity, unit_price, discount_type, discount_value, sort_order,
   } = data;
+
+  // Parent-write: a line item write recomputes the opportunity's expected_revenue.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteOpportunity(user, opportunityId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const opportunity = await prismadb.crm_Opportunities.findUnique({

--- a/actions/crm/opportunity-line-items/get-line-items.ts
+++ b/actions/crm/opportunity-line-items/get-line-items.ts
@@ -1,7 +1,14 @@
 import { cache } from "react";
 import { prismadb } from "@/lib/prisma";
+import { requireAuthenticated, assertCanReadOpportunity } from "@/lib/authz";
 
+// Read-scoped: the caller must be able to read the parent opportunity. Auth is
+// resolved inside the cache() body via next/headers (available in the RSC
+// callers of this function); requireAuthenticated / assertCanReadOpportunity
+// throw on denial, so the caller must be within a read-authorized page.
 export const getOpportunityLineItems = cache(async (opportunityId: string) => {
+  const user = await requireAuthenticated();
+  await assertCanReadOpportunity(user, opportunityId);
   return prismadb.crm_OpportunityLineItems.findMany({
     where: { opportunityId },
     include: {

--- a/actions/crm/opportunity-line-items/remove-line-item/index.ts
+++ b/actions/crm/opportunity-line-items/remove-line-item/index.ts
@@ -1,14 +1,28 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 import { sumLineTotals } from "@/lib/line-items";
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunityLineItem,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const removeOpportunityLineItem = async (id: string) => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteOpportunityLineItem(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {
@@ -35,7 +49,7 @@ export const removeOpportunityLineItem = async (id: string) => {
       entityId: id,
       action: "deleted",
       changes: null,
-      userId: session.user.id,
+      userId: user.id,
     });
 
     revalidatePath("/[locale]/(routes)/crm/opportunities/[opportunityId]", "page");

--- a/actions/crm/opportunity-line-items/reorder-line-items/index.ts
+++ b/actions/crm/opportunity-line-items/reorder-line-items/index.ts
@@ -1,14 +1,39 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const reorderOpportunityLineItems = async (
   items: { id: string; sort_order: number }[]
 ) => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  // No parent id is supplied, so resolve every line item's parent and require
+  // write on each. Any unresolved id or unwritable parent fails the whole batch.
+  const ids = items.map((i) => i.id);
+  const rows = await prismadb.crm_OpportunityLineItems.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, opportunityId: true },
+  });
+  const foundIds = new Set(rows.map((r) => r.id));
+  if (ids.some((id) => !foundIds.has(id))) return { error: "Forbidden" };
+  const parents = Array.from(new Set(rows.map((r) => r.opportunityId)));
+  try {
+    for (const opportunityId of parents) await assertCanWriteOpportunity(user, opportunityId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
   }
 
   try {

--- a/actions/crm/opportunity-line-items/update-line-item/index.ts
+++ b/actions/crm/opportunity-line-items/update-line-item/index.ts
@@ -1,5 +1,4 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { UpdateOpportunityLineItem } from "./schema";
 import { InputType, ReturnType } from "./types";
@@ -7,15 +6,31 @@ import { createSafeAction } from "@/lib/create-safe-action";
 import { writeAuditLog } from "@/lib/audit-log";
 import { revalidatePath } from "next/cache";
 import { calculateLineTotal, sumLineTotals } from "@/lib/line-items";
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunityLineItem,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 const handler = async (data: InputType): Promise<ReturnType> => {
-  const session = await getSession();
-  if (!session?.user?.id) {
-    return { error: "Unauthorized" };
-  }
-
-  const userId = session.user.id;
   const { id, ...updateData } = data;
+
+  // Authority is the parent opportunity (resolved by the helper from the line item).
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteOpportunityLineItem(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   try {
     const existing = await prismadb.crm_OpportunityLineItems.findUnique({ where: { id } });

--- a/actions/crm/opportunity/dashboard/__tests__/set-inactive-scope.test.ts
+++ b/actions/crm/opportunity/dashboard/__tests__/set-inactive-scope.test.ts
@@ -1,0 +1,48 @@
+// Object-level authorization for setInactiveOpportunity (GHSA-qwhm-9fcm-p878).
+// This mutating opportunity action lives outside actions/crm/opportunities/ and
+// previously used a hand-rolled assigned_to-only + admin-only guard; it now uses
+// the shared assertCanWriteOpportunity scope.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteOpportunity: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Opportunities: { update: jest.fn().mockResolvedValue({ id: "o-1" }) } },
+}));
+
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { setInactiveOpportunity } from "@/actions/crm/opportunity/dashboard/set-inactive";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertOpp = assertCanWriteOpportunity as jest.Mock;
+const oUpdate = prismadb.crm_Opportunities.update as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+});
+
+it("denies a non-owner and does not mutate", async () => {
+  assertOpp.mockRejectedValue(new AuthorizationError());
+  const res = await setInactiveOpportunity("victim");
+  expect(res).toEqual({ error: "Forbidden" });
+  expect(assertOpp).toHaveBeenCalledWith(OWNER, "victim");
+  expect(oUpdate).not.toHaveBeenCalled();
+});
+
+it("sets inactive for a writable opportunity", async () => {
+  assertOpp.mockResolvedValue(undefined);
+  await setInactiveOpportunity("o-1");
+  expect(assertOpp).toHaveBeenCalledWith(OWNER, "o-1");
+  expect(oUpdate).toHaveBeenCalledWith({ where: { id: "o-1" }, data: { status: "INACTIVE" } });
+});

--- a/actions/crm/opportunity/dashboard/set-inactive.ts
+++ b/actions/crm/opportunity/dashboard/set-inactive.ts
@@ -1,37 +1,32 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
+import {
+  requireAuthenticated,
+  assertCanWriteOpportunity,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export async function setInactiveOpportunity(id: string) {
-  const session = await getSession();
-  if (!session) {
-    return { error: "Unauthenticated" };
-  }
+  if (!id) return { error: "id is required" };
 
-  console.log(id, "id");
-
-  if (!id) {
-    console.log("Opportunity id is required");
+  // Use the shared write scope (assigned_to OR createdBy; admin/manager) rather
+  // than a hand-rolled assigned_to-only + admin-only check.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthenticated" };
+    throw e;
   }
   try {
-    const opportunity = await prismadb.crm_Opportunities.findUnique({
-      where: {
-        id,
-        deletedAt: null,
-      },
-      select: {
-        assigned_to: true,
-      },
-    });
+    await assertCanWriteOpportunity(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
-    if (!opportunity) {
-      return { error: "Opportunity not found" };
-    }
-
-    if (session.user.role !== "admin" && opportunity.assigned_to !== session.user.id) {
-      return { error: "Forbidden" };
-    }
-
+  try {
     const result = await prismadb.crm_Opportunities.update({
       where: {
         id,

--- a/actions/crm/target-lists/__tests__/target-lists-write-scope.test.ts
+++ b/actions/crm/target-lists/__tests__/target-lists-write-scope.test.ts
@@ -1,0 +1,118 @@
+// Object-level authorization regression tests for target-list write actions
+// (GHSA-qwhm-9fcm-p878). Denial tests must fail against the pre-guard code.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteTargetList: jest.fn(),
+  filterAuthorizedTargetIds: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_TargetLists: {
+      create: jest.fn().mockResolvedValue({ id: "tl-1", targets: [] }),
+      update: jest.fn().mockResolvedValue({ id: "tl-1" }),
+      findFirst: jest.fn().mockResolvedValue({ id: "tl-1" }),
+    },
+    targetsToTargetLists: {
+      createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      delete: jest.fn().mockResolvedValue({}),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteTargetList,
+  filterAuthorizedTargetIds,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { updateTargetList } from "@/actions/crm/target-lists/update-target-list";
+import { deleteTargetList } from "@/actions/crm/target-lists/delete-target-list";
+import { addTargetsToList } from "@/actions/crm/target-lists/add-targets-to-list";
+import { removeTargetFromList } from "@/actions/crm/target-lists/remove-target-from-list";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertList = assertCanWriteTargetList as jest.Mock;
+const filterTargets = filterAuthorizedTargetIds as jest.Mock;
+const tlUpdate = prismadb.crm_TargetLists.update as jest.Mock;
+const linkCreateMany = prismadb.targetsToTargetLists.createMany as jest.Mock;
+const linkDelete = prismadb.targetsToTargetLists.delete as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertList.mockResolvedValue(undefined);
+  filterTargets.mockImplementation(async (_u: any, ids: string[]) => ids);
+});
+
+describe("updateTargetList", () => {
+  it("denies a non-owner and does not update", async () => {
+    assertList.mockRejectedValue(new AuthorizationError());
+    const res = await updateTargetList({ id: "victim" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertList).toHaveBeenCalledWith(OWNER, "victim");
+    expect(tlUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates for an owner", async () => {
+    await updateTargetList({ id: "tl-1", name: "New" } as any);
+    expect(assertList).toHaveBeenCalledWith(OWNER, "tl-1");
+    expect(tlUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("deleteTargetList", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertList.mockRejectedValue(new AuthorizationError());
+    const res = await deleteTargetList("victim");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(tlUpdate).not.toHaveBeenCalled();
+  });
+
+  it("soft-deletes for an owner", async () => {
+    await deleteTargetList("tl-1");
+    expect(assertList).toHaveBeenCalledWith(OWNER, "tl-1");
+    expect(tlUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("addTargetsToList", () => {
+  it("denies when the list is not writable and does not link", async () => {
+    assertList.mockRejectedValue(new AuthorizationError());
+    const res = await addTargetsToList("victim-list", ["t1"]);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(linkCreateMany).not.toHaveBeenCalled();
+  });
+
+  it("narrows the target ids to the authorized subset before linking", async () => {
+    filterTargets.mockResolvedValue(["t1"]); // t2 filtered out
+    await addTargetsToList("tl-1", ["t1", "t2"]);
+    expect(filterTargets).toHaveBeenCalledWith(OWNER, ["t1", "t2"]);
+    const arg = linkCreateMany.mock.calls[0][0];
+    expect(arg.data).toEqual([{ target_id: "t1", target_list_id: "tl-1" }]);
+  });
+});
+
+describe("removeTargetFromList", () => {
+  it("denies when the list is not writable and does not delete the link", async () => {
+    assertList.mockRejectedValue(new AuthorizationError());
+    const res = await removeTargetFromList("victim-list", "t1");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(linkDelete).not.toHaveBeenCalled();
+  });
+
+  it("removes the link for an owner", async () => {
+    await removeTargetFromList("tl-1", "t1");
+    expect(assertList).toHaveBeenCalledWith(OWNER, "tl-1");
+    expect(linkDelete).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/target-lists/add-targets-to-list.ts
+++ b/actions/crm/target-lists/add-targets-to-list.ts
@@ -1,19 +1,39 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTargetList,
+  filterAuthorizedTargetIds,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const addTargetsToList = async (targetListId: string, targetIds: string[]) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!Array.isArray(targetIds) || targetIds.length === 0) {
     return { error: "targetIds must be a non-empty array" };
   }
 
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTargetList(user, targetListId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+
+  // Only attach targets the caller can access.
+  const authorizedIds = await filterAuthorizedTargetIds(user, targetIds);
+
   try {
     const result = await prismadb.targetsToTargetLists.createMany({
-      data: targetIds.map((id: string) => ({
+      data: authorizedIds.map((id: string) => ({
         target_id: id,
         target_list_id: targetListId,
       })),

--- a/actions/crm/target-lists/create-target-list.ts
+++ b/actions/crm/target-lists/create-target-list.ts
@@ -1,27 +1,40 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  filterAuthorizedTargetIds,
+  AuthenticationError,
+} from "@/lib/authz";
 
 export const createTargetList = async (data: {
   name: string;
   description?: string;
   targetIds?: string[];
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { name, description, targetIds = [] } = data;
   if (!name) return { error: "name is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+
+  // Only seed the list with targets the caller can access.
+  const authorizedIds =
+    targetIds.length > 0 ? await filterAuthorizedTargetIds(user, targetIds) : [];
 
   try {
     const list = await prismadb.crm_TargetLists.create({
       data: {
         name,
         description,
-        created_by: (session.user as any).id,
+        created_by: user.id,
         targets: {
-          create: targetIds.map((id: string) => ({ target_id: id })),
+          create: authorizedIds.map((id: string) => ({ target_id: id })),
         },
       },
       include: { targets: true },

--- a/actions/crm/target-lists/delete-target-list.ts
+++ b/actions/crm/target-lists/delete-target-list.ts
@@ -1,18 +1,34 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTargetList,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteTargetList = async (targetListId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!targetListId) return { error: "targetListId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTargetList(user, targetListId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_TargetLists.update({
       where: { id: targetListId },
-      data: { deletedAt: new Date(), deletedBy: session.user.id },
+      data: { deletedAt: new Date(), deletedBy: user.id },
     });
     revalidatePath("/[locale]/(routes)/crm/target-lists", "page");
     return { success: true };

--- a/actions/crm/target-lists/remove-target-from-list.ts
+++ b/actions/crm/target-lists/remove-target-from-list.ts
@@ -1,13 +1,29 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTargetList,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const removeTargetFromList = async (targetListId: string, targetId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!targetId) return { error: "targetId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTargetList(user, targetListId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.targetsToTargetLists.delete({

--- a/actions/crm/target-lists/update-target-list.ts
+++ b/actions/crm/target-lists/update-target-list.ts
@@ -1,7 +1,12 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTargetList,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateTargetList = async (data: {
   id: string;
@@ -9,11 +14,22 @@ export const updateTargetList = async (data: {
   description?: string;
   status?: boolean;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { id, name, description, status } = data;
   if (!id) return { error: "id is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTargetList(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const existing = await prismadb.crm_TargetLists.findFirst({ where: { id, deletedAt: null } });

--- a/actions/crm/targets/__tests__/convert-target-scope.test.ts
+++ b/actions/crm/targets/__tests__/convert-target-scope.test.ts
@@ -1,0 +1,59 @@
+// Object-level authorization for convertTarget (GHSA-qwhm-9fcm-p878). This is a
+// directly-callable "use server" action (invoked from UpdateTargetForm, not only
+// via convertTargetToDeal), so it needs its own write-scope guard: converting
+// creates an account + contact and mutates the target.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteTarget: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Targets: { findFirst: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { convertTarget } from "@/actions/crm/targets/convert-target";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertTarget = assertCanWriteTarget as jest.Mock;
+const targetFind = prismadb.crm_Targets.findFirst as jest.Mock;
+const tx = prismadb.$transaction as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+});
+
+it("denies a non-owner before reading or converting the target", async () => {
+  assertTarget.mockRejectedValue(new AuthorizationError());
+  const res = await convertTarget("victim");
+  expect(res).toEqual({ error: "Forbidden" });
+  expect(assertTarget).toHaveBeenCalledWith(OWNER, "victim");
+  expect(targetFind).not.toHaveBeenCalled();
+  expect(tx).not.toHaveBeenCalled();
+});
+
+it("proceeds for an owner (guard passes, then reads the target)", async () => {
+  assertTarget.mockResolvedValue(undefined);
+  targetFind.mockResolvedValue(null); // short-circuits to Target not found
+  const res = await convertTarget("t-1");
+  expect(assertTarget).toHaveBeenCalledWith(OWNER, "t-1");
+  expect(targetFind).toHaveBeenCalled();
+  expect(res).toEqual({ error: "Target not found" });
+});

--- a/actions/crm/targets/__tests__/convert-target-to-deal.test.ts
+++ b/actions/crm/targets/__tests__/convert-target-to-deal.test.ts
@@ -1,4 +1,13 @@
 jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+// convertTargetToDeal now resolves the caller via requireAuthenticated and
+// guards on assertCanWriteTarget; those are pass-through here (the guard itself
+// is covered by targets-write-scope.test.ts).
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteTarget: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
 jest.mock("@/lib/prisma", () => ({
   prismadb: {
     crm_Targets: { findFirst: jest.fn() },
@@ -19,6 +28,11 @@ jest.mock("@/actions/crm/targets/convert-target", () => ({
 import { prismadb } from "@/lib/prisma";
 import { inngest } from "@/inngest/client";
 import { getSession } from "@/lib/auth-server";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  AuthenticationError,
+} from "@/lib/authz";
 import { convertTarget } from "@/actions/crm/targets/convert-target";
 import { convertTargetToDeal } from "@/actions/crm/targets/convert-target-to-deal";
 
@@ -26,10 +40,12 @@ describe("convertTargetToDeal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (getSession as jest.Mock).mockResolvedValue({ user: { id: "u1" } });
+    (requireAuthenticated as jest.Mock).mockResolvedValue({ id: "u1", role: "admin" });
+    (assertCanWriteTarget as jest.Mock).mockResolvedValue(undefined);
   });
 
   it("unauthenticated returns Unauthorized", async () => {
-    (getSession as jest.Mock).mockResolvedValue(null);
+    (requireAuthenticated as jest.Mock).mockRejectedValue(new AuthenticationError());
     expect(await convertTargetToDeal("t1")).toEqual({ error: "Unauthorized" });
     expect(convertTarget).not.toHaveBeenCalled();
   });

--- a/actions/crm/targets/__tests__/targets-write-scope.test.ts
+++ b/actions/crm/targets/__tests__/targets-write-scope.test.ts
@@ -1,0 +1,103 @@
+// Object-level authorization regression tests for target write actions
+// (GHSA-qwhm-9fcm-p878). Denial tests must fail against the pre-guard code.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteTarget: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Targets: {
+      update: jest.fn().mockResolvedValue({ id: "t-1" }),
+      findFirst: jest.fn().mockResolvedValue({ id: "t-1", company: "Co", last_name: "X" }),
+    },
+    crm_Opportunities: {
+      findFirst: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({ id: "o-1", sales_stage: null }),
+    },
+    crm_campaign_sends: { findFirst: jest.fn().mockResolvedValue(null) },
+    crm_Opportunities_Sales_Stages: { findFirst: jest.fn().mockResolvedValue({ id: "stage-0" }) },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/inngest/client", () => ({ inngest: { send: jest.fn() } }));
+jest.mock("@/lib/audit-log", () => ({ writeAuditLog: jest.fn() }));
+jest.mock("@/lib/crm/stage-transition", () => ({ handleStageTransition: jest.fn() }));
+const mockConvertTarget = jest.fn();
+jest.mock("@/actions/crm/targets/convert-target", () => ({ convertTarget: mockConvertTarget }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { updateTarget } from "@/actions/crm/targets/update-target";
+import { deleteTarget } from "@/actions/crm/targets/delete-target";
+import { convertTargetToDeal } from "@/actions/crm/targets/convert-target-to-deal";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertTarget = assertCanWriteTarget as jest.Mock;
+const tUpdate = prismadb.crm_Targets.update as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertTarget.mockResolvedValue(undefined);
+  mockConvertTarget.mockResolvedValue({ accountId: "a-1", contactId: "c-1" });
+});
+
+describe("updateTarget", () => {
+  it("denies a non-owner and does not update", async () => {
+    assertTarget.mockRejectedValue(new AuthorizationError());
+    const res = await updateTarget({ id: "victim" } as any);
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertTarget).toHaveBeenCalledWith(OWNER, "victim");
+    expect(tUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates for an owner", async () => {
+    await updateTarget({ id: "t-1" } as any);
+    expect(assertTarget).toHaveBeenCalledWith(OWNER, "t-1");
+    expect(tUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("deleteTarget", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertTarget.mockRejectedValue(new AuthorizationError());
+    const res = await deleteTarget("victim");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(tUpdate).not.toHaveBeenCalled();
+  });
+
+  it("soft-deletes for an owner", async () => {
+    await deleteTarget("t-1");
+    expect(assertTarget).toHaveBeenCalledWith(OWNER, "t-1");
+    expect(tUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("convertTargetToDeal", () => {
+  it("denies a non-owner before converting the target", async () => {
+    assertTarget.mockRejectedValue(new AuthorizationError());
+    const res = await convertTargetToDeal("victim");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertTarget).toHaveBeenCalledWith(OWNER, "victim");
+    expect(mockConvertTarget).not.toHaveBeenCalled();
+  });
+
+  it("converts for an owner", async () => {
+    const res = await convertTargetToDeal("t-1");
+    expect(assertTarget).toHaveBeenCalledWith(OWNER, "t-1");
+    expect(mockConvertTarget).toHaveBeenCalledWith("t-1");
+    expect(res).toMatchObject({ opportunityId: "o-1" });
+  });
+});

--- a/actions/crm/targets/convert-target-to-deal.ts
+++ b/actions/crm/targets/convert-target-to-deal.ts
@@ -1,20 +1,36 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
 import { inngest } from "@/inngest/client";
 import { writeAuditLog } from "@/lib/audit-log";
 import { convertTarget } from "./convert-target";
 import { handleStageTransition } from "@/lib/crm/stage-transition";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export async function convertTargetToDeal(
   targetId: string
 ): Promise<
   { accountId: string; contactId: string; opportunityId: string } | { error: string }
 > {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-  const userId = (session.user as any).id;
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
+  const userId = user.id;
 
   const converted = await convertTarget(targetId);
   if ("error" in converted) return converted;

--- a/actions/crm/targets/convert-target.ts
+++ b/actions/crm/targets/convert-target.ts
@@ -1,13 +1,33 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export async function convertTarget(
   targetId: string
 ): Promise<{ accountId: string; contactId: string } | { error: string }> {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  // This is a directly-callable "use server" action (invoked from
+  // UpdateTargetForm as well as via convertTargetToDeal), so it needs its own
+  // object-level guard: converting a target creates an account + contact and
+  // mutates the target, and must be limited to targets the caller can write.
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   const target = await prismadb.crm_Targets.findFirst({ where: { id: targetId, deletedAt: null } });
   if (!target) return { error: "Target not found" };
@@ -39,7 +59,7 @@ export async function convertTarget(
           employees: target.employees ?? undefined,
           description: target.description ?? undefined,
           status: "Active",
-          createdBy: (session.user as any).id,
+          createdBy: user.id,
         },
       });
 
@@ -58,7 +78,7 @@ export async function convertTarget(
           social_instagram: target.social_instagram ?? undefined,
           social_facebook: target.social_facebook ?? undefined,
           accountsIDs: acct.id,
-          createdBy: (session.user as any).id,
+          createdBy: user.id,
         },
       });
 
@@ -68,7 +88,7 @@ export async function convertTarget(
           converted_at: new Date(),
           converted_account_id: acct.id,
           converted_contact_id: ctct.id,
-          updatedBy: (session.user as any).id,
+          updatedBy: user.id,
         },
       });
 

--- a/actions/crm/targets/create-target.ts
+++ b/actions/crm/targets/create-target.ts
@@ -1,7 +1,7 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import { requireAuthenticated, AuthenticationError } from "@/lib/authz";
 
 export const createTarget = async (data: {
   last_name?: string;
@@ -19,15 +19,20 @@ export const createTarget = async (data: {
   social_facebook?: string;
   status?: boolean;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
 
   const { last_name, email, mobile_phone, ...rest } = data;
   if (!last_name && !data.company) return { error: "last_name or company is required" };
 
   try {
     const target = await prismadb.crm_Targets.create({
-      data: { last_name: last_name ?? "", email, mobile_phone, ...rest, created_by: (session.user as any).id },
+      data: { last_name: last_name ?? "", email, mobile_phone, ...rest, created_by: user.id },
     });
     revalidatePath("/[locale]/(routes)/crm/targets", "page");
     return { data: target };

--- a/actions/crm/targets/delete-target.ts
+++ b/actions/crm/targets/delete-target.ts
@@ -1,18 +1,34 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteTarget = async (targetId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!targetId) return { error: "targetId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, targetId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     await prismadb.crm_Targets.update({
       where: { id: targetId },
-      data: { deletedAt: new Date(), deletedBy: session.user.id },
+      data: { deletedAt: new Date(), deletedBy: user.id },
     });
     revalidatePath("/[locale]/(routes)/crm/targets", "page");
     return { success: true };

--- a/actions/crm/targets/import-targets.ts
+++ b/actions/crm/targets/import-targets.ts
@@ -1,14 +1,14 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
-
 import { prismadb } from "@/lib/prisma";
 import { parseSpreadsheetFile } from "@/lib/spreadsheet/parse";
+import { requireAuthenticated } from "@/lib/authz";
 
 export async function importTargets(
   formData: FormData
 ): Promise<{ imported: number; skipped: number; errors: string[] }> {
-  const session = await getSession();
-  if (!session) throw new Error("Unauthorized");
+  // Plain bulk create; rows are owned by the importer. requireAuthenticated
+  // throws on no session, matching this function's throw-based contract.
+  const user = await requireAuthenticated();
 
   const file = formData.get("file") as File | null;
   if (!file) throw new Error("No file provided");
@@ -65,7 +65,7 @@ export async function importTargets(
       industry: row.industry || null,
       employees: row.employees || null,
       description: row.description || null,
-      created_by: (session.user as any).id,
+      created_by: user.id,
     });
   });
 

--- a/actions/crm/targets/update-target.ts
+++ b/actions/crm/targets/update-target.ts
@@ -1,7 +1,12 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteTarget,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const updateTarget = async (data: {
   id: string;
@@ -28,16 +33,27 @@ export const updateTarget = async (data: {
   description?: string;
   status?: boolean;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { id, ...rest } = data;
   if (!id) return { error: "id is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteTarget(user, id);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const target = await prismadb.crm_Targets.update({
       where: { id },
-      data: { ...rest, updatedBy: (session.user as any).id },
+      data: { ...rest, updatedBy: user.id },
     });
     revalidatePath("/[locale]/(routes)/crm/targets", "page");
     return { data: target };

--- a/actions/crm/tasks/__tests__/crm-tasks-write-scope.test.ts
+++ b/actions/crm/tasks/__tests__/crm-tasks-write-scope.test.ts
@@ -1,0 +1,114 @@
+// Object-level authorization regression tests for CRM task write actions
+// (GHSA-qwhm-9fcm-p878). crm_Accounts_Tasks ownership = creator or assignee.
+
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  assertCanWriteCrmTask: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/auth-server", () => ({
+  getSession: jest.fn().mockResolvedValue({ user: { id: "owner" } }),
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Accounts_Tasks: {
+      findUnique: jest.fn().mockResolvedValue({ id: "t-1" }),
+      delete: jest.fn().mockResolvedValue({ id: "t-1" }),
+    },
+    tasksComments: {
+      create: jest.fn().mockResolvedValue({ id: "cm-1" }),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    documentsToCrmAccountsTasks: {
+      create: jest.fn().mockResolvedValue({}),
+      delete: jest.fn().mockResolvedValue({}),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import {
+  requireAuthenticated,
+  assertCanWriteCrmTask,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { addComment } from "@/actions/crm/tasks/add-comment";
+import {
+  assignDocumentToCrmTask,
+  disconnectDocumentFromCrmTask,
+} from "@/actions/crm/tasks/assign-document";
+import { deleteTask } from "@/actions/crm/tasks/delete-task";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertTask = assertCanWriteCrmTask as jest.Mock;
+const commentCreate = prismadb.tasksComments.create as jest.Mock;
+const docCreate = prismadb.documentsToCrmAccountsTasks.create as jest.Mock;
+const docDelete = prismadb.documentsToCrmAccountsTasks.delete as jest.Mock;
+const taskDelete = prismadb.crm_Accounts_Tasks.delete as jest.Mock;
+
+const OWNER = { id: "owner", role: "user" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authed.mockResolvedValue(OWNER);
+  assertTask.mockResolvedValue(undefined);
+});
+
+describe("addComment", () => {
+  it("denies a non-owner and does not create a comment", async () => {
+    assertTask.mockRejectedValue(new AuthorizationError());
+    const res = await addComment({ taskId: "victim", comment: "x" });
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertTask).toHaveBeenCalledWith(OWNER, "victim");
+    expect(commentCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a comment for an owner", async () => {
+    await addComment({ taskId: "t-1", comment: "x" });
+    expect(assertTask).toHaveBeenCalledWith(OWNER, "t-1");
+    expect(commentCreate).toHaveBeenCalled();
+  });
+});
+
+describe("assignDocumentToCrmTask", () => {
+  it("denies a non-owner and does not link the document", async () => {
+    assertTask.mockRejectedValue(new AuthorizationError());
+    const res = await assignDocumentToCrmTask({ documentId: "d-1", taskId: "victim" });
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(docCreate).not.toHaveBeenCalled();
+  });
+
+  it("links for an owner", async () => {
+    await assignDocumentToCrmTask({ documentId: "d-1", taskId: "t-1" });
+    expect(assertTask).toHaveBeenCalledWith(OWNER, "t-1");
+    expect(docCreate).toHaveBeenCalled();
+  });
+});
+
+describe("disconnectDocumentFromCrmTask", () => {
+  it("denies a non-owner and does not unlink the document", async () => {
+    assertTask.mockRejectedValue(new AuthorizationError());
+    const res = await disconnectDocumentFromCrmTask({ documentId: "d-1", taskId: "victim" });
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(docDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteTask", () => {
+  it("denies a non-owner and does not delete the task", async () => {
+    assertTask.mockRejectedValue(new AuthorizationError());
+    const res = await deleteTask("victim");
+    expect(res).toEqual({ error: "Forbidden" });
+    expect(assertTask).toHaveBeenCalledWith(OWNER, "victim");
+    expect(taskDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes for an owner", async () => {
+    await deleteTask("t-1");
+    expect(assertTask).toHaveBeenCalledWith(OWNER, "t-1");
+    expect(taskDelete).toHaveBeenCalled();
+  });
+});

--- a/actions/crm/tasks/add-comment.ts
+++ b/actions/crm/tasks/add-comment.ts
@@ -1,19 +1,35 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteCrmTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const addComment = async (data: {
   taskId: string;
   comment: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { taskId, comment } = data;
 
   if (!taskId) return { error: "taskId is required" };
   if (!comment) return { error: "comment is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteCrmTask(user, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const task = await prismadb.crm_Accounts_Tasks.findUnique({
@@ -30,7 +46,7 @@ export const addComment = async (data: {
         v: 0,
         comment,
         assigned_crm_account_task: taskId,
-        user: session.user.id,
+        user: user.id,
       },
     });
 

--- a/actions/crm/tasks/assign-document.ts
+++ b/actions/crm/tasks/assign-document.ts
@@ -1,18 +1,34 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteCrmTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const assignDocumentToCrmTask = async (data: {
   documentId: string;
   taskId: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { documentId, taskId } = data;
   if (!documentId) return { error: "Missing document ID" };
   if (!taskId) return { error: "Missing task ID" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteCrmTask(user, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const task = await prismadb.crm_Accounts_Tasks.findUnique({
@@ -40,12 +56,23 @@ export const disconnectDocumentFromCrmTask = async (data: {
   documentId: string;
   taskId: string;
 }) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   const { documentId, taskId } = data;
   if (!documentId) return { error: "Missing document ID" };
   if (!taskId) return { error: "Missing task ID" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteCrmTask(user, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     const task = await prismadb.crm_Accounts_Tasks.findUnique({

--- a/actions/crm/tasks/delete-task.ts
+++ b/actions/crm/tasks/delete-task.ts
@@ -1,13 +1,29 @@
 "use server";
-import { getSession } from "@/lib/auth-server";
 import { prismadb } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import {
+  requireAuthenticated,
+  assertCanWriteCrmTask,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
 
 export const deleteTask = async (taskId: string) => {
-  const session = await getSession();
-  if (!session) return { error: "Unauthorized" };
-
   if (!taskId) return { error: "taskId is required" };
+
+  let user;
+  try {
+    user = await requireAuthenticated();
+  } catch (e) {
+    if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+    throw e;
+  }
+  try {
+    await assertCanWriteCrmTask(user, taskId);
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { error: "Forbidden" };
+    throw e;
+  }
 
   try {
     // CRM account task comments link via `assigned_crm_account_task`, not

--- a/actions/emails/__tests__/accounts-ssrf.test.ts
+++ b/actions/emails/__tests__/accounts-ssrf.test.ts
@@ -1,0 +1,111 @@
+// SSRF host-guard regression tests for the accounts.ts IMAP sinks
+// (GHSA-f5r5-f2v5-74ww). classifyMailError is the REAL module (its output is
+// what a blocked host must match). The imap mock records constructor config so
+// we can assert the pinned IP is dialled, not the hostname.
+
+const mockImapInstances: any[] = [];
+jest.mock("imap", () => {
+  const ctor = jest.fn().mockImplementation((config: any) => {
+    const handlers: Record<string, (...a: any[]) => void> = {};
+    const inst = {
+      config,
+      once: (ev: string, cb: any) => { handlers[ev] = cb; return inst; },
+      connect: () => { queueMicrotask(() => handlers["ready"]?.()); },
+      end: () => {},
+      getBoxes: (_: string, cb: any) => cb(null, {}),
+    };
+    mockImapInstances.push(inst);
+    return inst;
+  });
+  return { __esModule: true, default: ctor };
+});
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    emailAccount: {
+      create: jest.fn().mockResolvedValue({ id: "acc-1", label: "x" }),
+    },
+  },
+}));
+jest.mock("@/lib/email-crypto", () => ({ encrypt: jest.fn(() => "enc"), decrypt: jest.fn(() => "pw") }));
+jest.mock("@/lib/net/host-guard", () => ({
+  assertPublicHost: jest.fn(),
+  HostNotAllowedError: class HostNotAllowedError extends Error {},
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { assertPublicHost, HostNotAllowedError } from "@/lib/net/host-guard";
+import { classifyMailError } from "@/lib/email/imap-safety";
+import { testEmailConnection, listImapFolders, createEmailAccount } from "@/actions/emails/accounts";
+
+const getSess = getSession as jest.Mock;
+const guard = assertPublicHost as jest.Mock;
+const BLOCKED_MSG = classifyMailError({ message: "ECONNREFUSED" } as Error);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockImapInstances.length = 0;
+  getSess.mockResolvedValue({ user: { id: "u1" } });
+});
+
+describe("testEmailConnection", () => {
+  it("a blocked host is not dialled and returns the generic connect error", async () => {
+    guard.mockRejectedValue(new HostNotAllowedError());
+    const res = await testEmailConnection({
+      imapHost: "127.0.0.1", imapPort: 993, imapSsl: true, username: "u", password: "p",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe(BLOCKED_MSG);
+    expect(mockImapInstances.length).toBe(0);
+  });
+
+  it("an allowed host is dialled on the PINNED IP with servername=hostname", async () => {
+    guard.mockResolvedValue({ address: "93.184.216.34", hostname: "mail.example.com" });
+    const res = await testEmailConnection({
+      imapHost: "mail.example.com", imapPort: 993, imapSsl: true, username: "u", password: "p",
+    });
+    expect(res).toEqual({ ok: true });
+    expect(mockImapInstances[0].config.host).toBe("93.184.216.34");
+    expect(mockImapInstances[0].config.tlsOptions.servername).toBe("mail.example.com");
+  });
+});
+
+describe("listImapFolders", () => {
+  it("a blocked host is not dialled", async () => {
+    guard.mockRejectedValue(new HostNotAllowedError());
+    const res = await listImapFolders({
+      imapHost: "10.0.0.5", imapPort: 993, imapSsl: true, username: "u", password: "p",
+    });
+    expect(res.ok).toBe(false);
+    expect(mockImapInstances.length).toBe(0);
+  });
+
+  it("an allowed host is dialled on the PINNED IP", async () => {
+    guard.mockResolvedValue({ address: "93.184.216.34", hostname: "imap.example.com" });
+    await listImapFolders({
+      imapHost: "imap.example.com", imapPort: 993, imapSsl: true, username: "u", password: "p",
+    });
+    expect(mockImapInstances[0].config.host).toBe("93.184.216.34");
+    expect(mockImapInstances[0].config.tlsOptions.servername).toBe("imap.example.com");
+  });
+});
+
+describe("createEmailAccount", () => {
+  const input = {
+    label: "x", imapHost: "127.0.0.1", imapPort: 993, imapSsl: true,
+    smtpHost: "127.0.0.1", smtpPort: 465, smtpSsl: true, username: "u", password: "p",
+  };
+
+  it("rejects a private mail host (store-time defense) and does not create", async () => {
+    guard.mockRejectedValue(new HostNotAllowedError());
+    await expect(createEmailAccount(input)).rejects.toThrow();
+    expect(prismadb.emailAccount.create).not.toHaveBeenCalled();
+  });
+
+  it("creates for public mail hosts", async () => {
+    guard.mockResolvedValue({ address: "93.184.216.34", hostname: "mail.example.com" });
+    await createEmailAccount({ ...input, imapHost: "mail.example.com", smtpHost: "smtp.example.com" });
+    expect(prismadb.emailAccount.create).toHaveBeenCalled();
+  });
+});

--- a/actions/emails/__tests__/messages-ssrf.test.ts
+++ b/actions/emails/__tests__/messages-ssrf.test.ts
@@ -1,0 +1,53 @@
+// SSRF host-guard regression tests for sendEmail (SMTP sink).
+const createTransport = jest.fn((_opts: any) => ({ sendMail: jest.fn().mockResolvedValue({ messageId: "m1" }) }));
+jest.mock("nodemailer", () => ({ __esModule: true, default: { createTransport } }));
+jest.mock("@/lib/auth-server", () => ({ getSession: jest.fn() }));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    emailAccount: { findFirst: jest.fn() },
+    email: { create: jest.fn().mockResolvedValue({}) },
+  },
+}));
+jest.mock("@/lib/email-crypto", () => ({ decrypt: jest.fn(() => "pw") }));
+jest.mock("@/lib/net/host-guard", () => ({
+  assertPublicHost: jest.fn(),
+  HostNotAllowedError: class HostNotAllowedError extends Error {},
+}));
+
+import { getSession } from "@/lib/auth-server";
+import { prismadb } from "@/lib/prisma";
+import { assertPublicHost, HostNotAllowedError } from "@/lib/net/host-guard";
+import { sendEmail } from "@/actions/emails/messages";
+
+const getSess = getSession as jest.Mock;
+const guard = assertPublicHost as jest.Mock;
+const findAcc = prismadb.emailAccount.findFirst as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getSess.mockResolvedValue({ user: { id: "u1" } });
+});
+
+it("a blocked stored SMTP host is not dialled", async () => {
+  findAcc.mockResolvedValue({
+    id: "a1", userId: "u1", smtpHost: "127.0.0.1", smtpPort: 465, smtpSsl: true,
+    username: "u", passwordEncrypted: "enc",
+  });
+  guard.mockRejectedValue(new HostNotAllowedError());
+  await expect(
+    sendEmail({ accountId: "a1", to: ["x@y.z"], subject: "s", body: "b" } as any)
+  ).rejects.toThrow();
+  expect(createTransport).not.toHaveBeenCalled();
+});
+
+it("an allowed host dials the PINNED IP with servername=hostname", async () => {
+  findAcc.mockResolvedValue({
+    id: "a1", userId: "u1", smtpHost: "smtp.example.com", smtpPort: 465, smtpSsl: true,
+    username: "u", passwordEncrypted: "enc",
+  });
+  guard.mockResolvedValue({ address: "93.184.216.34", hostname: "smtp.example.com" });
+  await sendEmail({ accountId: "a1", to: ["x@y.z"], subject: "s", body: "b" } as any);
+  const cfg = createTransport.mock.calls[0][0];
+  expect(cfg.host).toBe("93.184.216.34");
+  expect(cfg.servername).toBe("smtp.example.com");
+});

--- a/actions/emails/accounts.ts
+++ b/actions/emails/accounts.ts
@@ -8,6 +8,7 @@ import {
   isAllowedSmtpPort,
   classifyMailError,
 } from "@/lib/email/imap-safety";
+import { assertPublicHost, HostNotAllowedError } from "@/lib/net/host-guard";
 import Imap from "imap";
 
 async function requireSession() {
@@ -66,6 +67,16 @@ export async function createEmailAccount(input: CreateInput) {
   if (!isAllowedImapPort(input.imapPort)) throw new Error("Unsupported IMAP port");
   if (!isAllowedSmtpPort(input.smtpPort)) throw new Error("Unsupported SMTP port");
 
+  // Store-time SSRF defense: a private/internal mail host cannot even be saved,
+  // protecting the later connect sinks (sendEmail, background sync) at the source.
+  try {
+    await assertPublicHost(input.imapHost);
+    await assertPublicHost(input.smtpHost);
+  } catch (e) {
+    if (e instanceof HostNotAllowedError) throw new Error("Mail host is not allowed");
+    throw e;
+  }
+
   const passwordEncrypted = encrypt(input.password);
   return prismadb.emailAccount.create({
     data: {
@@ -116,15 +127,27 @@ export async function testEmailConnection(
     return { ok: false, error: "Unsupported IMAP port" };
   }
 
+  let pinned: { address: string; hostname: string };
+  try {
+    pinned = await assertPublicHost(input.imapHost);
+  } catch (e) {
+    if (e instanceof HostNotAllowedError) {
+      // Indistinguishable from a real unreachable host — no SSRF oracle.
+      return { ok: false, error: classifyMailError({ message: "ECONNREFUSED" } as Error) };
+    }
+    throw e;
+  }
+
   const connectionPromise = new Promise<{ ok: boolean; error?: string }>((resolve) => {
     const imap = new Imap({
       user: input.username,
       password: input.password,
-      host: input.imapHost,
+      host: pinned.address,
       port: input.imapPort,
       tls: input.imapSsl,
-      // tlsOptions: { rejectUnauthorized: false } intentionally disabled for self-signed cert support
-      tlsOptions: { rejectUnauthorized: false },
+      // Dial the validated IP; keep the hostname for TLS SNI. (rejectUnauthorized
+      // left as-is — TLS verification is a separate workstream.)
+      tlsOptions: { servername: pinned.hostname, rejectUnauthorized: false },
       authTimeout: 8000,
       connTimeout: 8000,
     });
@@ -165,14 +188,24 @@ export async function listImapFolders(
     return { ok: false, error: "Unsupported IMAP port" };
   }
 
+  let pinned: { address: string; hostname: string };
+  try {
+    pinned = await assertPublicHost(input.imapHost);
+  } catch (e) {
+    if (e instanceof HostNotAllowedError) {
+      return { ok: false, error: classifyMailError({ message: "ECONNREFUSED" } as Error) };
+    }
+    throw e;
+  }
+
   return new Promise((resolve) => {
     const imap = new Imap({
       user: input.username,
       password: input.password,
-      host: input.imapHost,
+      host: pinned.address,
       port: input.imapPort,
       tls: input.imapSsl,
-      tlsOptions: { rejectUnauthorized: false },
+      tlsOptions: { servername: pinned.hostname, rejectUnauthorized: false },
       authTimeout: 8000,
       connTimeout: 8000,
     });

--- a/actions/emails/accounts.ts
+++ b/actions/emails/accounts.ts
@@ -3,6 +3,11 @@ import { getSession } from "@/lib/auth-server";
 
 import { prismadb } from "@/lib/prisma";
 import { encrypt } from "@/lib/email-crypto";
+import {
+  isAllowedImapPort,
+  isAllowedSmtpPort,
+  classifyMailError,
+} from "@/lib/email/imap-safety";
 import Imap from "imap";
 
 async function requireSession() {
@@ -56,8 +61,10 @@ export async function createEmailAccount(input: CreateInput) {
   if (!input.smtpHost?.trim()) throw new Error("SMTP host is required");
   if (!input.username?.trim()) throw new Error("Username is required");
   if (!input.password?.trim()) throw new Error("Password is required");
-  if (input.imapPort < 1 || input.imapPort > 65535) throw new Error("Invalid IMAP port");
-  if (input.smtpPort < 1 || input.smtpPort > 65535) throw new Error("Invalid SMTP port");
+  // Restrict to real mail ports so a stored account cannot be used to reach
+  // internal services (Postgres/MinIO/Inngest/metadata) on later connects.
+  if (!isAllowedImapPort(input.imapPort)) throw new Error("Unsupported IMAP port");
+  if (!isAllowedSmtpPort(input.smtpPort)) throw new Error("Unsupported SMTP port");
 
   const passwordEncrypted = encrypt(input.password);
   return prismadb.emailAccount.create({
@@ -105,6 +112,10 @@ export async function testEmailConnection(
 ): Promise<{ ok: boolean; error?: string }> {
   await requireSession();
 
+  if (!isAllowedImapPort(input.imapPort)) {
+    return { ok: false, error: "Unsupported IMAP port" };
+  }
+
   const connectionPromise = new Promise<{ ok: boolean; error?: string }>((resolve) => {
     const imap = new Imap({
       user: input.username,
@@ -122,7 +133,10 @@ export async function testEmailConnection(
       resolve({ ok: true });
     });
     imap.once("error", (err: Error) => {
-      resolve({ ok: false, error: err.message });
+      // Log the real error server-side; return a classified message so
+      // protocol/banner text cannot leak to the caller (SSRF oracle).
+      console.error("[testEmailConnection] IMAP error:", err.message);
+      resolve({ ok: false, error: classifyMailError(err) });
     });
     imap.connect();
   });
@@ -147,6 +161,10 @@ export async function listImapFolders(
 ): Promise<{ ok: true; folders: string[] } | { ok: false; error: string }> {
   await requireSession();
 
+  if (!isAllowedImapPort(input.imapPort)) {
+    return { ok: false, error: "Unsupported IMAP port" };
+  }
+
   return new Promise((resolve) => {
     const imap = new Imap({
       user: input.username,
@@ -162,7 +180,10 @@ export async function listImapFolders(
     imap.once("ready", () => {
       imap.getBoxes("", (err, boxes) => {
         imap.end();
-        if (err) return resolve({ ok: false, error: err.message });
+        if (err) {
+          console.error("[listImapFolders] getBoxes error:", err.message);
+          return resolve({ ok: false, error: classifyMailError(err) });
+        }
 
         const names: string[] = [];
         function walk(node: Imap.MailBoxes, prefix: string) {
@@ -177,7 +198,10 @@ export async function listImapFolders(
       });
     });
 
-    imap.once("error", (err: Error) => resolve({ ok: false, error: err.message }));
+    imap.once("error", (err: Error) => {
+      console.error("[listImapFolders] IMAP error:", err.message);
+      resolve({ ok: false, error: classifyMailError(err) });
+    });
     imap.connect();
 
     setTimeout(() => resolve({ ok: false, error: "Connection timed out" }), 10000);

--- a/actions/emails/messages.ts
+++ b/actions/emails/messages.ts
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth-server";
 
 import { prismadb } from "@/lib/prisma";
 import { decrypt } from "@/lib/email-crypto";
+import { assertPublicHost, HostNotAllowedError } from "@/lib/net/host-guard";
 import nodemailer from "nodemailer";
 import { EmailFolder } from "@prisma/client";
 
@@ -162,13 +163,25 @@ export async function sendEmail(input: SendInput) {
   });
   if (!account) throw new Error("Account not found");
 
+  let pinned: { address: string; hostname: string };
+  try {
+    pinned = await assertPublicHost(account.smtpHost);
+  } catch (e) {
+    if (e instanceof HostNotAllowedError) throw new Error("Mail host is not allowed");
+    throw e;
+  }
+
   const password = decrypt(account.passwordEncrypted);
 
   const transporter = nodemailer.createTransport({
-    host: account.smtpHost,
+    host: pinned.address,
     port: account.smtpPort,
     secure: account.smtpSsl,
     auth: { user: account.username, pass: password },
+    // servername for TLS SNI (host is a pinned IP). Added via a typed spread so
+    // the object literal keeps only the well-known SMTP props and TS resolves the
+    // SMTP overload correctly.
+    ...({ servername: account.smtpHost } as { servername: string }),
   });
 
   const info = await transporter.sendMail({

--- a/app/[locale]/(routes)/admin/_components/ResendCard.tsx
+++ b/app/[locale]/(routes)/admin/_components/ResendCard.tsx
@@ -7,51 +7,13 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-import { z } from "zod";
-
 import { prismadb } from "@/lib/prisma";
 
-import { revalidatePath } from "next/cache";
 import { Input } from "@/components/ui/input";
 import CopyKeyComponent from "./copy-key";
+import { setResendKey } from "@/actions/admin/system/set-resend-key";
 
 const ResendCard = async () => {
-  const setSMTP = async (formData: FormData) => {
-    "use server";
-    const schema = z.object({
-      id: z.string(),
-      serviceKey: z.string(),
-    });
-    const parsed = schema.parse({
-      id: formData.get("id"),
-      serviceKey: formData.get("serviceKey"),
-    });
-
-    //console.log(parsed.id, "id");
-    //console.log(parsed.serviceKey, "serviceKey");
-
-    if (!parsed.id) {
-      await prismadb.systemServices.create({
-        data: {
-          v: 0,
-          name: "resend_smtp",
-          serviceKey: parsed.serviceKey,
-        },
-      });
-      revalidatePath("/admin");
-    } else {
-      await prismadb.systemServices.update({
-        where: {
-          id: parsed.id,
-        },
-        data: {
-          serviceKey: parsed.serviceKey,
-        },
-      });
-      revalidatePath("/admin");
-    }
-  };
-
   const resend_key = await prismadb.systemServices.findFirst({
     where: {
       name: "resend_smtp",
@@ -88,7 +50,7 @@ const ResendCard = async () => {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-2">
-        <form action={setSMTP}>
+        <form action={setResendKey}>
           <div>
             <input type="hidden" name="id" value={resend_key?.id} />
             <Input type="text" name="serviceKey" placeholder="Your API key" />

--- a/app/[locale]/(routes)/admin/services/page.tsx
+++ b/app/[locale]/(routes)/admin/services/page.tsx
@@ -1,0 +1,33 @@
+import ResendCard from "../_components/ResendCard";
+import { getSession } from "@/lib/auth-server";
+import Container from "../../components/ui/Container";
+import { getTranslations } from "next-intl/server";
+
+export default async function ServicesPage() {
+  const session = await getSession();
+  const t = await getTranslations("AdminPage");
+
+  // The admin layout already gates on requireRole(["admin"]); this page-level
+  // check mirrors the other admin pages as defense-in-depth. The Resend key
+  // write itself is authorized in the setResendKey server action.
+  if (session?.user?.role !== "admin") {
+    return (
+      <Container title="Services" description="System service integrations">
+        <div className="flex w-full h-full items-center justify-center">
+          {t("accessNotAllowed")}
+        </div>
+      </Container>
+    );
+  }
+
+  return (
+    <Container
+      title="Services"
+      description="System service integrations. Priority: ENV → System-wide (DB)."
+    >
+      <div className="space-y-6 max-w-2xl">
+        <ResendCard />
+      </div>
+    </Container>
+  );
+}

--- a/docs/superpowers/plans/2026-07-20-crm-server-action-authz.md
+++ b/docs/superpowers/plans/2026-07-20-crm-server-action-authz.md
@@ -1,0 +1,736 @@
+# CRM Server-Action Authorization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add object-level authorization to every unguarded mutating CRM server action so a `role: "user"` can only write records they own/are assigned (admin/manager: all), closing the IDOR half of GHSA-qwhm-9fcm-p878.
+
+**Architecture:** Add seven `assertCanWrite*` helpers to `lib/authz/scopes/crm.ts` mirroring the existing `assertCanWriteAccount`, then guard each action by resolving an `AuthzUser` via `requireAuthenticated()` and calling the matching assert before the mutation. The authorization model already ships on the read side; this mirrors it onto writes.
+
+**Tech Stack:** Next.js server actions, Prisma 7, `lib/authz` (existing), jest 30.
+
+Spec: `docs/superpowers/specs/2026-07-20-crm-server-action-authz-design.md`
+
+## Global Constraints
+
+- **Model, not invented:** a `user` owns a record via that model's ownership columns; admin/manager are unrestricted. Writes mirror the already-shipped read scope. No schema change, no migration.
+- **Every regression test must FAIL against the pre-fix code.** A test that passes with the guard removed proves nothing — that is the acceptance bar.
+- Run jest via `./node_modules/.bin/jest <path>` (NEVER `pnpm test` — `ERR_PNPM_IGNORED_BUILDS`). Finish each task with `pnpm exec tsc --noEmit` clean.
+- Existing suites must stay green; the whole suite baseline is 204 suites / 1096 tests (this branch, `security/workstream-a-crm-authz`, forked from `dev`).
+- Conventional commits, one per task. Work on `security/workstream-a-crm-authz`.
+- CRM tasks (`crm_Accounts_Tasks`) and Projects tasks (`boards`/`tasks`) are separate modules; do NOT reuse the Projects `assertCanWriteTask` for CRM tasks.
+- Exact ownership columns per model (a copy-paste guard keyed on the wrong column silently authorizes against a nonexistent field):
+  - `crm_Leads`, `crm_Opportunities`, `crm_Contracts`: `assigned_to`, `createdBy` (camelCase), soft-delete `deletedAt`.
+  - `crm_TargetLists`: `created_by` (snake_case, **no `assigned_to`**), soft-delete `deletedAt`.
+  - `crm_Accounts_Tasks`: `createdBy` **or** `user` (assignee); **no `deletedAt`** (hard delete).
+  - `crm_OpportunityLineItems`: parent `opportunityId` (relation `opportunity`); no assignee/soft-delete.
+  - `crm_ContractLineItems`: parent `contractId` (relation `contract`); no assignee/soft-delete.
+
+### Guard Recipe (apply verbatim; substitute the named parts per action)
+
+Every guarded action replaces its `getSession()` existence check with an `AuthzUser` resolution, then asserts. Authorization runs **outside** the mutation try/catch so a denial is never swallowed. This exact shape (from `actions/crm/activities/update-activity.ts`) is the canonical pattern:
+
+```ts
+import {
+  requireAuthenticated,
+  AuthenticationError,
+  AuthorizationError,
+  /* the specific assertCanWrite* for this entity */
+} from "@/lib/authz";
+
+// ...inside the action, at the very top, replacing the old getSession() block:
+let user;
+try {
+  user = await requireAuthenticated();
+} catch (e) {
+  if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+  throw e;
+}
+try {
+  await assertCanWriteX(user, ID);        // ID = the record id or parent id per action
+} catch (e) {
+  if (e instanceof AuthorizationError) return { error: "Forbidden" };
+  throw e;
+}
+// ...existing mutation try/catch unchanged; use user.id wherever session.user.id was used.
+```
+
+Notes for applying the recipe:
+- Where an action previously stamped `createdBy`/`updatedBy`/`deletedBy` from `session.user.id`, use `user.id`.
+- Some actions currently return the string `"Unauthorized"` or `{ error: "Unauthorized" }` on no session; the recipe standardizes on `{ error: "Unauthorized" }` / `{ error: "Forbidden" }` object returns.
+- Contract actions currently resolve the user via `session.user.email` → `prismadb.users.findUnique`. Replace that lookup with `requireAuthenticated()`; `user.id` is the same value they stamped as `createdBy`.
+- Actions wrapped by `createSafeAction` keep their wrapper; the guard goes at the top of the handler body.
+
+### Action-test Recipe (apply verbatim; substitute the named parts per action test)
+
+Each guarded action gets a colocated `__tests__/<action>-scope.test.ts` mocking `@/lib/authz` and `@/lib/prisma`. The three load-bearing assertions: owner/assignee succeeds; non-owner `user` returns `{ error: "Forbidden" }` **and the mutation is not called**; admin/manager succeeds.
+
+```ts
+jest.mock("@/lib/authz", () => ({
+  requireAuthenticated: jest.fn(),
+  AuthenticationError: class AuthenticationError extends Error {},
+  AuthorizationError: class AuthorizationError extends Error {},
+  assertCanWriteX: jest.fn(),        // the entity's helper
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: { crm_Model: { update: jest.fn(), findUnique: jest.fn(), /* etc */ } },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { requireAuthenticated, assertCanWriteX, AuthorizationError } from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { theAction } from "@/actions/crm/.../the-action";
+
+const authed = requireAuthenticated as jest.Mock;
+const assertX = assertCanWriteX as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+it("denies a non-owner and does not mutate", async () => {
+  authed.mockResolvedValue({ id: "attacker", role: "user" });
+  assertX.mockRejectedValue(new AuthorizationError());
+  const res = await theAction(/* args with a victim id */);
+  expect(res).toEqual({ error: "Forbidden" });
+  expect(prismadb.crm_Model.update).not.toHaveBeenCalled();
+});
+
+it("allows an authorized caller", async () => {
+  authed.mockResolvedValue({ id: "owner", role: "user" });
+  assertX.mockResolvedValue(undefined);
+  prismadb.crm_Model.update.mockResolvedValue({ id: "x" });
+  const res = await theAction(/* args */);
+  expect(assertX).toHaveBeenCalledWith({ id: "owner", role: "user" }, /* the id */);
+  expect(prismadb.crm_Model.update).toHaveBeenCalled();
+});
+```
+
+Because `assertCanWriteX` is mocked, the action test verifies **wiring** (that the guard is called with the right id and that a rejection blocks the mutation). The **scope logic** itself is verified by the helper unit tests in Task 1. This split is deliberate and matches the repo's existing separation.
+
+---
+
+### Task 1: Foundation — the seven write-scope helpers
+
+**Files:**
+- Modify: `lib/authz/scopes/crm.ts` (add helpers after the existing read-scope helpers, ~line 392)
+- Modify: `lib/authz/index.ts` (re-export the new helpers, ~line 51)
+- Test: `lib/authz/__tests__/scopes-crm-write.test.ts` (new)
+
+**Interfaces:**
+- Produces (all exported from `lib/authz/index.ts`, consumed by Tasks 2–11):
+
+```ts
+export async function assertCanWriteLead(user: AuthzUser, leadId: string): Promise<void>;
+export async function assertCanWriteOpportunity(user: AuthzUser, opportunityId: string): Promise<void>;
+export async function assertCanWriteContract(user: AuthzUser, contractId: string): Promise<void>;
+export async function assertCanWriteTargetList(user: AuthzUser, listId: string): Promise<void>;
+export async function assertCanWriteCrmTask(user: AuthzUser, taskId: string): Promise<void>;
+export async function assertCanWriteOpportunityLineItem(user: AuthzUser, lineItemId: string): Promise<void>;
+export async function assertCanWriteContractLineItem(user: AuthzUser, lineItemId: string): Promise<void>;
+```
+
+- Consumes: `AuthzUser` (`../session`), `AuthorizationError` (`../errors`), `prismadb`, and the existing `assertCanWriteOpportunity`/`assertCanWriteContract` (the line-item wrappers delegate to them).
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `lib/authz/__tests__/scopes-crm-write.test.ts`:
+
+```ts
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Leads: { findFirst: jest.fn() },
+    crm_Opportunities: { findFirst: jest.fn() },
+    crm_Contracts: { findFirst: jest.fn() },
+    crm_TargetLists: { findFirst: jest.fn() },
+    crm_Accounts_Tasks: { findFirst: jest.fn() },
+    crm_OpportunityLineItems: { findUnique: jest.fn() },
+    crm_ContractLineItems: { findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  assertCanWriteLead,
+  assertCanWriteOpportunity,
+  assertCanWriteContract,
+  assertCanWriteTargetList,
+  assertCanWriteCrmTask,
+  assertCanWriteOpportunityLineItem,
+  assertCanWriteContractLineItem,
+} from "../scopes/crm";
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanWriteLead / Opportunity / Contract (assigned_to+createdBy, deletedAt)", () => {
+  const cases = [
+    ["Leads", assertCanWriteLead, prismadb.crm_Leads.findFirst as jest.Mock],
+    ["Opportunities", assertCanWriteOpportunity, prismadb.crm_Opportunities.findFirst as jest.Mock],
+    ["Contracts", assertCanWriteContract, prismadb.crm_Contracts.findFirst as jest.Mock],
+  ] as const;
+
+  for (const [label, assertFn, find] of cases) {
+    it(`${label}: admin gets a bare id+deletedAt where`, async () => {
+      find.mockResolvedValue({ id: "r1" });
+      await assertFn({ id: "u", role: "admin" }, "r1");
+      expect(find).toHaveBeenCalledWith({
+        where: { id: "r1", deletedAt: null },
+        select: { id: true },
+      });
+    });
+
+    it(`${label}: user is scoped to assigned_to/createdBy`, async () => {
+      find.mockResolvedValue({ id: "r1" });
+      await assertFn({ id: "u3", role: "user" }, "r1");
+      const arg = find.mock.calls[0][0]!;
+      expect(arg.where).toMatchObject({
+        id: "r1",
+        deletedAt: null,
+        OR: [{ assigned_to: "u3" }, { createdBy: "u3" }],
+      });
+    });
+
+    it(`${label}: throws when not in scope`, async () => {
+      find.mockResolvedValue(null);
+      await expect(assertFn({ id: "u3", role: "user" }, "r1")).rejects.toBeInstanceOf(
+        AuthorizationError
+      );
+    });
+  }
+});
+
+describe("assertCanWriteTargetList (created_by only, no assigned_to)", () => {
+  const find = prismadb.crm_TargetLists.findFirst as jest.Mock;
+
+  it("admin: bare id+deletedAt", async () => {
+    find.mockResolvedValue({ id: "l1" });
+    await assertCanWriteTargetList({ id: "u", role: "admin" }, "l1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "l1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped to created_by (no assigned_to clause)", async () => {
+    find.mockResolvedValue({ id: "l1" });
+    await assertCanWriteTargetList({ id: "u3", role: "user" }, "l1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "l1", deletedAt: null, created_by: "u3" },
+      select: { id: true },
+    });
+  });
+
+  it("throws when not in scope", async () => {
+    find.mockResolvedValue(null);
+    await expect(
+      assertCanWriteTargetList({ id: "u3", role: "user" }, "l1")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteCrmTask (createdBy OR user assignee, no deletedAt)", () => {
+  const find = prismadb.crm_Accounts_Tasks.findFirst as jest.Mock;
+
+  it("admin: bare id where (no deletedAt column on this model)", async () => {
+    find.mockResolvedValue({ id: "t1" });
+    await assertCanWriteCrmTask({ id: "u", role: "manager" }, "t1");
+    expect(find).toHaveBeenCalledWith({ where: { id: "t1" }, select: { id: true } });
+  });
+
+  it("user: scoped to creator or assignee", async () => {
+    find.mockResolvedValue({ id: "t1" });
+    await assertCanWriteCrmTask({ id: "u3", role: "user" }, "t1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "t1", OR: [{ createdBy: "u3" }, { user: "u3" }] },
+      select: { id: true },
+    });
+  });
+
+  it("throws when not creator/assignee", async () => {
+    find.mockResolvedValue(null);
+    await expect(
+      assertCanWriteCrmTask({ id: "u3", role: "user" }, "t1")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("line-item wrappers delegate to the parent write assert", () => {
+  it("opportunity line-item: resolves parent then asserts opportunity write", async () => {
+    (prismadb.crm_OpportunityLineItems.findUnique as jest.Mock).mockResolvedValue({
+      opportunityId: "opp1",
+    });
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({ id: "opp1" });
+    await assertCanWriteOpportunityLineItem({ id: "u3", role: "user" }, "li1");
+    expect(prismadb.crm_OpportunityLineItems.findUnique).toHaveBeenCalledWith({
+      where: { id: "li1" },
+      select: { opportunityId: true },
+    });
+    // parent write assert ran against the resolved opportunityId
+    expect(prismadb.crm_Opportunities.findFirst).toHaveBeenCalled();
+  });
+
+  it("opportunity line-item: throws when the line item does not exist", async () => {
+    (prismadb.crm_OpportunityLineItems.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(
+      assertCanWriteOpportunityLineItem({ id: "u3", role: "user" }, "missing")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("contract line-item: resolves parent then asserts contract write", async () => {
+    (prismadb.crm_ContractLineItems.findUnique as jest.Mock).mockResolvedValue({
+      contractId: "ct1",
+    });
+    (prismadb.crm_Contracts.findFirst as jest.Mock).mockResolvedValue({ id: "ct1" });
+    await assertCanWriteContractLineItem({ id: "u3", role: "user" }, "cli1");
+    expect(prismadb.crm_ContractLineItems.findUnique).toHaveBeenCalledWith({
+      where: { id: "cli1" },
+      select: { contractId: true },
+    });
+    expect(prismadb.crm_Contracts.findFirst).toHaveBeenCalled();
+  });
+
+  it("contract line-item: throws when the line item does not exist", async () => {
+    (prismadb.crm_ContractLineItems.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(
+      assertCanWriteContractLineItem({ id: "u3", role: "user" }, "missing")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+Run: `./node_modules/.bin/jest lib/authz/__tests__/scopes-crm-write.test.ts`
+Expected: FAIL — the seven functions are not exported from `../scopes/crm`.
+
+- [ ] **Step 3: Implement the helpers in `lib/authz/scopes/crm.ts`**
+
+Append after `assertCanReadTargetList` (~line 392):
+
+```ts
+// ── Write-scope asserts (Workstream A — GHSA-qwhm-9fcm-p878) ─────────────────
+// Mirror assertCanWriteAccount: admin/manager unrestricted; user scoped to the
+// model's ownership columns. Exact columns differ per model — see each helper.
+
+export async function assertCanWriteLead(
+  user: AuthzUser,
+  leadId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: leadId, deletedAt: null }
+      : { id: leadId, deletedAt: null, OR: [{ assigned_to: user.id }, { createdBy: user.id }] };
+  const row = await prismadb.crm_Leads.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteOpportunity(
+  user: AuthzUser,
+  opportunityId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: opportunityId, deletedAt: null }
+      : { id: opportunityId, deletedAt: null, OR: [{ assigned_to: user.id }, { createdBy: user.id }] };
+  const row = await prismadb.crm_Opportunities.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteContract(
+  user: AuthzUser,
+  contractId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: contractId, deletedAt: null }
+      : { id: contractId, deletedAt: null, OR: [{ assigned_to: user.id }, { createdBy: user.id }] };
+  const row = await prismadb.crm_Contracts.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+// crm_TargetLists has NO assigned_to — ownership is created_by only.
+export async function assertCanWriteTargetList(
+  user: AuthzUser,
+  listId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: listId, deletedAt: null }
+      : { id: listId, deletedAt: null, created_by: user.id };
+  const row = await prismadb.crm_TargetLists.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+// crm_Accounts_Tasks has NO deletedAt (hard delete). Ownership = creator or assignee.
+// NOTE: this covers creator/assignee. Broadening to parent-account writers is a
+// deliberate, safe narrowing deferred here (it would only widen access).
+export async function assertCanWriteCrmTask(
+  user: AuthzUser,
+  taskId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: taskId }
+      : { id: taskId, OR: [{ createdBy: user.id }, { user: user.id }] };
+  const row = await prismadb.crm_Accounts_Tasks.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+// Line items carry no ownership column; authority is the parent opportunity/contract
+// (correct because a line-item write recomputes the parent's totals). Resolve the
+// parent id from the line-item row, then delegate to the parent write assert.
+export async function assertCanWriteOpportunityLineItem(
+  user: AuthzUser,
+  lineItemId: string,
+): Promise<void> {
+  const row = await prismadb.crm_OpportunityLineItems.findUnique({
+    where: { id: lineItemId },
+    select: { opportunityId: true },
+  });
+  if (!row) throw new AuthorizationError();
+  await assertCanWriteOpportunity(user, row.opportunityId);
+}
+
+export async function assertCanWriteContractLineItem(
+  user: AuthzUser,
+  lineItemId: string,
+): Promise<void> {
+  const row = await prismadb.crm_ContractLineItems.findUnique({
+    where: { id: lineItemId },
+    select: { contractId: true },
+  });
+  if (!row) throw new AuthorizationError();
+  await assertCanWriteContract(user, row.contractId);
+}
+```
+
+- [ ] **Step 4: Re-export from `lib/authz/index.ts`**
+
+After the block ending at line 56 (`assertCanReadTargetList`), add:
+
+```ts
+export {
+  assertCanWriteLead,
+  assertCanWriteOpportunity,
+  assertCanWriteContract,
+  assertCanWriteTargetList,
+  assertCanWriteCrmTask,
+  assertCanWriteOpportunityLineItem,
+  assertCanWriteContractLineItem,
+} from "./scopes/crm";
+```
+
+- [ ] **Step 5: GREEN + typecheck**
+
+Run: `./node_modules/.bin/jest lib/authz/__tests__/scopes-crm-write.test.ts` — all pass.
+Run: `pnpm exec tsc --noEmit` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/authz
+git commit -m "feat(authz): write-scope asserts for lead, opportunity, contract, target-list, crm-task, line-items"
+```
+
+---
+
+### Task 2: Guard Accounts actions
+
+**Files:**
+- Modify: `actions/crm/accounts/update-account.ts`, `delete-account.ts`, `watch-account.ts`, `unwatch-account.ts`, `create-task.ts`, `create-account.ts`
+- Test: `actions/crm/accounts/__tests__/accounts-write-scope.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `requireAuthenticated`, `assertCanWriteAccount` (existing), `AuthenticationError`, `AuthorizationError` from `@/lib/authz`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `actions/crm/accounts/__tests__/accounts-write-scope.test.ts`. Mock `@/lib/authz` (with `requireAuthenticated`, `assertCanWriteAccount`, the two error classes), `@/lib/prisma` (`crm_Accounts.update`, `crm_Accounts_Tasks.create`, and the watcher junction helpers' underlying calls), `next/cache`, `@/lib/audit-log`, and `@/inngest/client`. For each of `updateAccount`, `deleteAccount`, `watchAccount`, `unwatchAccount`, `createTask`:
+
+```ts
+it("<action>: denies a non-owner and does not mutate", async () => {
+  authed.mockResolvedValue({ id: "attacker", role: "user" });
+  assertAccount.mockRejectedValue(new AuthorizationError());
+  const res = await ACTION(VICTIM_ARGS);
+  expect(res).toEqual({ error: "Forbidden" });
+  expect(prismadb.crm_Accounts.update).not.toHaveBeenCalled();   // or crm_Accounts_Tasks.create for createTask
+});
+
+it("<action>: allows an owner and mutates", async () => {
+  authed.mockResolvedValue({ id: "owner", role: "user" });
+  assertAccount.mockResolvedValue(undefined);
+  // set up the mutation mock to resolve
+  const res = await ACTION(OWNER_ARGS);
+  expect(assertAccount).toHaveBeenCalledWith({ id: "owner", role: "user" }, EXPECTED_ID);
+  expect(/* the mutation */).toHaveBeenCalled();
+});
+```
+
+Use these `EXPECTED_ID` values: `updateAccount` → `data.id`; `deleteAccount` → the `accountId` arg; `watchAccount`/`unwatchAccount` → the `accountId` arg; `createTask` → `data.account`.
+
+- [ ] **Step 2: RED** — `./node_modules/.bin/jest actions/crm/accounts/__tests__/accounts-write-scope.test.ts` fails (guards absent; non-owner path still mutates).
+
+- [ ] **Step 3: Apply the Guard Recipe to each action**
+
+- `update-account.ts`: import `requireAuthenticated, assertCanWriteAccount, AuthenticationError, AuthorizationError`; replace the `getSession()` block; assert `assertCanWriteAccount(user, id)`; stamp `updatedBy: user.id`.
+- `delete-account.ts`: same imports; assert `assertCanWriteAccount(user, accountId)`; stamp `deletedBy: user.id`.
+- `watch-account.ts` / `unwatch-account.ts`: assert `assertCanWriteAccount(user, accountId)`. **Rationale (record in a code comment): `watchers` is inside `accountUserScopeOR`, so an unguarded watch self-grants read+write scope — an escalation primitive. Watch therefore requires write.**
+- `create-task.ts`: assert `assertCanWriteAccount(user, data.account)` (parent-write). **Also fix the ownership-spoof: stamp `createdBy: user.id` (the authenticated caller), NOT the input `user` field. Keep the input `user` field only as the task assignee.**
+- `create-account.ts`: plain create — replace `getSession()` with `requireAuthenticated()` (Unauthorized mapping only, no write assert — the row is owned by its creator); stamp `createdBy: user.id`.
+
+- [ ] **Step 4: GREEN + typecheck**
+
+Run the task's test file — all pass. Run `pnpm exec tsc --noEmit` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add actions/crm/accounts
+git commit -m "feat(authz): object-level authorization on account write actions"
+```
+
+---
+
+### Task 3: Guard Contacts actions
+
+**Files:**
+- Modify: `actions/crm/contacts/update-contact.ts`, `delete-contact.ts`, `unlink-opportunity.ts`, `create-contact.ts`
+- Test: `actions/crm/contacts/__tests__/contacts-write-scope.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `requireAuthenticated`, `assertCanWriteContact` (existing), `assertCanWriteAccount` (existing), `assertCanWriteOpportunity` (Task 1), error classes.
+
+- [ ] **Step 1: Write the failing tests** — mirror the Task-2 test shape for `updateContact`, `deleteContact`, `unlinkOpportunity`. `EXPECTED_ID`: `updateContact` → `data.id`; `deleteContact` → `contactId` arg; `unlinkOpportunity` → assert BOTH `assertCanWriteContact(user, contactId)` and `assertCanWriteOpportunity(user, opportunityId)` are called, and that a rejection from EITHER returns `{ error: "Forbidden" }` and skips the `contactsToOpportunities.delete`.
+
+- [ ] **Step 2: RED** — run the test file, confirm failure.
+
+- [ ] **Step 3: Apply guards**
+- `update-contact.ts`: `assertCanWriteContact(user, data.id)`; stamp `updatedBy: user.id`. When `assigned_account` is being set, also `assertCanWriteAccount(user, assigned_account)` (parent-write on the newly-linked account).
+- `delete-contact.ts`: `assertCanWriteContact(user, contactId)`.
+- `unlink-opportunity.ts`: assert `assertCanWriteContact(user, contactId)` then `assertCanWriteOpportunity(user, opportunityId)` (bidirectional junction — both sides must be writable).
+- `create-contact.ts`: `requireAuthenticated()`; when `assigned_account` supplied, `assertCanWriteAccount(user, assigned_account)` (parent-write); else plain create stamped `createdBy: user.id`.
+
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add actions/crm/contacts && git commit -m "feat(authz): object-level authorization on contact write actions"`
+
+---
+
+### Task 4: Guard Opportunities actions
+
+**Files:**
+- Modify: `actions/crm/opportunities/update-opportunity.ts`, `delete-opportunity.ts`, `create-opportunity.ts`
+- Test: `actions/crm/opportunities/__tests__/opportunities-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteOpportunity` (Task 1), `assertCanWriteAccount` (existing), error classes.
+
+- [ ] **Step 1: Failing tests** — `updateOpportunity` (`EXPECTED_ID` = `data.id`), `deleteOpportunity` (= `opportunityId` arg). Assert non-owner → `{ error: "Forbidden" }`, no `crm_Opportunities.update`.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply guards**
+- `update-opportunity.ts`: `assertCanWriteOpportunity(user, data.id)` inserted **before** the existing `qualifiedEntryBlockReason` gate and `handleStageTransition` (the approval gate stays intact and runs after the authz assert). Stamp `updatedBy: user.id`.
+- `delete-opportunity.ts`: `assertCanWriteOpportunity(user, opportunityId)`.
+- `create-opportunity.ts`: `requireAuthenticated()`; when `account` supplied, `assertCanWriteAccount(user, account)` (parent-write); else plain create stamped `createdBy: user.id`.
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add actions/crm/opportunities && git commit -m "feat(authz): object-level authorization on opportunity write actions"`
+
+---
+
+### Task 5: Guard Opportunity line-items
+
+**Files:**
+- Modify: `actions/crm/opportunity-line-items/add-line-item/index.ts`, `update-line-item/index.ts`, `remove-line-item/index.ts`, `reorder-line-items/index.ts`, `get-line-items.ts`
+- Test: `actions/crm/opportunity-line-items/__tests__/opp-line-items-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteOpportunity`, `assertCanWriteOpportunityLineItem`, `assertCanReadOpportunity` (existing), error classes.
+
+- [ ] **Step 1: Failing tests** covering: `addLineItem` asserts `assertCanWriteOpportunity(user, opportunityId)` (parent from input) and a rejection skips `create`; `updateLineItem`/`removeLineItem` assert `assertCanWriteOpportunityLineItem(user, id)` and a rejection skips the mutation; `reorderLineItems` — see Step 4 below — must reject the whole batch if any item's parent is not writable.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply single-parent guards**
+- `add-line-item/index.ts`: `assertCanWriteOpportunity(user, opportunityId)` (replaces the existing bare `findUnique` null-check; the assert already 404s on missing/soft-deleted via scope miss → `AuthorizationError`).
+- `update-line-item/index.ts`: `assertCanWriteOpportunityLineItem(user, id)` (the helper resolves the parent).
+- `remove-line-item/index.ts`: `assertCanWriteOpportunityLineItem(user, id)`.
+- [ ] **Step 4: Guard the blind reorder** (`reorder-line-items/index.ts`). It receives `items: { id, sort_order }[]` with no parent id. Resolve every parent and assert each distinct one; reject the whole batch on any failure:
+
+```ts
+let user;
+try { user = await requireAuthenticated(); }
+catch (e) { if (e instanceof AuthenticationError) return { error: "Unauthorized" }; throw e; }
+
+const ids = items.map((i) => i.id);
+const rows = await prismadb.crm_OpportunityLineItems.findMany({
+  where: { id: { in: ids } },
+  select: { id: true, opportunityId: true },
+});
+// Any id that doesn't resolve, or any parent the user can't write, fails the batch.
+if (rows.length !== ids.length) return { error: "Forbidden" };
+const parents = [...new Set(rows.map((r) => r.opportunityId))];
+try {
+  for (const opportunityId of parents) await assertCanWriteOpportunity(user, opportunityId);
+} catch (e) {
+  if (e instanceof AuthorizationError) return { error: "Forbidden" };
+  throw e;
+}
+// ...existing $transaction of updates unchanged.
+```
+
+- [ ] **Step 5: Guard the reader** (`get-line-items.ts`). Add `assertCanReadOpportunity(user, opportunityId)` after resolving the caller. If the `cache()` wrapper makes `requireAuthenticated()` unavailable at call time, resolve the user in the calling server component and pass it in; document whichever path is taken in a code comment. The reader must not return line items for an opportunity the caller cannot read.
+- [ ] **Step 6: GREEN + typecheck.**
+- [ ] **Step 7: Commit** — `git add actions/crm/opportunity-line-items && git commit -m "feat(authz): parent-scoped authorization on opportunity line-items (incl. blind reorder)"`
+
+---
+
+### Task 6: Guard Contracts actions
+
+**Files:**
+- Modify: `actions/crm/contracts/create-new-contract/index.ts`, `update-contract/index.ts`, `delete-contract/index.ts`
+- Test: `actions/crm/contracts/__tests__/contracts-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteContract` (Task 1), `assertCanWriteAccount` (existing), error classes.
+
+- [ ] **Step 1: Failing tests** — `updateContract` (`EXPECTED_ID` = `data.id`), `deleteContract` (= `id`). Non-owner → `{ error: "Forbidden" }`, no `crm_Contracts.update`.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply guards** — for each, **replace the `session.user.email` → `users.findUnique` lookup** with `requireAuthenticated()` (per the recipe note), then:
+- `update-contract/index.ts`: `assertCanWriteContract(user, data.id)` before the `before` fetch; stamp `updatedBy`/`createdBy` from `user.id` as the file currently does.
+- `delete-contract/index.ts`: `assertCanWriteContract(user, id)`.
+- `create-new-contract/index.ts`: `requireAuthenticated()`; when `account` supplied, `assertCanWriteAccount(user, account)`; else plain create.
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add actions/crm/contracts && git commit -m "feat(authz): object-level authorization on contract write actions"`
+
+---
+
+### Task 7: Guard Contract line-items
+
+**Files:**
+- Modify: `actions/crm/contract-line-items/add-line-item/index.ts`, `copy-from-opportunity/index.ts`, `update-line-item/index.ts`, `remove-line-item/index.ts`, `reorder-line-items/index.ts`, `get-line-items.ts`
+- Test: `actions/crm/contract-line-items/__tests__/contract-line-items-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteContract`, `assertCanWriteContractLineItem`, `assertCanReadOpportunity`, `assertCanReadContract` (existing), error classes.
+
+- [ ] **Step 1: Failing tests** — mirror Task 5, plus the dual-guard case for `copyFromOpportunity`.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply guards**
+- `add-line-item/index.ts`: `assertCanWriteContract(user, contractId)`.
+- `update-line-item/index.ts` / `remove-line-item/index.ts`: `assertCanWriteContractLineItem(user, id)`.
+- `copy-from-opportunity/index.ts`: **dual guard** — `assertCanWriteContract(user, contractId)` (destination) AND `assertCanReadOpportunity(user, opportunityId)` (source; read suffices since it is only copied from). Both must pass before `createMany`.
+- [ ] **Step 4: Guard the blind reorder** (`reorder-line-items/index.ts`) — identical shape to Task 5 Step 4 but resolving `contractId` and asserting `assertCanWriteContract`:
+
+```ts
+const rows = await prismadb.crm_ContractLineItems.findMany({
+  where: { id: { in: ids } },
+  select: { id: true, contractId: true },
+});
+if (rows.length !== ids.length) return { error: "Forbidden" };
+const parents = [...new Set(rows.map((r) => r.contractId))];
+try {
+  for (const contractId of parents) await assertCanWriteContract(user, contractId);
+} catch (e) {
+  if (e instanceof AuthorizationError) return { error: "Forbidden" };
+  throw e;
+}
+```
+
+- [ ] **Step 5: Guard the reader** (`get-line-items.ts`) — `assertCanReadContract(user, contractId)`, same caching caveat as Task 5 Step 5.
+- [ ] **Step 6: GREEN + typecheck.**
+- [ ] **Step 7: Commit** — `git add actions/crm/contract-line-items && git commit -m "feat(authz): parent-scoped authorization on contract line-items (incl. copy + reorder)"`
+
+---
+
+### Task 8: Guard Leads actions
+
+**Files:**
+- Modify: `actions/crm/leads/update-lead.ts`, `delete-lead.ts`, `create-lead.ts`
+- Test: `actions/crm/leads/__tests__/leads-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteLead` (Task 1), `assertCanWriteAccount` (existing), error classes.
+
+- [ ] **Step 1: Failing tests** — `updateLead` (`EXPECTED_ID` = `data.id`), `deleteLead` (= `leadId`). Non-owner → `{ error: "Forbidden" }`, no `crm_Leads.update`.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply guards**
+- `update-lead.ts`: `assertCanWriteLead(user, data.id)`; stamp `updatedBy: user.id`.
+- `delete-lead.ts`: `assertCanWriteLead(user, leadId)`.
+- `create-lead.ts`: `requireAuthenticated()`; when `accountIDs` supplied, `assertCanWriteAccount(user, accountIDs)`; else plain create stamped with `assigned_to: assigned_to || user.id`.
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add actions/crm/leads && git commit -m "feat(authz): object-level authorization on lead write actions"`
+
+---
+
+### Task 9: Guard Targets actions
+
+**Files:**
+- Modify: `actions/crm/targets/update-target.ts`, `delete-target.ts`, `convert-target-to-deal.ts`, `create-target.ts`, `import-targets.ts`
+- Test: `actions/crm/targets/__tests__/targets-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteTarget` (existing), `assertCanWriteTargetList` (Task 1), error classes.
+
+- [ ] **Step 1: Failing tests** — `updateTarget` (`EXPECTED_ID` = `data.id`), `deleteTarget` (= `targetId`), `convertTargetToDeal` (= `targetId`). Non-owner → `{ error: "Forbidden" }`, no mutation.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply guards**
+- `update-target.ts`: `assertCanWriteTarget(user, data.id)` (helper exists).
+- `delete-target.ts`: `assertCanWriteTarget(user, targetId)`.
+- `convert-target-to-deal.ts`: `assertCanWriteTarget(user, targetId)` before `convertTarget(targetId)`.
+- `create-target.ts`: `requireAuthenticated()`; when the input links a target-list, `assertCanWriteTargetList(user, listId)`; else plain create stamped `created_by: user.id`.
+- `import-targets.ts`: `requireAuthenticated()`; when it links a list, `assertCanWriteTargetList(user, listId)`; else plain bulk-create stamped `created_by: user.id`.
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add actions/crm/targets && git commit -m "feat(authz): object-level authorization on target write actions"`
+
+---
+
+### Task 10: Guard Target-lists actions
+
+**Files:**
+- Modify: `actions/crm/target-lists/update-target-list.ts`, `delete-target-list.ts`, `add-targets-to-list.ts`, `remove-target-from-list.ts`, `create-target-list.ts`
+- Test: `actions/crm/target-lists/__tests__/target-lists-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteTargetList` (Task 1), `filterAuthorizedTargetIds` (existing), error classes.
+
+- [ ] **Step 1: Failing tests** — `updateTargetList` (`EXPECTED_ID` = `id`), `deleteTargetList` (= `targetListId`), `addTargetsToList` (= `targetListId`), `removeTargetFromList` (= `targetListId`). Non-owner → `{ error: "Forbidden" }`, no mutation.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply guards**
+- `update-target-list.ts`: `assertCanWriteTargetList(user, id)`.
+- `delete-target-list.ts`: `assertCanWriteTargetList(user, targetListId)`.
+- `add-targets-to-list.ts`: `assertCanWriteTargetList(user, targetListId)`; additionally narrow the incoming `targetIds` through `filterAuthorizedTargetIds(user, targetIds)` so a caller cannot attach targets they cannot access, and `createMany` only the authorized subset.
+- `remove-target-from-list.ts`: `assertCanWriteTargetList(user, targetListId)`.
+- `create-target-list.ts`: `requireAuthenticated()`; plain create stamped `created_by: user.id`. When `targetIds` are supplied inline, narrow with `filterAuthorizedTargetIds(user, targetIds)`.
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add actions/crm/target-lists && git commit -m "feat(authz): object-level authorization on target-list write actions"`
+
+---
+
+### Task 11: Guard CRM tasks actions
+
+**Files:**
+- Modify: `actions/crm/tasks/add-comment.ts`, `assign-document.ts`, `delete-task.ts`
+- Test: `actions/crm/tasks/__tests__/crm-tasks-write-scope.test.ts` (new)
+
+**Interfaces:** Consumes `requireAuthenticated`, `assertCanWriteCrmTask` (Task 1), error classes.
+
+- [ ] **Step 1: Failing tests** — `addComment` (`EXPECTED_ID` = `taskId`), both `assignDocumentToCrmTask` and `disconnectDocumentFromCrmTask` (= `taskId`), `deleteTask` (= `taskId`). Non-owner → `{ error: "Forbidden" }`, and no `tasksComments.create` / no `crm_Accounts_Tasks.delete`.
+- [ ] **Step 2: RED.**
+- [ ] **Step 3: Apply guards** — `assertCanWriteCrmTask(user, taskId)` at the top of `addComment`, both exports of `assign-document.ts`, and `deleteTask`. Note `delete-task.ts` is a hard delete (no `deletedAt` on the model) — the guard precedes the comment/doc-link/task deletion cascade.
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add actions/crm/tasks && git commit -m "feat(authz): object-level authorization on CRM task write actions"`
+
+---
+
+### Task 12: Whole-branch verification + advisory note
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-20-crm-server-action-authz-design.md` (mark implemented)
+
+- [ ] **Step 1: Full suite** — `./node_modules/.bin/jest` — all pass (baseline 204 suites / 1096 tests plus every new scope suite, 0 failures).
+- [ ] **Step 2: Typecheck + build** — `pnpm exec tsc --noEmit && pnpm build` — both succeed.
+- [ ] **Step 3: Coverage sweep** — grep every guarded directory to confirm no mutating `"use server"` action under `actions/crm/{accounts,contacts,leads,opportunities,contracts,opportunity-line-items,contract-line-items,targets,target-lists,tasks}` still lacks an `assertCanWrite*`/`requireAuthenticated` call. List any stragglers; a straggler is a failed task, not a note.
+- [ ] **Step 4: Mark the spec implemented** and record the residual follow-ups (the `create-task` assignee-spoof note if not fully addressed; parent-account-writer broadening of `assertCanWriteCrmTask`; the two `get-line-items` caching caveats).
+- [ ] **Step 5: Commit (no push — final review first)**
+
+```bash
+git add docs/superpowers/specs/2026-07-20-crm-server-action-authz-design.md
+git commit -m "docs: mark CRM server-action authz workstream implemented"
+```
+
+---
+
+## Notes for the executor
+
+- The Guard Recipe and Action-test Recipe in Global Constraints are exact code to apply verbatim with the named substitutions — they are the single source for the boilerplate so each task lists only its per-action deltas (imports, the assert call, the id).
+- Line-item Tasks 5 and 7 are the only non-mechanical ones: the blind `reorder` endpoints and the dual-guard `copy-from-opportunity` need the full code shown in their steps.
+- If any action's real signature differs from what a task states (e.g. positional vs object arg), follow the actual file — the recipe's substitution (`EXPECTED_ID`) is what matters, not the arg shape.
+- Every scope test must fail with the guard removed. If a test passes against the pre-fix action, it is not testing the guard — fix the test before moving on.

--- a/docs/superpowers/plans/2026-07-21-mcp-project-tools-authz.md
+++ b/docs/superpowers/plans/2026-07-21-mcp-project-tools-authz.md
@@ -1,0 +1,792 @@
+# MCP Project Tools Authorization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire every MCP project tool in `lib/mcp/tools/projects.ts` to the existing board/task authorization asserts so an API-token holder can only read/write boards and tasks they are authorized for, closing GHSA-vq6p-3qj5-p666.
+
+**Architecture:** Each handler gains the `user: AuthzUser` third argument the dispatcher already passes, and calls the same `assertCan{Read,Write}{Board,Task}` helpers the web surface uses. A new `assertScopeOrNotFound` adapter converts a denial into the codebase's `notFound()` (surfacing `NOT_FOUND`, no existence oracle). Lists filter by `boardReadScopeWhere`. The misused `userBoardWhere` read-predicate is deleted.
+
+**Tech Stack:** Next.js MCP handlers (`mcp-handler`), Prisma 7, `lib/authz` (existing), jest 30.
+
+Spec: `docs/superpowers/specs/2026-07-21-mcp-project-tools-authz-design.md`
+
+## Global Constraints
+
+- **No new authorization model or helpers.** Every assert already exists in `lib/authz/scopes/crm.ts` and is exported from `@/lib/authz`: `assertCanReadBoard`, `assertCanWriteBoard`, `assertCanReadTask`, `assertCanWriteTask`, `assertCanReadDocument`, `boardReadScopeWhere`, `boardWriteScopeWhere`.
+- **Denial surfaces as `NOT_FOUND`, not `FORBIDDEN`.** The board/task asserts throw `AuthorizationError` (message `"Forbidden"`), which the dispatcher does NOT map — so every single-record assert runs through `assertScopeOrNotFound(...)`, which converts `AuthorizationError` into `notFound(entity)` (`throw new Error("NOT_FOUND")`). This matches `campaigns.ts` and avoids leaking existence.
+- **Handler signature:** every handler becomes `async handler(args, _userId: string, user: AuthzUser)`. The dispatcher (`app/api/mcp/[transport]/route.ts`) already calls `tool.handler(args, mcpUser.id, mcpUser)` where `mcpUser: AuthzUser = { id, role }`. Stamp `user.id` wherever `userId` was used.
+- **`watch_board` is a READ gate** (`assertCanReadBoard`): board watchers sit only in `boardReadScopeWhere`, so watching cannot grant write; the only risk is self-granting read, which a read gate prevents.
+- **Delete `userBoardWhere`** (`projects.ts:13-21`) once its last use (in `list_tasks`, Task 4) is migrated — a read predicate used as a write gate, which also wrongly omits public/watched boards.
+- Run jest via `./node_modules/.bin/jest <path>` (NEVER `pnpm test` — `ERR_PNPM_IGNORED_BUILDS`). Finish each task with `pnpm exec tsc --noEmit` clean.
+- **Every regression test must FAIL against the pre-fix code** — the acceptance bar.
+- Conventional commits, one per task. Work on `security/workstream-b-mcp-authz` (forked from `dev`; independent of workstream A).
+- Add only the imports a task actually uses (TS reports unused imports), so no task leaves an unused import.
+
+### Test harness (apply verbatim in each tool-group test)
+
+No MCP tool test exists yet. A tool is invoked by locating it in `projectTools` by `name` and calling its `handler`. Mock `@/lib/prisma` and `@/lib/authz`. Standard header:
+
+```ts
+jest.mock("@/lib/authz", () => ({
+  // include the asserts the tools under test call:
+  assertCanReadBoard: jest.fn(),
+  assertCanWriteBoard: jest.fn(),
+  assertCanReadTask: jest.fn(),
+  assertCanWriteTask: jest.fn(),
+  assertCanReadDocument: jest.fn(),
+  boardReadScopeWhere: jest.fn(() => ({ deletedAt: null, __scope: "read" })),
+  AuthorizationError: class AuthorizationError extends Error {},
+}));
+jest.mock("@/lib/prisma", () => ({ prismadb: { /* the models the tools touch */ } }));
+
+import { projectTools } from "@/lib/mcp/tools/projects";
+
+const USER = { id: "u1", role: "user" } as const;
+// invoke a tool by name with (args, userId, user)
+function call(name: string, args: any) {
+  const tool = projectTools.find((t) => t.name === name)!;
+  return (tool.handler as any)(args, USER.id, USER);
+}
+```
+
+Load-bearing assertions per guarded tool: a caller the assert rejects (mock the relevant `assertCan*` to `mockRejectedValue(new AuthorizationError())`) causes the call to reject with `Error("NOT_FOUND")` **and the Prisma mutation is not called**; an authorized caller (assert resolves) performs the operation and the assert was called with the right id.
+
+---
+
+### Task 1: Foundation — `assertScopeOrNotFound` adapter
+
+**Files:**
+- Modify: `lib/mcp/helpers.ts` (add the adapter)
+- Test: `lib/mcp/__tests__/scope-adapter.test.ts` (new — first MCP test file)
+
+**Interfaces:**
+- Produces: `assertScopeOrNotFound(assert: () => Promise<void>, entity: string): Promise<void>` — runs `assert`; on `AuthorizationError` calls `notFound(entity)` (throws `Error("NOT_FOUND")`); other errors propagate. Consumed by Tasks 2–6.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/mcp/__tests__/scope-adapter.test.ts`:
+
+```ts
+import { assertScopeOrNotFound } from "../helpers";
+import { AuthorizationError } from "@/lib/authz";
+
+describe("assertScopeOrNotFound", () => {
+  it("converts an AuthorizationError into a NOT_FOUND error", async () => {
+    await expect(
+      assertScopeOrNotFound(async () => {
+        throw new AuthorizationError();
+      }, "Board")
+    ).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("passes through when the assert resolves", async () => {
+    await expect(
+      assertScopeOrNotFound(async () => {}, "Board")
+    ).resolves.toBeUndefined();
+  });
+
+  it("propagates non-authorization errors unchanged", async () => {
+    await expect(
+      assertScopeOrNotFound(async () => {
+        throw new Error("db down");
+      }, "Board")
+    ).rejects.toThrow("db down");
+  });
+});
+```
+
+- [ ] **Step 2: RED** — `./node_modules/.bin/jest lib/mcp/__tests__/scope-adapter.test.ts` fails: `assertScopeOrNotFound` is not exported.
+
+- [ ] **Step 3: Implement in `lib/mcp/helpers.ts`**
+
+At the top of the file, add the import:
+
+```ts
+import { AuthorizationError } from "@/lib/authz";
+```
+
+After the error helpers (after `externalError`), add:
+
+```ts
+// Run an object-level authorization assert (assertCanWriteBoard, etc.) and
+// convert a denial into NOT_FOUND so the caller cannot tell whether the id
+// exists (no existence oracle). Non-authorization errors propagate unchanged.
+export async function assertScopeOrNotFound(
+  assert: () => Promise<void>,
+  entity: string,
+): Promise<void> {
+  try {
+    await assert();
+  } catch (e) {
+    if (e instanceof AuthorizationError) notFound(entity);
+    throw e;
+  }
+}
+```
+
+- [ ] **Step 4: GREEN** — same jest command, 3/3 pass. `pnpm exec tsc --noEmit` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/mcp/helpers.ts lib/mcp/__tests__/scope-adapter.test.ts
+git commit -m "feat(mcp): assertScopeOrNotFound adapter for object-level tool authorization"
+```
+
+---
+
+### Task 2: Guard Board tools
+
+**Files:**
+- Modify: `lib/mcp/tools/projects.ts` (imports; `list_boards`, `get_board`, `create_board`, `update_board`, `delete_board`)
+- Test: `lib/mcp/__tests__/projects-boards-scope.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `assertScopeOrNotFound` (Task 1); `assertCanWriteBoard`, `boardReadScopeWhere`, `AuthzUser` from `@/lib/authz`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/mcp/__tests__/projects-boards-scope.test.ts` using the harness. Mock prismadb with `boards: { findMany, count, findFirst, create, update }`. Cases:
+
+```ts
+it("update_board: denies a non-owner (NOT_FOUND) and does not update", async () => {
+  (assertCanWriteBoard as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_update_board", { id: "b-victim", title: "x" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteBoard).toHaveBeenCalledWith(USER, "b-victim");
+  expect(prismadb.boards.update).not.toHaveBeenCalled();
+});
+
+it("update_board: updates for an owner", async () => {
+  (assertCanWriteBoard as jest.Mock).mockResolvedValue(undefined);
+  (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b-1" });
+  await call("projects_update_board", { id: "b-1", title: "x" });
+  expect(prismadb.boards.update).toHaveBeenCalled();
+});
+
+it("delete_board: denies a non-owner and does not soft-delete", async () => {
+  (assertCanWriteBoard as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_delete_board", { id: "b-victim" })).rejects.toThrow("NOT_FOUND");
+  expect(prismadb.boards.update).not.toHaveBeenCalled();
+});
+
+it("list_boards: filters by boardReadScopeWhere", async () => {
+  (prismadb.boards.findMany as jest.Mock).mockResolvedValue([]);
+  (prismadb.boards.count as jest.Mock).mockResolvedValue(0);
+  await call("projects_list_boards", { limit: 20, offset: 0 });
+  const arg = (prismadb.boards.findMany as jest.Mock).mock.calls[0][0];
+  expect(arg.where).toMatchObject({ __scope: "read" }); // boardReadScopeWhere(user) mock marker
+});
+
+it("get_board: scopes the findFirst by boardReadScopeWhere", async () => {
+  (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b-1" });
+  await call("projects_get_board", { id: "b-1" });
+  const arg = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+  expect(arg.where).toMatchObject({ id: "b-1", __scope: "read" });
+});
+
+it("create_board: stamps the caller as owner", async () => {
+  (prismadb.boards.create as jest.Mock).mockResolvedValue({ id: "b-new" });
+  await call("projects_create_board", { title: "T", description: "D" });
+  const data = (prismadb.boards.create as jest.Mock).mock.calls[0][0].data;
+  expect(data.user).toBe("u1");
+  expect(data.createdBy).toBe("u1");
+});
+```
+
+- [ ] **Step 2: RED** — the deny tests fail (no guard; update runs), the scope tests fail (`userBoardWhere` marker, not `__scope`).
+
+- [ ] **Step 3: Add imports to `projects.ts`**
+
+Add after the existing `import ... from "../helpers"` block:
+
+```ts
+import type { AuthzUser } from "@/lib/authz";
+import { assertCanWriteBoard, boardReadScopeWhere } from "@/lib/authz";
+import { assertScopeOrNotFound } from "../helpers";
+```
+
+(Add `assertScopeOrNotFound` to the existing `../helpers` import instead of a second import line if you prefer; either is fine.)
+
+- [ ] **Step 4: Rewrite the five board handlers**
+
+`projects_list_boards` handler:
+```ts
+    async handler(args: { limit: number; offset: number }, _userId: string, user: AuthzUser) {
+      const where = boardReadScopeWhere(user);
+      const [data, total] = await Promise.all([
+        prismadb.boards.findMany({
+          where,
+          ...paginationArgs(args),
+          orderBy: { createdAt: "desc" },
+          include: { _count: { select: { sections: true } } },
+        }),
+        prismadb.boards.count({ where }),
+      ]);
+      return listResponse(data, total, args.offset);
+    },
+```
+
+`projects_get_board` handler:
+```ts
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      const board = await prismadb.boards.findFirst({
+        where: { id: args.id, ...boardReadScopeWhere(user) },
+        include: {
+          sections: {
+            orderBy: { position: "asc" },
+            include: {
+              tasks: { orderBy: { position: "asc" }, where: { taskStatus: { not: "COMPLETE" } } },
+            },
+          },
+          watchers: true,
+        },
+      });
+      if (!board) notFound("Board");
+      return itemResponse(board);
+    },
+```
+
+`projects_create_board` handler — change `userId` param to `_userId`, add `user: AuthzUser`, and stamp `user.id`:
+```ts
+    async handler(
+      args: { title: string; description: string; icon?: string; visibility?: string },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const board = await prismadb.boards.create({
+        data: {
+          v: 0,
+          title: args.title,
+          description: args.description,
+          icon: args.icon,
+          visibility: args.visibility,
+          user: user.id,
+          createdBy: user.id,
+          updatedBy: user.id,
+        },
+      });
+      return itemResponse(board);
+    },
+```
+
+`projects_update_board` handler — replace the `userBoardWhere` existence check with the write assert:
+```ts
+    async handler(args: Record<string, any>, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, args.id), "Board");
+      const { id, ...updateData } = args;
+      const board = await prismadb.boards.update({
+        where: { id },
+        data: { ...updateData, updatedBy: user.id },
+      });
+      return itemResponse(board);
+    },
+```
+
+`projects_delete_board` handler:
+```ts
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, args.id), "Board");
+      const board = await prismadb.boards.update({
+        where: { id: args.id },
+        data: softDeleteData(user.id),
+      });
+      return itemResponse({ id: board.id, deletedAt: board.deletedAt });
+    },
+```
+
+- [ ] **Step 5: GREEN + typecheck** — the board test file passes; `pnpm exec tsc --noEmit` clean. (Note: `userBoardWhere` is still used by `create_section` and `list_tasks`, so it is NOT yet unused — do not delete it here.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/mcp/tools/projects.ts lib/mcp/__tests__/projects-boards-scope.test.ts
+git commit -m "feat(mcp): object-level authorization on project board tools"
+```
+
+---
+
+### Task 3: Guard Section tools
+
+**Files:**
+- Modify: `lib/mcp/tools/projects.ts` (`create_section`, `update_section`, `delete_section`)
+- Test: `lib/mcp/__tests__/projects-sections-scope.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `assertScopeOrNotFound`, `assertCanWriteBoard` (already imported in Task 2).
+
+- [ ] **Step 1: Write the failing tests** — mock prismadb `sections: { findUnique, aggregate, create, update, delete }`, `boards: { findFirst }`. Cases:
+
+```ts
+it("create_section: denies when the parent board is not writable", async () => {
+  (assertCanWriteBoard as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_create_section", { board: "b-victim", title: "S" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteBoard).toHaveBeenCalledWith(USER, "b-victim");
+  expect(prismadb.sections.create).not.toHaveBeenCalled();
+});
+
+it("update_section: resolves parent board then requires write; denies otherwise", async () => {
+  (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1" });
+  (assertCanWriteBoard as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_update_section", { id: "s-1", title: "x" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteBoard).toHaveBeenCalledWith(USER, "b-1");
+  expect(prismadb.sections.update).not.toHaveBeenCalled();
+});
+
+it("update_section: NOT_FOUND when the section does not exist", async () => {
+  (prismadb.sections.findUnique as jest.Mock).mockResolvedValue(null);
+  await expect(call("projects_update_section", { id: "missing" })).rejects.toThrow("NOT_FOUND");
+});
+
+it("delete_section: resolves parent board then requires write", async () => {
+  (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1", _count: { tasks: 0 } });
+  (assertCanWriteBoard as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_delete_section", { id: "s-1" })).rejects.toThrow("NOT_FOUND");
+  expect(prismadb.sections.delete).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: RED.**
+
+- [ ] **Step 3: Rewrite the three section handlers**
+
+`projects_create_section` — replace the `userBoardWhere` board lookup with the write assert (keep the `maxPos` + create):
+```ts
+    async handler(args: { board: string; title: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, args.board), "Board");
+      const maxPos = await prismadb.sections.aggregate({
+        where: { board: args.board },
+        _max: { position: true },
+      });
+      const section = await prismadb.sections.create({
+        data: {
+          v: 0,
+          board: args.board,
+          title: args.title,
+          position: (maxPos._max.position ?? BigInt(0)) + BigInt(1000),
+        },
+      });
+      return itemResponse(section);
+    },
+```
+
+`projects_update_section` — resolve the parent board from the existing section, then require write:
+```ts
+    async handler(args: { id: string; title?: string; position?: number }, _userId: string, user: AuthzUser) {
+      const existing = await prismadb.sections.findUnique({ where: { id: args.id } });
+      if (!existing) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, existing.board), "Board");
+      const { id, position, ...rest } = args;
+      const section = await prismadb.sections.update({
+        where: { id },
+        data: { ...rest, ...(position !== undefined && { position: BigInt(position) }) },
+      });
+      return itemResponse(section);
+    },
+```
+
+`projects_delete_section` — require write on the parent board before the empty-check/delete:
+```ts
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      const section = await prismadb.sections.findUnique({
+        where: { id: args.id },
+        include: { _count: { select: { tasks: true } } },
+      });
+      if (!section) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, section.board), "Board");
+      if (section._count.tasks > 0) conflict("Cannot delete section with tasks. Move or delete tasks first.");
+      await prismadb.sections.delete({ where: { id: args.id } });
+      return itemResponse({ id: args.id, deleted: true });
+    },
+```
+
+- [ ] **Step 4: GREEN + typecheck.**
+- [ ] **Step 5: Commit** — `git add lib/mcp/tools/projects.ts lib/mcp/__tests__/projects-sections-scope.test.ts && git commit -m "feat(mcp): object-level authorization on project section tools"`
+
+---
+
+### Task 4: Guard Task tools + delete `userBoardWhere`
+
+**Files:**
+- Modify: `lib/mcp/tools/projects.ts` (`list_tasks`, `get_task`, `create_task`, `update_task`, `move_task`, `delete_task`; delete `userBoardWhere`)
+- Test: `lib/mcp/__tests__/projects-tasks-scope.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `assertScopeOrNotFound`, `assertCanWriteBoard` (imported); adds `assertCanReadTask`, `assertCanWriteTask`.
+
+- [ ] **Step 1: Write the failing tests** — mock prismadb `tasks: { findMany, count, findUnique, create, update }`, `sections: { findUnique, aggregate }`. Cases:
+
+```ts
+it("update_task: denies a non-authorized caller and does not update", async () => {
+  (assertCanWriteTask as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_update_task", { id: "t-victim", title: "x" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteTask).toHaveBeenCalledWith(USER, "t-victim");
+  expect(prismadb.tasks.update).not.toHaveBeenCalled();
+});
+
+it("delete_task: denies and does not update status", async () => {
+  (assertCanWriteTask as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_delete_task", { id: "t-victim" })).rejects.toThrow("NOT_FOUND");
+  expect(prismadb.tasks.update).not.toHaveBeenCalled();
+});
+
+it("get_task: denies read and does not fetch the task body", async () => {
+  (assertCanReadTask as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_get_task", { id: "t-victim" })).rejects.toThrow("NOT_FOUND");
+});
+
+it("create_task: requires write on the parent board (via the section)", async () => {
+  (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1" });
+  (assertCanWriteBoard as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_create_task", { title: "T", section: "s-1", priority: "Normal" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteBoard).toHaveBeenCalledWith(USER, "b-1");
+  expect(prismadb.tasks.create).not.toHaveBeenCalled();
+});
+
+it("move_task: requires write on BOTH the source task and the destination board", async () => {
+  (assertCanWriteTask as jest.Mock).mockResolvedValue(undefined); // source ok
+  (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-dest", board: "b-dest" });
+  (assertCanWriteBoard as jest.Mock).mockRejectedValue(new AuthorizationError()); // dest denied
+  await expect(call("projects_move_task", { id: "t-1", section: "s-dest" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteTask).toHaveBeenCalledWith(USER, "t-1");
+  expect(assertCanWriteBoard).toHaveBeenCalledWith(USER, "b-dest");
+  expect(prismadb.tasks.update).not.toHaveBeenCalled();
+});
+
+it("list_tasks: always constrains to boards the user can read, even when a board id is supplied", async () => {
+  (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+  (prismadb.tasks.count as jest.Mock).mockResolvedValue(0);
+  await call("projects_list_tasks", { board: "b-any", limit: 20, offset: 0 });
+  const where = (prismadb.tasks.findMany as jest.Mock).mock.calls[0][0].where;
+  // the board read scope is always applied to the parent board relation
+  expect(where.assigned_section.board_relation).toMatchObject({ __scope: "read" });
+  // and the requested board id is ANDed in
+  expect(where.assigned_section.board).toBe("b-any");
+});
+```
+
+- [ ] **Step 2: RED.**
+
+- [ ] **Step 3: Add the task imports** — extend the `@/lib/authz` import in `projects.ts` to add `assertCanReadTask, assertCanWriteTask`.
+
+- [ ] **Step 4: Rewrite `list_tasks`** — always scope by the parent board's read scope, then AND the optional filters:
+
+```ts
+    async handler(
+      args: { board?: string; section?: string; user?: string; status?: string; limit: number; offset: number },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const where: any = {
+        ...(args.section && { section: args.section }),
+        ...(args.user && { user: args.user }),
+        ...(args.status && { taskStatus: args.status as any }),
+        // Always constrain to tasks whose parent board the caller can read, and
+        // AND any requested board on top. This is the fix: a supplied board id
+        // can no longer bypass scoping (previously it did).
+        assigned_section: {
+          board_relation: boardReadScopeWhere(user),
+          ...(args.board && { board: args.board }),
+        },
+      };
+      const [data, total] = await Promise.all([
+        prismadb.tasks.findMany({ where, ...paginationArgs(args), orderBy: { createdAt: "desc" } }),
+        prismadb.tasks.count({ where }),
+      ]);
+      return listResponse(data, total, args.offset);
+    },
+```
+
+(`section`, `user`, `status` stay as the pre-existing top-level task filters; only `board_relation` — the tasks→section→board relation the read helpers use — is always applied, with `board` ANDed into the same `assigned_section` relation filter when supplied.)
+
+- [ ] **Step 5: Rewrite `get_task`, `create_task`, `update_task`, `move_task`, `delete_task`**
+
+`projects_get_task`:
+```ts
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanReadTask(user, args.id), "Task");
+      const task = await prismadb.tasks.findUnique({
+        where: { id: args.id },
+        include: {
+          comments: { orderBy: { createdAt: "desc" }, take: 20 },
+          documents: { include: { document: true } },
+          assigned_section: { select: { id: true, title: true, board: true } },
+        },
+      });
+      if (!task) notFound("Task");
+      return itemResponse(task);
+    },
+```
+
+`projects_create_task` — resolve the section's board and require write on it:
+```ts
+    async handler(
+      args: { title: string; content?: string; section: string; priority: string; dueDateAt?: string },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const sec = await prismadb.sections.findUnique({ where: { id: args.section } });
+      if (!sec) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, sec.board), "Board");
+      const maxPos = await prismadb.tasks.aggregate({
+        where: { section: args.section },
+        _max: { position: true },
+      });
+      const task = await prismadb.tasks.create({
+        data: {
+          v: 0,
+          title: args.title,
+          content: args.content,
+          section: args.section,
+          priority: args.priority,
+          position: (maxPos._max.position ?? BigInt(0)) + BigInt(1000),
+          user: user.id,
+          createdBy: user.id,
+          updatedBy: user.id,
+          ...(args.dueDateAt && { dueDateAt: new Date(args.dueDateAt) }),
+        },
+      });
+      return itemResponse(task);
+    },
+```
+
+`projects_update_task`:
+```ts
+    async handler(args: Record<string, any>, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task");
+      const { id, dueDateAt, ...rest } = args;
+      const task = await prismadb.tasks.update({
+        where: { id },
+        data: {
+          ...rest,
+          ...(dueDateAt !== undefined && { dueDateAt: new Date(dueDateAt) }),
+          updatedBy: user.id,
+        },
+      });
+      return itemResponse(task);
+    },
+```
+
+`projects_move_task` — write on the source task AND the destination board:
+```ts
+    async handler(args: { id: string; section: string; position?: number }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task");
+      const sec = await prismadb.sections.findUnique({ where: { id: args.section } });
+      if (!sec) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, sec.board), "Board");
+      const task = await prismadb.tasks.update({
+        where: { id: args.id },
+        data: {
+          section: args.section,
+          ...(args.position !== undefined && { position: BigInt(args.position) }),
+          updatedBy: user.id,
+        },
+      });
+      return itemResponse(task);
+    },
+```
+
+`projects_delete_task`:
+```ts
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task");
+      const task = await prismadb.tasks.update({
+        where: { id: args.id },
+        data: { taskStatus: "COMPLETE", updatedBy: user.id },
+      });
+      return itemResponse({ id: task.id, status: "COMPLETE" });
+    },
+```
+
+- [ ] **Step 6: Delete `userBoardWhere`** — remove the function at `projects.ts:13-21`. It now has zero references (grep to confirm: `grep -n userBoardWhere lib/mcp/tools/projects.ts` returns nothing).
+
+- [ ] **Step 7: GREEN + typecheck** — the task test file passes; `pnpm exec tsc --noEmit` clean (no unused-function error, since `userBoardWhere` is gone).
+
+- [ ] **Step 8: Commit** — `git add lib/mcp/tools/projects.ts lib/mcp/__tests__/projects-tasks-scope.test.ts && git commit -m "feat(mcp): object-level authorization on project task tools; drop userBoardWhere"`
+
+---
+
+### Task 5: Guard Comment + Document-link tools
+
+**Files:**
+- Modify: `lib/mcp/tools/projects.ts` (`add_comment`, `list_comments`, `assign_document`)
+- Test: `lib/mcp/__tests__/projects-comments-docs-scope.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `assertScopeOrNotFound`, `assertCanReadTask`, `assertCanWriteTask` (imported); adds `assertCanReadDocument`.
+
+- [ ] **Step 1: Write the failing tests** — mock prismadb `tasksComments: { findMany, count, create }`, `documentsToTasks: { create }`. Cases:
+
+```ts
+it("add_comment: denies write on the task and does not create", async () => {
+  (assertCanWriteTask as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_add_comment", { task: "t-victim", comment: "x" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteTask).toHaveBeenCalledWith(USER, "t-victim");
+  expect(prismadb.tasksComments.create).not.toHaveBeenCalled();
+});
+
+it("list_comments: denies read on the task and does not list", async () => {
+  (assertCanReadTask as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_list_comments", { task: "t-victim", limit: 20, offset: 0 })).rejects.toThrow("NOT_FOUND");
+  expect(prismadb.tasksComments.findMany).not.toHaveBeenCalled();
+});
+
+it("assign_document: requires write on the task AND read on the document", async () => {
+  (assertCanWriteTask as jest.Mock).mockResolvedValue(undefined);
+  (assertCanReadDocument as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_assign_document", { task_id: "t-1", document_id: "d-victim" })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanWriteTask).toHaveBeenCalledWith(USER, "t-1");
+  expect(assertCanReadDocument).toHaveBeenCalledWith(USER, "d-victim");
+  expect(prismadb.documentsToTasks.create).not.toHaveBeenCalled();
+});
+```
+
+Add `assertCanReadDocument: jest.fn()` to the `@/lib/authz` mock in this file's harness header.
+
+- [ ] **Step 2: RED.**
+
+- [ ] **Step 3: Add the document import** — extend the `@/lib/authz` import in `projects.ts` to add `assertCanReadDocument`.
+
+- [ ] **Step 4: Rewrite the three handlers**
+
+`projects_add_comment`:
+```ts
+    async handler(args: { task: string; comment: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.task), "Task");
+      const tc = await prismadb.tasksComments.create({
+        data: { v: 0, task: args.task, comment: args.comment, user: user.id },
+      });
+      return itemResponse(tc);
+    },
+```
+
+`projects_list_comments`:
+```ts
+    async handler(args: { task: string; limit: number; offset: number }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanReadTask(user, args.task), "Task");
+      const where = { task: args.task };
+      const [data, total] = await Promise.all([
+        prismadb.tasksComments.findMany({
+          where,
+          ...paginationArgs(args),
+          orderBy: { createdAt: "desc" },
+          include: { assigned_user: { select: { id: true, name: true } } },
+        }),
+        prismadb.tasksComments.count({ where }),
+      ]);
+      return listResponse(data, total, args.offset);
+    },
+```
+
+`projects_assign_document`:
+```ts
+    async handler(args: { task_id: string; document_id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.task_id), "Task");
+      await assertScopeOrNotFound(() => assertCanReadDocument(user, args.document_id), "Document");
+      await prismadb.documentsToTasks.create({
+        data: { task_id: args.task_id, document_id: args.document_id },
+      });
+      return itemResponse({ task_id: args.task_id, document_id: args.document_id });
+    },
+```
+
+- [ ] **Step 5: GREEN + typecheck.**
+- [ ] **Step 6: Commit** — `git add lib/mcp/tools/projects.ts lib/mcp/__tests__/projects-comments-docs-scope.test.ts && git commit -m "feat(mcp): object-level authorization on project comment + document-link tools"`
+
+---
+
+### Task 6: Guard Watch tool
+
+**Files:**
+- Modify: `lib/mcp/tools/projects.ts` (`watch_board`)
+- Test: `lib/mcp/__tests__/projects-watch-scope.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `assertScopeOrNotFound`; adds `assertCanReadBoard`.
+
+- [ ] **Step 1: Write the failing tests** — mock prismadb `boardWatchers: { create, delete }`. Cases:
+
+```ts
+it("watch_board: denies read on the board and does not create a watcher (escalation guard)", async () => {
+  (assertCanReadBoard as jest.Mock).mockRejectedValue(new AuthorizationError());
+  await expect(call("projects_watch_board", { board_id: "b-victim", watch: true })).rejects.toThrow("NOT_FOUND");
+  expect(assertCanReadBoard).toHaveBeenCalledWith(USER, "b-victim");
+  expect(prismadb.boardWatchers.create).not.toHaveBeenCalled();
+});
+
+it("watch_board: watches a readable board", async () => {
+  (assertCanReadBoard as jest.Mock).mockResolvedValue(undefined);
+  (prismadb.boardWatchers.create as jest.Mock).mockResolvedValue({});
+  await call("projects_watch_board", { board_id: "b-1", watch: true });
+  expect(prismadb.boardWatchers.create).toHaveBeenCalled();
+});
+```
+
+Add `assertCanReadBoard: jest.fn()` to this file's `@/lib/authz` mock header.
+
+- [ ] **Step 2: RED.**
+
+- [ ] **Step 3: Add the import** — extend the `@/lib/authz` import in `projects.ts` to add `assertCanReadBoard`.
+
+- [ ] **Step 4: Rewrite `watch_board`** — read gate before the watcher create/delete:
+```ts
+    async handler(args: { board_id: string; watch: boolean }, _userId: string, user: AuthzUser) {
+      // Read gate: board watchers sit only in the read scope, so watching a
+      // readable board grants nothing new; deny self-granting read to a board
+      // the caller cannot see.
+      await assertScopeOrNotFound(() => assertCanReadBoard(user, args.board_id), "Board");
+      if (args.watch) {
+        await prismadb.boardWatchers.create({
+          data: { board_id: args.board_id, user_id: user.id },
+        }).catch(() => {});
+      } else {
+        await prismadb.boardWatchers.delete({
+          where: { board_id_user_id: { board_id: args.board_id, user_id: user.id } },
+        }).catch(() => {});
+      }
+      return itemResponse({ board_id: args.board_id, watching: args.watch });
+    },
+```
+
+- [ ] **Step 5: GREEN + typecheck.**
+- [ ] **Step 6: Commit** — `git add lib/mcp/tools/projects.ts lib/mcp/__tests__/projects-watch-scope.test.ts && git commit -m "feat(mcp): read-scoped authorization on project watch_board (escalation fix)"`
+
+---
+
+### Task 7: Verification gate + coverage sweep
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-21-mcp-project-tools-authz-design.md` (mark implemented)
+
+- [ ] **Step 1: Coverage sweep** — every mutating/reading `projects_*` handler must reference an assert or a scope predicate, and `userBoardWhere` must be gone:
+
+```bash
+grep -n 'userBoardWhere' lib/mcp/tools/projects.ts   # expect: no output
+# Every handler should now reference one of: assertCanReadBoard/assertCanWriteBoard/
+# assertCanReadTask/assertCanWriteTask/assertCanReadDocument/boardReadScopeWhere.
+grep -c 'assertCan\|boardReadScopeWhere' lib/mcp/tools/projects.ts   # expect: >= 14
+```
+
+List any `projects_*` handler that still does a bare `findUnique`/`create`/`update`/`delete` on a client-supplied id with no preceding assert (other than `create_board`, which is auth-only by design). A straggler is a failed task, not a note.
+
+- [ ] **Step 2: Full suite** — `./node_modules/.bin/jest` — all pass (baseline for this branch is `dev`'s suite plus the new MCP scope suites, 0 failures).
+
+- [ ] **Step 3: Typecheck + build** — `pnpm exec tsc --noEmit && pnpm build` — both succeed.
+
+- [ ] **Step 4: Mark the spec implemented** — set `Status:` to implemented, record the residuals (task-assignee write breadth; public-board creation) and the coverage-sweep result.
+
+- [ ] **Step 5: Commit (no push — final review first)**
+
+```bash
+git add docs/superpowers/specs/2026-07-21-mcp-project-tools-authz-design.md
+git commit -m "docs: mark MCP project-tools authz workstream implemented"
+```
+
+---
+
+## Notes for the executor
+
+- The dispatcher already passes `(args, mcpUser.id, mcpUser)`; you are only changing handler bodies and signatures, never `app/api/mcp/[transport]/route.ts`.
+- Denials must surface as `NOT_FOUND` — always go through `assertScopeOrNotFound`, never let a raw `AuthorizationError` escape a handler (it would map to `INTERNAL_ERROR`).
+- `create_board` is the only write tool with no object-level assert (a new board is owned by its creator); it still stamps `user.id`.
+- Every scope test must fail with the guard removed. If a test passes against the pre-fix handler, it is not testing the guard — fix the test before moving on.
+- If the Agent classifier blocks subagent dispatch (as in workstream A), execute inline with tsc + jest as the gate.

--- a/docs/superpowers/plans/2026-07-21-ssrf-host-guard.md
+++ b/docs/superpowers/plans/2026-07-21-ssrf-host-guard.md
@@ -1,0 +1,564 @@
+# SSRF Host-Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop an authenticated user from making the server open IMAP/SMTP connections to internal/private hosts, by validating and IP-pinning the destination of every attacker-controllable mail sink (GHSA-f5r5-f2v5-74ww).
+
+**Architecture:** A pure `lib/net/ip-rules.ts` classifies addresses (allow only public unicast). `lib/net/host-guard.ts` `assertPublicHost(host)` resolves the host once, validates every resolved address, and returns a pinned IP + the original hostname. Each sink dials the pinned IP (closing DNS rebinding) with the hostname as TLS `servername`.
+
+**Tech Stack:** Node 22 `node:dns/promises` + `node:net`, `ipaddr.js` (new), `imap` v0.8.19, `nodemailer` v9.0.1, jest 30.
+
+Spec: `docs/superpowers/specs/2026-07-21-ssrf-host-guard-design.md`
+
+## Global Constraints
+
+- **Allow only public unicast addresses.** Refuse loopback, private (`10/8`, `172.16/12`, `192.168/16`), link-local (`169.254/16`, `fe80::/10`), unique-local (`fc00::/7`), CGNAT (`100.64/10`), unspecified (`0.0.0.0`, `::`), broadcast/multicast/reserved, and IPv4-mapped IPv6 wrapping any of the above. Unparseable input is refused (fail closed).
+- **IP-pinning is the rebinding fix.** Sinks dial the validated IP (`pinned.address`), never the hostname; the original hostname rides as `servername` for TLS SNI. Never re-resolve after validating.
+- **Env escape hatch:** `MAIL_ALLOW_PRIVATE_HOSTS === "true"` bypasses validation (default off) — documented for self-hosters with an internal mail server.
+- **No existence/host oracle:** a blocked host in the non-blind accounts.ts sinks returns the *same* classified "could not connect" message a real unreachable host yields, via the inherited `classifyMailError`.
+- **Do NOT change `tls.rejectUnauthorized: false`** — deferred to a separate workstream. Set `servername` for SNI correctness, but leave `rejectUnauthorized` as-is.
+- Reuse, don't re-implement: `lib/email/imap-safety.ts` (`isAllowedImapPort`/`isAllowedSmtpPort`/`classifyMailError`) already exists on this branch — keep the existing port checks.
+- Run jest via `./node_modules/.bin/jest <path>` (NEVER `pnpm test` — `ERR_PNPM_IGNORED_BUILDS`). Finish each task with `pnpm exec tsc --noEmit` clean.
+- **Every regression test must FAIL against the pre-guard code** — the acceptance bar.
+- Conventional commits, one per task. Work on `security/workstream-c-ssrf-hostguard` (forked from `security/quick-fixes-resend-imap`).
+
+### Reusable `imap` mock (Tasks 3 & 4)
+
+To assert host-pinning without a real connection, mock the `imap` module with a constructor that records its config and drives the event flow. The recording array MUST be named with a `mock` prefix — a `jest.mock` factory may not reference any other out-of-scope variable:
+
+```ts
+const mockImapInstances: any[] = [];
+jest.mock("imap", () => {
+  const ctor = jest.fn().mockImplementation((config: any) => {
+    const handlers: Record<string, (...a: any[]) => void> = {};
+    const inst = {
+      config,
+      once: (ev: string, cb: any) => { handlers[ev] = cb; return inst; },
+      connect: () => { queueMicrotask(() => handlers["ready"]?.()); },
+      end: () => {},
+      getBoxes: (_: string, cb: any) => cb(null, {}),
+    };
+    mockImapInstances.push(inst);
+    return inst;
+  });
+  return { __esModule: true, default: ctor };
+});
+beforeEach(() => { mockImapInstances.length = 0; });
+// after a call: expect(mockImapInstances[0].config.host).toBe("1.2.3.4")
+```
+
+If `import Imap from "imap"` does not resolve the mock as a constructor under the repo's esModuleInterop, drop the `{ __esModule: true, default: ... }` wrapper and return `ctor` directly — verify via the RED run.
+
+---
+
+### Task 1: `lib/net/ip-rules.ts` + `ipaddr.js` dependency
+
+**Files:**
+- Add dependency: `ipaddr.js`
+- Create: `lib/net/ip-rules.ts`
+- Test: `lib/net/__tests__/ip-rules.test.ts` (new)
+
+**Interfaces:**
+- Produces: `isDisallowedAddress(ip: string): boolean` — true if `ip` is NOT a public unicast address (must be refused). Consumed by Task 2.
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `pnpm add ipaddr.js`
+Expected: installs cleanly (pure JS, no postinstall/build script — no `ERR_PNPM_IGNORED_BUILDS`). Confirm: `node -e "console.log(require('ipaddr.js/package.json').version)"` prints a version.
+If `pnpm add` fails for environment reasons, hand-roll `ip-rules.ts` covering the exact ranges in Global Constraints — the Step 2 test table is the safety net. Do not proceed without one or the other.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `lib/net/__tests__/ip-rules.test.ts`:
+
+```ts
+import { isDisallowedAddress } from "../ip-rules";
+
+describe("isDisallowedAddress", () => {
+  const disallowed = [
+    "127.0.0.1", "127.1.2.3", "10.0.0.1", "172.16.0.1", "172.31.255.255",
+    "192.168.1.1", "169.254.169.254", "100.64.0.1", "0.0.0.0",
+    "255.255.255.255", "224.0.0.1",
+    "::1", "fe80::1", "fc00::1", "fd12:3456::1", "::",
+    "::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:192.168.0.1",
+    "not-an-ip", "", "999.999.999.999",
+  ];
+  const allowed = [
+    "8.8.8.8", "1.1.1.1", "93.184.216.34", "203.0.113.9",
+    "2606:4700:4700::1111", "2001:4860:4860::8888",
+    "::ffff:8.8.8.8", // IPv4-mapped public → allowed
+  ];
+
+  it.each(disallowed)("refuses %s", (ip) => {
+    expect(isDisallowedAddress(ip)).toBe(true);
+  });
+  it.each(allowed)("allows %s", (ip) => {
+    expect(isDisallowedAddress(ip)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify RED** — `./node_modules/.bin/jest lib/net/__tests__/ip-rules.test.ts` fails (module not found).
+
+- [ ] **Step 4: Implement `lib/net/ip-rules.ts`**
+
+```ts
+import ipaddr from "ipaddr.js";
+
+// Refuse everything that is not a public unicast address: loopback, private,
+// link-local, unique-local, CGNAT, unspecified, broadcast/multicast/reserved,
+// and IPv4-mapped IPv6 wrapping any of the above. Unparseable input is refused
+// (fail closed). Used by the SSRF host guard before dialling any mail server.
+export function isDisallowedAddress(ip: string): boolean {
+  let addr: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    addr = ipaddr.parse(ip);
+  } catch {
+    return true; // fail closed on anything we cannot parse
+  }
+  // Unwrap IPv4-mapped IPv6 (::ffff:a.b.c.d) and classify the embedded IPv4.
+  if (addr.kind() === "ipv6" && (addr as ipaddr.IPv6).isIPv4MappedAddress()) {
+    addr = (addr as ipaddr.IPv6).toIPv4Address();
+  }
+  // ipaddr's range() returns "unicast" only for globally-routable unicast space;
+  // every other classification (loopback/private/linkLocal/uniqueLocal/
+  // carrierGradeNat/unspecified/broadcast/multicast/reserved/...) is refused.
+  return addr.range() !== "unicast";
+}
+```
+
+- [ ] **Step 5: GREEN + typecheck** — the test passes; `pnpm exec tsc --noEmit` clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml lib/net/ip-rules.ts lib/net/__tests__/ip-rules.test.ts
+git commit -m "feat(net): ip-rules — refuse non-public-unicast addresses (SSRF)"
+```
+
+---
+
+### Task 2: `lib/net/host-guard.ts` — `assertPublicHost`
+
+**Files:**
+- Create: `lib/net/host-guard.ts`
+- Test: `lib/net/__tests__/host-guard.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `isDisallowedAddress` (Task 1).
+- Produces: `class HostNotAllowedError extends Error`; `assertPublicHost(host: string): Promise<{ address: string; hostname: string }>` — resolves `host`, validates every resolved address, returns the pinned IP + original hostname; throws `HostNotAllowedError` on any disallowed/unresolvable host. Consumed by Tasks 3 & 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/net/__tests__/host-guard.test.ts`:
+
+```ts
+jest.mock("node:dns/promises", () => ({ lookup: jest.fn() }));
+
+import { lookup } from "node:dns/promises";
+import { assertPublicHost, HostNotAllowedError } from "../host-guard";
+
+const mockLookup = lookup as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.MAIL_ALLOW_PRIVATE_HOSTS;
+});
+
+it("returns the pinned IP for a host resolving to a public address", async () => {
+  mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  const res = await assertPublicHost("mail.example.com");
+  expect(res).toEqual({ address: "93.184.216.34", hostname: "mail.example.com" });
+});
+
+it("throws when the host resolves to a private address", async () => {
+  mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+  await expect(assertPublicHost("evil.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("throws when ANY resolved address is disallowed (mixed results)", async () => {
+  mockLookup.mockResolvedValue([
+    { address: "93.184.216.34", family: 4 },
+    { address: "169.254.169.254", family: 4 },
+  ]);
+  await expect(assertPublicHost("rebind.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("throws on empty resolution", async () => {
+  mockLookup.mockResolvedValue([]);
+  await expect(assertPublicHost("nx.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("throws when lookup rejects (fail closed)", async () => {
+  mockLookup.mockRejectedValue(new Error("ENOTFOUND"));
+  await expect(assertPublicHost("nx.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("validates a public IP literal without a lookup", async () => {
+  const res = await assertPublicHost("8.8.8.8");
+  expect(res).toEqual({ address: "8.8.8.8", hostname: "8.8.8.8" });
+  expect(mockLookup).not.toHaveBeenCalled();
+});
+
+it("throws for a private IP literal", async () => {
+  await expect(assertPublicHost("127.0.0.1")).rejects.toBeInstanceOf(HostNotAllowedError);
+  expect(mockLookup).not.toHaveBeenCalled();
+});
+
+it("bypasses validation when MAIL_ALLOW_PRIVATE_HOSTS=true", async () => {
+  process.env.MAIL_ALLOW_PRIVATE_HOSTS = "true";
+  const res = await assertPublicHost("mail.internal");
+  expect(res).toEqual({ address: "mail.internal", hostname: "mail.internal" });
+  expect(mockLookup).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: RED** — `./node_modules/.bin/jest lib/net/__tests__/host-guard.test.ts` fails (module not found).
+
+- [ ] **Step 3: Implement `lib/net/host-guard.ts`**
+
+```ts
+import { lookup } from "node:dns/promises";
+import net from "node:net";
+import { isDisallowedAddress } from "./ip-rules";
+
+export class HostNotAllowedError extends Error {
+  constructor(message = "Host is not allowed") {
+    super(message);
+    this.name = "HostNotAllowedError";
+  }
+}
+
+// Resolve `host` once and return a validated, pinned address to dial. If any
+// resolved address is non-public (or the host is unresolvable), throw. Callers
+// MUST dial the returned `address` (the pinned IP), keeping `hostname` for TLS
+// SNI — dialling the hostname would re-resolve and reopen the DNS-rebinding hole.
+export async function assertPublicHost(
+  host: string,
+): Promise<{ address: string; hostname: string }> {
+  if (process.env.MAIL_ALLOW_PRIVATE_HOSTS === "true") {
+    return { address: host, hostname: host };
+  }
+
+  if (net.isIP(host) !== 0) {
+    if (isDisallowedAddress(host)) throw new HostNotAllowedError();
+    return { address: host, hostname: host };
+  }
+
+  let results: { address: string; family: number }[];
+  try {
+    results = await lookup(host, { all: true, verbatim: true });
+  } catch {
+    throw new HostNotAllowedError();
+  }
+  if (!results || results.length === 0) throw new HostNotAllowedError();
+  for (const r of results) {
+    if (isDisallowedAddress(r.address)) throw new HostNotAllowedError();
+  }
+  return { address: results[0].address, hostname: host };
+}
+```
+
+- [ ] **Step 4: GREEN + typecheck** — the test passes; `pnpm exec tsc --noEmit` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/net/host-guard.ts lib/net/__tests__/host-guard.test.ts
+git commit -m "feat(net): assertPublicHost — resolve-validate-pin guard against SSRF/DNS-rebinding"
+```
+
+---
+
+### Task 3: Guard the `accounts.ts` sinks
+
+**Files:**
+- Modify: `actions/emails/accounts.ts` (`createEmailAccount`, `testEmailConnection`, `listImapFolders`)
+- Test: `actions/emails/__tests__/accounts-ssrf.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `assertPublicHost`, `HostNotAllowedError` from `@/lib/net/host-guard`; existing `classifyMailError` from `@/lib/email/imap-safety`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `actions/emails/__tests__/accounts-ssrf.test.ts`. Mock `@/lib/auth-server` (getSession), `@/lib/prisma`, `@/lib/email-crypto`, `@/lib/net/host-guard`, and `imap` (use the reusable imap mock from Global Constraints). Real `@/lib/email/imap-safety` (do not mock — its port allow-list and classifyMailError are under test too). Cases:
+
+```ts
+it("testEmailConnection: a blocked host is not dialled and returns the generic connect error", async () => {
+  getSess.mockResolvedValue({ user: { id: "u1" } });
+  (assertPublicHost as jest.Mock).mockRejectedValue(new HostNotAllowedError());
+  const res = await testEmailConnection({ imapHost: "127.0.0.1", imapPort: 993, imapSsl: true, username: "u", password: "p" });
+  expect(res.ok).toBe(false);
+  // same message a real unreachable host yields (no oracle):
+  expect(res.error).toBe(classifyMailError({ message: "ECONNREFUSED" } as Error));
+  expect(mockImapInstances.length).toBe(0); // no connection attempted
+});
+
+it("testEmailConnection: an allowed host is dialled on the PINNED IP with servername=hostname", async () => {
+  getSess.mockResolvedValue({ user: { id: "u1" } });
+  (assertPublicHost as jest.Mock).mockResolvedValue({ address: "93.184.216.34", hostname: "mail.example.com" });
+  const res = await testEmailConnection({ imapHost: "mail.example.com", imapPort: 993, imapSsl: true, username: "u", password: "p" });
+  expect(res).toEqual({ ok: true });
+  expect(mockImapInstances[0].config.host).toBe("93.184.216.34");
+  expect(mockImapInstances[0].config.tlsOptions.servername).toBe("mail.example.com");
+});
+
+it("listImapFolders: a blocked host is not dialled", async () => {
+  getSess.mockResolvedValue({ user: { id: "u1" } });
+  (assertPublicHost as jest.Mock).mockRejectedValue(new HostNotAllowedError());
+  const res = await listImapFolders({ imapHost: "10.0.0.5", imapPort: 993, imapSsl: true, username: "u", password: "p" });
+  expect(res.ok).toBe(false);
+  expect(mockImapInstances.length).toBe(0);
+});
+
+it("createEmailAccount: rejects a private mail host (store-time defense) and does not create", async () => {
+  getSess.mockResolvedValue({ user: { id: "u1" } });
+  (assertPublicHost as jest.Mock).mockRejectedValue(new HostNotAllowedError());
+  await expect(createEmailAccount({
+    label: "x", imapHost: "127.0.0.1", imapPort: 993, imapSsl: true,
+    smtpHost: "127.0.0.1", smtpPort: 465, smtpSsl: true, username: "u", password: "p",
+  })).rejects.toThrow();
+  expect(prismadb.emailAccount.create).not.toHaveBeenCalled();
+});
+```
+
+Wire the imap mock's `mockImapInstances` array, and `jest.mock("@/lib/net/host-guard", () => ({ assertPublicHost: jest.fn(), HostNotAllowedError: class HostNotAllowedError extends Error {} }))`.
+
+- [ ] **Step 2: RED** — the tests fail (no host guard; the blocked-host tests still attempt/allow the connection).
+
+- [ ] **Step 3: Add imports** to `actions/emails/accounts.ts`:
+
+```ts
+import { assertPublicHost, HostNotAllowedError } from "@/lib/net/host-guard";
+```
+
+- [ ] **Step 4: Guard `testEmailConnection`** — after the port check, resolve+pin before building the Imap:
+
+```ts
+  if (!isAllowedImapPort(input.imapPort)) {
+    return { ok: false, error: "Unsupported IMAP port" };
+  }
+
+  let pinned: { address: string; hostname: string };
+  try {
+    pinned = await assertPublicHost(input.imapHost);
+  } catch (e) {
+    if (e instanceof HostNotAllowedError) {
+      // Indistinguishable from a real unreachable host — no SSRF oracle.
+      return { ok: false, error: classifyMailError({ message: "ECONNREFUSED" } as Error) };
+    }
+    throw e;
+  }
+
+  const connectionPromise = new Promise<{ ok: boolean; error?: string }>((resolve) => {
+    const imap = new Imap({
+      user: input.username,
+      password: input.password,
+      host: pinned.address,
+      port: input.imapPort,
+      tls: input.imapSsl,
+      // Dial the validated IP; keep the hostname for TLS SNI. (rejectUnauthorized
+      // left as-is — TLS verification is a separate workstream.)
+      tlsOptions: { servername: pinned.hostname, rejectUnauthorized: false },
+      authTimeout: 8000,
+      connTimeout: 8000,
+    });
+    // ...unchanged ready/error/connect...
+```
+
+- [ ] **Step 5: Guard `listImapFolders`** — same shape: after the port check, `assertPublicHost` (on `HostNotAllowedError` return `{ ok: false, error: classifyMailError({ message: "ECONNREFUSED" } as Error) }`), then `new Imap({ ..., host: pinned.address, tlsOptions: { servername: pinned.hostname, rejectUnauthorized: false }, ... })`.
+
+- [ ] **Step 6: Guard `createEmailAccount`** — after the port checks, validate both hosts at store time:
+
+```ts
+  if (!isAllowedImapPort(input.imapPort)) throw new Error("Unsupported IMAP port");
+  if (!isAllowedSmtpPort(input.smtpPort)) throw new Error("Unsupported SMTP port");
+
+  try {
+    await assertPublicHost(input.imapHost);
+    await assertPublicHost(input.smtpHost);
+  } catch (e) {
+    if (e instanceof HostNotAllowedError) throw new Error("Mail host is not allowed");
+    throw e;
+  }
+```
+
+- [ ] **Step 7: GREEN + typecheck** — the SSRF test passes; the existing `actions/emails/__tests__/accounts.test.ts` still passes (run it); `pnpm exec tsc --noEmit` clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add actions/emails/accounts.ts actions/emails/__tests__/accounts-ssrf.test.ts
+git commit -m "feat(security): SSRF host-guard on IMAP test/discover/create sinks"
+```
+
+---
+
+### Task 4: Guard `sendEmail` (SMTP) and `connectImap` (background IMAP)
+
+**Files:**
+- Modify: `actions/emails/messages.ts` (`sendEmail`)
+- Modify: `inngest/lib/imap-utils.ts` (`connectImap`)
+- Test: `actions/emails/__tests__/messages-ssrf.test.ts` (new), `inngest/lib/__tests__/imap-utils-ssrf.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `assertPublicHost`, `HostNotAllowedError` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+`actions/emails/__tests__/messages-ssrf.test.ts` — mock `@/lib/auth-server`, `@/lib/prisma`, `@/lib/email-crypto`, `@/lib/net/host-guard`, and `nodemailer` (capture `createTransport` args):
+
+```ts
+const createTransport = jest.fn(() => ({ sendMail: jest.fn().mockResolvedValue({ messageId: "m1" }) }));
+jest.mock("nodemailer", () => ({ __esModule: true, default: { createTransport } }));
+
+it("sendEmail: a blocked stored SMTP host is not dialled", async () => {
+  requireSessionMock(); // getSession -> { user: { id: "u1" } }
+  (prismadb.emailAccount.findFirst as jest.Mock).mockResolvedValue({
+    id: "a1", userId: "u1", smtpHost: "127.0.0.1", smtpPort: 465, smtpSsl: true,
+    username: "u", passwordEncrypted: "enc",
+  });
+  (assertPublicHost as jest.Mock).mockRejectedValue(new HostNotAllowedError());
+  await expect(sendEmail({ accountId: "a1", to: ["x@y.z"], subject: "s", body: "b" } as any)).rejects.toThrow();
+  expect(createTransport).not.toHaveBeenCalled();
+});
+
+it("sendEmail: an allowed host dials the PINNED IP with servername=hostname", async () => {
+  requireSessionMock();
+  (prismadb.emailAccount.findFirst as jest.Mock).mockResolvedValue({
+    id: "a1", userId: "u1", smtpHost: "smtp.example.com", smtpPort: 465, smtpSsl: true,
+    username: "u", passwordEncrypted: "enc",
+  });
+  (assertPublicHost as jest.Mock).mockResolvedValue({ address: "93.184.216.34", hostname: "smtp.example.com" });
+  await sendEmail({ accountId: "a1", to: ["x@y.z"], subject: "s", body: "b" } as any);
+  const cfg = createTransport.mock.calls[0][0];
+  expect(cfg.host).toBe("93.184.216.34");
+  expect(cfg.servername).toBe("smtp.example.com");
+});
+```
+
+`inngest/lib/__tests__/imap-utils-ssrf.test.ts` — mock `@/lib/net/host-guard` and `imap` (reusable imap mock):
+
+```ts
+it("connectImap: a blocked host is not dialled", async () => {
+  (assertPublicHost as jest.Mock).mockRejectedValue(new HostNotAllowedError());
+  await expect(connectImap({ username: "u", password: "p", imapHost: "10.0.0.5", imapPort: 993, imapSsl: true }))
+    .rejects.toThrow();
+  expect(mockImapInstances.length).toBe(0);
+});
+
+it("connectImap: an allowed host dials the PINNED IP with servername=hostname", async () => {
+  (assertPublicHost as jest.Mock).mockResolvedValue({ address: "93.184.216.34", hostname: "imap.example.com" });
+  await connectImap({ username: "u", password: "p", imapHost: "imap.example.com", imapPort: 993, imapSsl: true });
+  expect(mockImapInstances[0].config.host).toBe("93.184.216.34");
+  expect(mockImapInstances[0].config.tlsOptions.servername).toBe("imap.example.com");
+});
+```
+
+- [ ] **Step 2: RED** — both fail (no guard).
+
+- [ ] **Step 3: Guard `sendEmail`** (`actions/emails/messages.ts`) — add the import and pin the SMTP host:
+
+```ts
+import { assertPublicHost, HostNotAllowedError } from "@/lib/net/host-guard";
+// ...
+  if (!account) throw new Error("Account not found");
+
+  let pinned: { address: string; hostname: string };
+  try {
+    pinned = await assertPublicHost(account.smtpHost);
+  } catch (e) {
+    if (e instanceof HostNotAllowedError) throw new Error("Mail host is not allowed");
+    throw e;
+  }
+
+  const password = decrypt(account.passwordEncrypted);
+
+  const transporter = nodemailer.createTransport({
+    host: pinned.address,
+    port: account.smtpPort,
+    secure: account.smtpSsl,
+    servername: account.smtpHost,
+    auth: { user: account.username, pass: password },
+  });
+  // ...unchanged sendMail...
+```
+
+- [ ] **Step 4: Guard `connectImap`** (`inngest/lib/imap-utils.ts`) — make it async and pin the host:
+
+```ts
+import { assertPublicHost } from "@/lib/net/host-guard";
+// ...
+export async function connectImap(account: ImapAccount): Promise<Imap> {
+  const pinned = await assertPublicHost(account.imapHost);
+  return new Promise((resolve, reject) => {
+    const imap = new Imap({
+      user: account.username,
+      password: account.password,
+      host: pinned.address,
+      port: account.imapPort,
+      tls: account.imapSsl,
+      tlsOptions: { servername: account.imapHost, rejectUnauthorized: false },
+      authTimeout: 15000,
+      connTimeout: 15000,
+    });
+    imap.once("ready", () => {
+      imap.removeAllListeners("error");
+      resolve(imap);
+    });
+    imap.once("error", reject);
+    imap.connect();
+  });
+}
+```
+
+(`connectImap` already returned a `Promise<Imap>`; it is now `async` but the return type is unchanged, so callers in `inngest/functions/emails/sync-account.ts` — which `await` it — need no change. Verify `pnpm exec tsc --noEmit` after.)
+
+- [ ] **Step 5: GREEN + typecheck** — both new tests pass; existing `inngest`/`emails` suites stay green (run them); `pnpm exec tsc --noEmit` clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add actions/emails/messages.ts inngest/lib/imap-utils.ts actions/emails/__tests__/messages-ssrf.test.ts inngest/lib/__tests__/imap-utils-ssrf.test.ts
+git commit -m "feat(security): SSRF host-guard on SMTP send and background IMAP connect"
+```
+
+---
+
+### Task 5: Verification gate + sweep
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-21-ssrf-host-guard-design.md` (mark implemented)
+
+- [ ] **Step 1: Sweep for unguarded sinks** — every `new Imap(` / `createTransport(` with an attacker-controllable host must be preceded by `assertPublicHost`:
+
+```bash
+grep -rnE 'new Imap\(|createTransport\(' actions inngest lib
+```
+
+Expected sinks and their state: `actions/emails/accounts.ts` (test + discover — guarded), `inngest/lib/imap-utils.ts` (guarded), `actions/emails/messages.ts` (guarded), `lib/sendmail.ts` (`createTransport` on `process.env.EMAIL_HOST` — fixed host, out of scope, no guard needed). Any other hit with a request- or DB-supplied host is a straggler — a failed task, not a note.
+
+- [ ] **Step 2: Full suite** — `./node_modules/.bin/jest` — all pass (this branch's baseline plus the new net + ssrf suites, 0 failures).
+
+- [ ] **Step 3: Typecheck + build** — `pnpm exec tsc --noEmit && pnpm build` — both succeed.
+
+- [ ] **Step 4: Mark the spec implemented** — set `Status:` to implemented; record the sweep result and that `MAIL_ALLOW_PRIVATE_HOSTS` is the documented self-hoster escape hatch.
+
+- [ ] **Step 5: Commit (no push — final review first)**
+
+```bash
+git add docs/superpowers/specs/2026-07-21-ssrf-host-guard-design.md
+git commit -m "docs: mark SSRF host-guard workstream implemented"
+```
+
+---
+
+## Notes for the executor
+
+- The pinned IP goes in `host`; the original hostname goes in `servername` — never dial the hostname, or DNS rebinding reopens.
+- Blocked hosts in the two non-blind accounts.ts sinks must return the exact `classifyMailError({ message: "ECONNREFUSED" } as Error)` string — the same a real refusal yields — so there is no block-vs-unreachable oracle.
+- Do not touch `rejectUnauthorized` — set `servername` only.
+- `lib/sendmail.ts` uses a fixed env host and is intentionally NOT guarded.
+- Every scope/guard test must fail with the guard removed.
+- If the Agent classifier blocks subagent dispatch (as in workstreams A and B), execute inline with tsc + jest as the gate.
+```

--- a/docs/superpowers/specs/2026-07-20-crm-server-action-authz-design.md
+++ b/docs/superpowers/specs/2026-07-20-crm-server-action-authz-design.md
@@ -1,0 +1,148 @@
+# Workstream A — Object-Level Authorization for CRM Server Actions — Design
+
+**Date:** 2026-07-20
+**Status:** Approved (design), pending implementation
+**Advisory:** GHSA-qwhm-9fcm-p878 (critical) — "Pervasive Missing Authorization: Privilege Escalation + IDOR Across All API Endpoints"
+
+## Problem
+
+The `lib/authz` migration (shipped across 0.9–0.17) added object-level scoping to projects, documents, invoices, campaigns, reports, and the CRM **API routes**. It never reached the CRM **server actions**. Those actions authorize on session-existence alone and then mutate by a client-supplied id:
+
+```ts
+const session = await getSession();
+if (!session?.user?.id) return { error: "Unauthorized" };
+await prismadb.crm_Accounts.update({ where: { id }, data });   // no ownership check
+```
+
+Any authenticated `role: "user"` account can therefore take over or destroy any CRM record in the deployment. The most damaging instance rewrites ownership:
+
+```js
+await updateAccount({ id: "<victim-account-uuid>", assigned_to: "<my-user-id>" })
+```
+
+which silently transfers the record and, because `assigned_to` is in the read scope, makes it legitimately the attacker's afterward. **~42 unguarded mutating server actions** span accounts, contacts, leads, opportunities, contracts, opportunity/contract line-items, targets, target-lists, and CRM tasks. (The exact count varies ±1 on judgment calls — the session-only `convert-target` wrapper, the two non-`"use server"` `get-line-items` readers — so the implementation plan pins the definitive per-file set; this spec enumerates by group.)
+
+This is genuinely exploitable at 0.17.0. The advisory's privilege-escalation vector (changing `role`/`userStatus`) is **already fixed** — `role`/`userStatus` are `input: false` in the auth layer, and admin actions are behind `requireRole(["admin"])`. Only the IDOR/object-level half remains, and that is the entire scope of this workstream.
+
+## Scope
+
+**In scope:** adding object-level authorization to every unguarded mutating CRM server action, the missing `lib/authz` write-scope helpers they need, and regression tests.
+
+**Out of scope:** the MCP project tools (separate advisory GHSA-vq6p-3qj5-p666, workstream B); SSRF (GHSA-f5r5-f2v5-74ww, workstream C); the admin ResendCard action and IMAP hardening (already fixed on `security/quick-fixes-resend-imap`); the read-scope surface (already guarded); `restore-*` actions (already admin-gated — left unchanged); email actions (already enforce per-row `userId` ownership).
+
+## Non-goals
+
+- No new authorization *model*. The model already exists and ships on the read side; this workstream mirrors it onto writes.
+- No refactor of the read-scope helpers or the guarded actions.
+- No change to role semantics.
+
+## Architecture
+
+### The model is already defined (and already shipped on reads)
+
+`lib/authz/scopes/crm.ts` defines the scope every read already enforces:
+
+- `role: "user"` — owns a record when it is `assigned_to` them or they `createdBy`/`created_by` it (exact column per model below).
+- `role: "manager" | "admin"` — unrestricted.
+
+Because **reads are already locked this way**, a `user` cannot see records they do not own. Locking writes to the same scope therefore cannot break a workflow that works today — you cannot currently edit through the UI what you cannot see. This is the compatibility guarantee: writes converge to the read scope, no new denial surface beyond what reads already impose.
+
+### The guard pattern (replicated from `actions/crm/activities/update-activity.ts`)
+
+The canonical guarded action is the template. Authorization runs **outside** the mutation try/catch so a denial is never swallowed into the generic failure branch:
+
+```ts
+import {
+  requireAuthenticated,
+  assertCanWriteAccount,
+  AuthenticationError,
+  AuthorizationError,
+} from "@/lib/authz";
+
+let user;
+try {
+  user = await requireAuthenticated();
+} catch (e) {
+  if (e instanceof AuthenticationError) return { error: "Unauthorized" };
+  throw e;
+}
+try {
+  await assertCanWriteAccount(user, accountId);
+} catch (e) {
+  if (e instanceof AuthorizationError) return { error: "Forbidden" };
+  throw e;
+}
+// ... existing mutation try/catch, stamping updatedBy: user.id where the column exists
+```
+
+Mapping convention (already established repo-wide): `AuthenticationError → { error: "Unauthorized" }`, `AuthorizationError → { error: "Forbidden" }`.
+
+### Three guard shapes
+
+1. **Record write** — update / soft-delete / watch of a record that carries ownership columns. Assert write on the record itself.
+2. **Parent write** — create/link operations that attach a child to a parent (contact→account, line-item→opportunity/contract, target→target-list, CRM task→account/opportunity). **Assert write on the parent** (per the design decision below). Plain creates with no parent need only `requireAuthenticated` + ownership stamping, since the created row is owned by its creator.
+3. **Parent-only ownership** — line-items carry no assignee/soft-delete column; ownership is defined entirely by the parent opportunity/contract. This is also semantically correct because a line-item write recomputes the parent's totals (the action already cascades a `crm_Opportunities`/`crm_Contracts` update).
+
+### Design decisions
+
+- **Parent authorization = WRITE on the parent.** Creating or linking a child requires write access to the parent, not merely read. Consistent with line-items mutating the parent, and the write scope already admits assignees, so legitimately-assigned users are not locked out.
+- **Soft-delete = a write.** `delete-*` actions require record write, identical to update. `restore-*` actions remain admin-only (unchanged).
+- **CRM task ownership** (`crm_Accounts_Tasks`) = creator OR assignee OR parent-write, mirroring how the Projects task model grants the assignee write. This model has no soft-delete column.
+
+## Components
+
+### New `lib/authz/scopes/crm.ts` helpers (foundation)
+
+Each mirrors the existing `assertCanWriteAccount` (throws `AuthorizationError` on miss; admin/manager unrestricted). **Column names differ per model — the guard must key on the exact column, or it silently authorizes against a nonexistent field.**
+
+| Helper | Model | Ownership columns (exact) | Soft-delete filter |
+|---|---|---|---|
+| `assertCanWriteLead` | `crm_Leads` | `assigned_to`, `createdBy` (camelCase) | `deletedAt: null` |
+| `assertCanWriteOpportunity` | `crm_Opportunities` | `assigned_to`, `createdBy` | `deletedAt: null` |
+| `assertCanWriteContract` | `crm_Contracts` | `assigned_to`, `createdBy` | `deletedAt: null` |
+| `assertCanWriteTargetList` | `crm_TargetLists` | `created_by` (snake_case; **no `assigned_to`**) | `deletedAt: null` |
+| `assertCanWriteCrmTask` | `crm_Accounts_Tasks` | `createdBy` **or** `user` (assignee); **no soft-delete column** | none |
+| `assertCanWriteOpportunityLineItem` | `crm_OpportunityLineItems` | none — resolve parent `opportunityId`, delegate to `assertCanWriteOpportunity` | via parent |
+| `assertCanWriteContractLineItem` | `crm_ContractLineItems` | none — resolve parent `contractId`, delegate to `assertCanWriteContract` | via parent |
+
+Existing and reused unchanged: `assertCanWriteAccount`, `assertCanWriteContact`, `assertCanWriteTarget`, `requireAuthenticated`, `AuthenticationError`, `AuthorizationError`. All new helpers are re-exported from `lib/authz/index.ts`.
+
+The two line-item wrappers resolve the parent id from the line-item row (for update/remove/reorder) or take it from the input (for create), then delegate — so they are independently unit-testable and the parent-write rule lives in one place.
+
+### The 42 actions to guard, by group
+
+Each action gets the guard shape noted. `updatedBy: user.id` is stamped where the column exists.
+
+- **Accounts (6):** `create-account` (plain create), `update-account` (record write), `delete-account` (record write), `watch-account`/`unwatch-account` (record write), `create-task` (parent write on account/opportunity).
+- **Contacts (4):** `create-contact` (parent write on account when `accountsIDs` set, else plain create), `update-contact` (record write; may use `tryScopedUpdateContact`), `delete-contact` (record write), `unlink-opportunity` (record write on contact **and** parent write on opportunity).
+- **Leads (3):** `create-lead` (plain create), `update-lead`, `delete-lead` (record write).
+- **Opportunities (3):** `create-opportunity` (parent write on account when linked, else plain create), `update-opportunity`, `delete-opportunity` (record write). Note `update-opportunity` is also the stage-transition path — the existing approval gate stays; the authz assert is added ahead of it.
+- **Contracts (3):** `create-new-contract`, `update-contract`, `delete-contract` (record write; parent write on account when linked).
+- **Opportunity line-items (4):** `add-line-item` (parent write via input `opportunityId`), `update-line-item`/`remove-line-item`/`reorder-line-items` (parent write via resolved parent). Also guard the non-`"use server"` reader `get-line-items` with a parent read assert.
+- **Contract line-items (5):** `add-line-item`, `copy-from-opportunity` (parent write on **both** the source opportunity and destination contract), `update-line-item`, `remove-line-item`, `reorder-line-items` (parent write). Guard `get-line-items` reader too.
+- **Targets (5):** `create-target` (plain create; parent write on list if linked), `update-target`, `delete-target` (record write), `import-targets` (plain create; parent write on list if linked), `convert-target-to-deal` (record write on the source target).
+- **Target-lists (5):** `create-target-list` (plain create), `update-target-list`, `delete-target-list` (record write), `add-targets-to-list` (parent write on list), `remove-target-from-list` (parent write on list).
+- **CRM tasks (3):** `tasks/add-comment` (write on task via `assertCanWriteCrmTask`), `tasks/assign-document` (write on task), `tasks/delete-task` (write on task). (`accounts/create-task` is counted under Accounts, not here.)
+
+### Data flow / error handling
+
+Unchanged from the canonical pattern: auth resolved first, assert next (both outside the mutation try/catch), mutation last. Denials return `{ error: "Forbidden" }` / `{ error: "Unauthorized" }` — the same shape the UI already handles from guarded actions. No existence oracle: a scoped assert that misses returns Forbidden regardless of whether the id exists.
+
+## Testing
+
+Every group has **zero** authz coverage today; each fix needs net-new tests, colocated as `<action>-scope.test.ts` (existing convention).
+
+- **Helper unit tests** mirror `lib/authz/__tests__/scopes-crm-account.test.ts`: for each new helper, owner/assignee passes, non-owner `user` throws `AuthorizationError`, admin/manager passes, soft-deleted/missing row throws.
+- **Action tests** per action: owner (and assignee where applicable) succeeds; a non-owner `user` receives `{ error: "Forbidden" }` **and the Prisma mutation is not called**; admin/manager succeeds. Parent-write actions add: linking under a parent the user cannot write is Forbidden and no child is created.
+- **Every test must fail against the pre-fix code.** A test that passes with the guard removed proves nothing; this is the acceptance bar for the workstream.
+
+## Compatibility & rollout
+
+- No schema change, no migration.
+- No new denial beyond the existing read scope (argued above), so no expected regression for legitimate users.
+- Behavioral change is intentional and security-motivated: previously-succeeding cross-user writes now return Forbidden.
+- The advisory stays unpublished until this lands; on completion, publish narrowed to the CRM server-action surface, crediting the reporter, and close the duplicate `GHSA-6hv5-gx63-fqrf`.
+
+## Packaging
+
+One implementation plan, decomposed into ~10 tasks: a **foundation task** adding the seven new helpers with unit tests, then **one task per entity group** guarding that group's actions with their scope tests. Executed via subagent-driven development with review between tasks. Sequencing within the plan: helpers first (prerequisite), then accounts → contacts → opportunities → opportunity line-items → contracts → contract line-items → leads → targets → target-lists → CRM tasks (line-item groups follow their parent-entity group, which supplies the parent-write helper).

--- a/docs/superpowers/specs/2026-07-20-crm-server-action-authz-design.md
+++ b/docs/superpowers/specs/2026-07-20-crm-server-action-authz-design.md
@@ -1,8 +1,20 @@
 # Workstream A — Object-Level Authorization for CRM Server Actions — Design
 
 **Date:** 2026-07-20
-**Status:** Approved (design), pending implementation
+**Status:** Implemented 2026-07-20 (branch `security/workstream-a-crm-authz`, unpushed; pending final review)
 **Advisory:** GHSA-qwhm-9fcm-p878 (critical) — "Pervasive Missing Authorization: Privilege Escalation + IDOR Across All API Endpoints"
+
+## Implementation notes (2026-07-20)
+
+Delivered across 12 commits: 7 write-scope helpers in `lib/authz/scopes/crm.ts`, then per-entity guards on every unguarded mutating CRM server action (accounts, contacts, leads, opportunities, contracts, both line-item modules, targets, target-lists, CRM tasks). Verification gate green: 216 suites / 1195 tests (baseline 204/1096), tsc clean, `pnpm build` succeeds.
+
+Executed inline rather than via subagent dispatch: the Agent tool's permission classifier blocked the security-content dispatches (same pattern recorded for P2/P3/P4C), so the controller implemented and reviewed each task directly, with TDD (every scope test verified RED against pre-guard code) plus tsc/jest/build as the independent gate. A final whole-branch review is still owed.
+
+Residual items for the final review:
+- **Coverage-sweep catch:** `actions/crm/targets/convert-target.ts` was a mutating `"use server"` action (creates account+contact, updates target) called directly from `UpdateTargetForm`, missed by the plan's enumeration (the inventory mislabeled it "no mutation"). Guarded with `assertCanWriteTarget` + a scope test.
+- **Cross-entity inconsistency (Minor):** relink-on-update parent-write is enforced only on `update-contact` (assigned_account), not on `update-lead`/`update-opportunity`/`update-contract` when they relink an account. Worth a uniform decision.
+- **`assertCanWriteCrmTask` deviation (documented):** covers creator/assignee only; the spec also mentioned "or parent-write". Deferred as a safe narrowing (it would only widen access) to avoid an unverified relation name.
+- **Line-item read guards (`get-line-items` x2):** guarded inside the `cache()` body via `requireAuthenticated`/`assertCanRead*`; the caching-vs-auth interaction is asserted correct by reasoning, not an integration test.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-21-mcp-project-tools-authz-design.md
+++ b/docs/superpowers/specs/2026-07-21-mcp-project-tools-authz-design.md
@@ -1,8 +1,22 @@
 # Workstream B — Object-Level Authorization for MCP Project Tools — Design
 
 **Date:** 2026-07-21
-**Status:** Approved (design), pending implementation
+**Status:** Implemented 2026-07-21 (branch `security/workstream-b-mcp-authz`, unpushed; pending final review)
 **Advisory:** GHSA-vq6p-3qj5-p666 (high) — "RBAC Bypass in MCP Project Tools Allows Shared Users to Tamper with Project Boards and Tasks"
+
+## Implementation notes (2026-07-21)
+
+Delivered across 7 commits: the `assertScopeOrNotFound` adapter + first-of-its-kind `lib/mcp/__tests__/` harness, then per-tool-group guards on all 18 `projects.ts` tools, plus deletion of `userBoardWhere`. Coverage sweep: 17/18 tools reference an assert/scope; `create_board` is intentionally auth-only. Gate green: 210 suites / 1133 tests, tsc clean, `pnpm build` succeeds. 66 MCP scope tests across 8 suites (6 new + 2 pre-existing kept green).
+
+Executed inline after the first task: the Agent classifier blocked the security-content subagent dispatches (same pattern as workstream A), so the controller implemented and reviewed each task with TDD (every scope test verified RED against pre-guard code) plus tsc/jest/build as the gate. A final whole-branch review is still owed.
+
+Two implementation lessons worth recording:
+- **helpers.ts must import `AuthorizationError` from the leaf `@/lib/authz/errors`, not the barrel `@/lib/authz`** — the barrel pulls in better-auth (ESM), which breaks any jest suite transitively importing helpers (it broke the two pre-existing MCP suites until fixed in Task 1).
+- **MCP scope tests must surface the real `AuthorizationError` via `jest.requireActual("@/lib/authz/errors")`** — a fresh `class extends Error` fails the adapter's `instanceof` check, so denials would not convert to `NOT_FOUND` and the tests would falsely fail (or, worse in production-shaped code, falsely pass).
+
+Residuals (unchanged from the design, for the final review):
+- **Task-assignee write breadth:** `assertCanWriteTask` grants a `role:"user"` assignee full write; a non-owner assignee can edit a task's title/content via `update_task`, not only its status. Matches the web surface; a field whitelist is a separate cross-surface refinement.
+- **`create_board` visibility:** any authenticated user may create a `visibility:"public"` board; unchanged by this work.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-21-mcp-project-tools-authz-design.md
+++ b/docs/superpowers/specs/2026-07-21-mcp-project-tools-authz-design.md
@@ -1,0 +1,122 @@
+# Workstream B — Object-Level Authorization for MCP Project Tools — Design
+
+**Date:** 2026-07-21
+**Status:** Approved (design), pending implementation
+**Advisory:** GHSA-vq6p-3qj5-p666 (high) — "RBAC Bypass in MCP Project Tools Allows Shared Users to Tamper with Project Boards and Tasks"
+
+## Problem
+
+`lib/mcp/tools/projects.ts` exposes 18 MCP tools over the Projects module (boards, sections, tasks, comments, document links, watchers). It never imports `@/lib/authz`. Of the 18 tools, 15 are exploitable:
+
+- **Cross-tenant, no authorization at all** — `update_section`, `delete_section`, `get_task`, `update_task`, `move_task`, `delete_task`, `add_comment`, `list_comments`, `assign_document`. These do a bare `findUnique` on an attacker-supplied id and mutate/read. Any holder of any valid MCP API token (minted from the profile UI by any registered user) can tamper with **any board's** tasks, sections, comments, and document links in the deployment — not limited to boards shared with them.
+- **Share-scope → write escalation** — `update_board`, `delete_board`, `create_section` gate writes with `userBoardWhere` (a *read* predicate: owner OR `sharedWith`), so a user a board is merely shared with can rename/soft-delete it or add sections.
+- **Escalation primitive** — `watch_board` is unguarded; a `boardWatchers` row places the caller inside `boardReadScopeWhere`, so an attacker can self-grant durable **read** access to any board.
+- **Arbitrary board enumeration** — `list_tasks` applies its board scope only when neither `board` nor `section` is supplied; passing a board id dumps that board's tasks.
+
+The equivalent web/server-action surface for every one of these operations is correctly guarded (via `assertCanReadBoard`/`assertCanWriteBoard`/`assertCanReadTask`/`assertCanWriteTask` and the board scope predicates). The MCP layer simply reimplemented the operations without the guards. **That asymmetry — a guarded surface and an unguarded parallel surface reaching the same data — is the vulnerability**, and it is the same class as workstream A (unguarded CRM server actions) and the campaign-tools advisory (GHSA-c9vg-c532-ppqx) already fixed in this same file family.
+
+## Scope
+
+**In scope:** wiring every MCP project tool in `lib/mcp/tools/projects.ts` to the existing board/task authorization, a small MCP scope-adapter, deletion of the misused `userBoardWhere`, and the first MCP-tool regression tests.
+
+**Out of scope:** the authorization *model* and helpers (already exist and ship on the web surface); the MCP transport/auth layer (the dispatcher already resolves `mcpUser: AuthzUser` and passes it to handlers); the other MCP tool files (campaigns already fixed; CRM tools carry their own owner scoping); the duplicate advisory `GHSA-6hv5-gx63-fqrf` (close as a dup on completion).
+
+## Non-goals
+
+- No new authorization model or helpers. Every assert this needs already exists in `lib/authz/scopes/crm.ts` and is exported from `lib/authz`.
+- No change to the MCP dispatcher or `getMcpUser`.
+- No field-level whitelist for task-assignee writes (documented residual — see below).
+
+## Architecture
+
+### The mechanism (verified against current code)
+
+- The dispatcher (`app/api/mcp/[transport]/route.ts`) calls `tool.handler(args, mcpUser.id, mcpUser)`. `mcpUser` is `McpUser = AuthzUser` (`{ id, role }`, role resolved from the DB in `lib/mcp/auth.ts`). Handlers currently take `(args, userId)` and ignore the third arg.
+- The dispatcher maps thrown errors to MCP codes by **message string**: `"NOT_FOUND"` → `NOT_FOUND`, `"FORBIDDEN"` → `FORBIDDEN`, `"Unauthorized"` → `UNAUTHORIZED`, else `INTERNAL_ERROR`. `notFound(entity)` (`lib/mcp/helpers.ts`) throws `Error("NOT_FOUND")`.
+- The board/task asserts throw `AuthorizationError` (message `"Forbidden"`, not the exact `"FORBIDDEN"` the dispatcher matches), so an un-adapted assert would surface as `INTERNAL_ERROR`.
+
+### The scope adapter (new, `lib/mcp/helpers.ts`)
+
+One small helper runs an assert and converts a denial into `notFound` — surfacing `NOT_FOUND` (no existence oracle: a non-owner cannot distinguish "forbidden" from "does not exist") and matching `campaigns.ts`'s existing behavior:
+
+```ts
+import { AuthorizationError } from "@/lib/authz";
+
+// Run an object-level authorization assert; convert a denial into a NOT_FOUND
+// so callers do not learn whether the id exists. Non-authorization errors propagate.
+export async function assertScopeOrNotFound(
+  assert: () => Promise<void>,
+  entity: string,
+): Promise<void> {
+  try {
+    await assert();
+  } catch (e) {
+    if (e instanceof AuthorizationError) notFound(entity); // throws Error("NOT_FOUND")
+    throw e;
+  }
+}
+```
+
+### Enforcement model (all asserts exist; verified in `lib/authz/scopes/crm.ts`)
+
+- `boardReadScopeWhere(user)` — admin/manager: `deletedAt:null`; user: owner OR `sharedWith` OR `visibility:"public"` OR watcher.
+- `boardWriteScopeWhere(user)` — admin/manager: `deletedAt:null`; user: owner (`user:user.id`) only.
+- `assertCanReadBoard` / `assertCanWriteBoard(user, boardId)` — throw `AuthorizationError` on miss.
+- `assertCanReadTask` / `assertCanWriteTask(user, taskId)` — resolve the parent board via `assigned_section.board_relation`, then apply the board scope; `assertCanWriteTask` additionally allows a `role:"user"` task assignee (`task.user === user.id`).
+
+### Per-tool guard mapping
+
+Handlers become `async handler(args, _userId: string, user: AuthzUser)`. Stamp `user.id` where `userId` was used.
+
+| Tool | Op | Guard |
+|---|---|---|
+| `projects_list_boards` | read/list | query `where: boardReadScopeWhere(user)` (replaces `userBoardWhere`; restores public/watched access) |
+| `projects_get_board` | read | `findFirst({ where: { id, ...boardReadScopeWhere(user) }})` → `notFound("Board")` |
+| `projects_create_board` | create | auth only (row owned by creator); stamp `user.id` |
+| `projects_update_board` | write | `assertScopeOrNotFound(() => assertCanWriteBoard(user, args.id), "Board")` |
+| `projects_delete_board` | write | `assertScopeOrNotFound(() => assertCanWriteBoard(user, args.id), "Board")` |
+| `projects_create_section` | write parent | `assertScopeOrNotFound(() => assertCanWriteBoard(user, args.board), "Board")` |
+| `projects_update_section` | write | resolve `sections.findUnique(args.id).board` → `assertCanWriteBoard(user, board)` (missing section → `notFound("Section")`) |
+| `projects_delete_section` | write | resolve section→board → `assertCanWriteBoard(user, board)` |
+| `projects_list_tasks` | read/list | **always** set `where.assigned_section = { board_relation: boardReadScopeWhere(user) }`, then AND the optional `board`/`section`/`user`/`status` filters into the same `where` (closes the supplied-`board`/`section` bypass) |
+| `projects_get_task` | read | `assertScopeOrNotFound(() => assertCanReadTask(user, args.id), "Task")` then fetch |
+| `projects_create_task` | write parent | resolve `sections.findUnique(args.section).board` → `assertCanWriteBoard(user, board)` (missing section → `notFound("Section")`) |
+| `projects_update_task` | write | `assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task")` |
+| `projects_move_task` | write both | `assertCanWriteTask(user, args.id)` (source) **and** resolve `sections.findUnique(args.section).board` → `assertCanWriteBoard(user, board)` (destination); both via the adapter |
+| `projects_delete_task` | write | `assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task")` |
+| `projects_add_comment` | write task | `assertScopeOrNotFound(() => assertCanWriteTask(user, args.task), "Task")` |
+| `projects_list_comments` | read task | `assertScopeOrNotFound(() => assertCanReadTask(user, args.task), "Task")` then list |
+| `projects_assign_document` | write task + read doc | `assertCanWriteTask(user, args.task_id)` **and** `assertCanReadDocument(user, args.document_id)`, both via the adapter |
+| `projects_watch_board` | read | `assertScopeOrNotFound(() => assertCanReadBoard(user, args.board_id), "Board")` |
+
+**`watch_board` is a read gate, deliberately.** Board `watchers` sit only in `boardReadScopeWhere`, not the write scope, so watching a board the caller can already read grants nothing new; the only risk is self-granting read to a board they cannot see, which a read gate prevents. (This differs from workstream A's account-watch, a *write* gate, because account watchers are inside the account *write* OR-clause.)
+
+**Delete `userBoardWhere`** (lines 13–21) after `list_boards`/`get_board` move to `boardReadScopeWhere`, so the misused read-as-write predicate cannot be reused.
+
+## Data flow / error handling
+
+Each single-record write/read runs its assert first (through the adapter, so a denial → `NOT_FOUND`), then performs the operation. Lists apply the board read scope in the query `where` so out-of-scope rows are never returned. `create_board` needs no assert — the row is owned by its creator. Existing `conflict`/`notFound` behavior for empty-section-delete and missing rows is preserved.
+
+## Testing
+
+No MCP tool test exists today; this workstream introduces the first harness under `lib/mcp/__tests__/`. A tool is invoked by locating it in `projectTools` by `name` and calling its `handler(args, user.id, user)` with `@/lib/prisma` and `@/lib/authz` mocked.
+
+- **Adapter unit test:** `assertScopeOrNotFound` converts a thrown `AuthorizationError` into `Error("NOT_FOUND")` and lets a passing assert through and non-auth errors propagate.
+- **Per-tool tests:** for each guarded tool — a caller the assert rejects (mock the relevant `assertCan*` to throw `AuthorizationError`) gets `NOT_FOUND` **and the Prisma mutation is not called**; an authorized caller performs the operation with the expected id; the assert is invoked with the right id/parent. Dual-guard tools (`move_task`, `assign_document`) assert that a rejection from **either** side blocks the operation. `list_tasks` asserts the board read scope is always present in the query `where`.
+- **Every test must fail against the pre-fix code** — the acceptance bar.
+
+## Compatibility & rollout
+
+- No schema change, no migration, no dispatcher change.
+- `list_boards`/`get_board` become *more* permissive in one correct direction (public + watched boards now visible, which `userBoardWhere` wrongly hid) and correctly scoped in the dangerous direction.
+- Behavioral change is intentional and security-motivated: previously-succeeding cross-tenant and share-scope writes now return `NOT_FOUND`.
+- The advisory stays unpublished until this lands; on completion, publish and close the duplicate `GHSA-6hv5-gx63-fqrf`.
+
+## Residual items (for the final review, not this scope)
+
+- **Task-assignee write breadth:** `assertCanWriteTask` allows a `role:"user"` assignee full write (the helper defers field-whitelisting to the caller). This matches the web surface, but means a non-owner assignee can edit a task's title/content via `update_task`, not only its status. A field whitelist for the assignee-bypass path is a separate, cross-surface refinement.
+- **`create_board` visibility:** any authenticated user may create a board with `visibility:"public"`; unchanged by this work, noted for completeness.
+
+## Packaging
+
+One implementation plan: a foundation task (the `assertScopeOrNotFound` adapter + its unit test + the first MCP test harness), then one task per tool-group — boards, sections, tasks, comments+documents, watch (with `list_tasks` folded into tasks) — each guarding its tools with per-tool tests, then a verification task (full suite, tsc, build, coverage sweep confirming no `projects_*` handler still lacks an assert, and deletion of `userBoardWhere`). Executed via subagent-driven development where possible; inline fallback if the Agent classifier blocks the security content (as it did in workstream A).

--- a/docs/superpowers/specs/2026-07-21-ssrf-host-guard-design.md
+++ b/docs/superpowers/specs/2026-07-21-ssrf-host-guard-design.md
@@ -1,0 +1,100 @@
+# Workstream C — SSRF Host-Guarding for IMAP/SMTP Sinks — Design
+
+**Date:** 2026-07-21
+**Status:** Approved (design), pending implementation
+**Advisory:** GHSA-f5r5-f2v5-74ww (critical) — "Server-Side Request Forgery (SSRF) in nextcrm-app"
+
+## Problem
+
+The advisory's originally-reported path (a Rossum integration that fetched an attacker-supplied URL with a bearer token) was removed with the invoice module in `6cd94a3a`, so it no longer exists. But the SSRF *class* is still live in the IMAP/SMTP surface: an authenticated user controls the host and port of server-side mail connections, letting them make the server open TCP connections to internal hosts (its own Postgres, MinIO, Inngest, cloud metadata, other private-network services).
+
+Four sink call-sites, all with an attacker-controllable host:
+
+- `actions/emails/accounts.ts` — `testEmailConnection` and `listImapFolders` take `imapHost`/`imapPort` **directly from the request body** and are **non-blind** (they return the connection outcome to the browser), synchronous server actions. This is a live internal port scanner for any authenticated user. `createEmailAccount` stores the same attacker-supplied host for later use.
+- `actions/emails/messages.ts` — `sendEmail` builds a nodemailer transport from a **stored** `emailAccount.smtpHost` (the user set it at account creation).
+- `inngest/lib/imap-utils.ts` — `connectImap` opens `new Imap({ host: account.imapHost, ... })` from a stored row, called by the background sync job (blind, but still a real SSRF primitive against internal hosts).
+
+The quick-fixes branch (this branch's parent) already narrowed the accounts.ts oracle: an IMAP/SMTP **port allow-list** (`lib/email/imap-safety.ts`: `isAllowedImapPort`/`isAllowedSmtpPort`) and `classifyMailError` (collapses raw driver errors to a fixed set of generic messages, so protocol/banner text no longer leaks). That file's own header states host validation is "the complete fix and is tracked separately" — this workstream is that fix.
+
+There is no host/IP validation, no DNS-rebinding protection, and no shared network guard anywhere in the codebase today.
+
+## Scope
+
+**In scope:** a central `lib/net/` host-guard (reject non-public hosts, with DNS-rebinding protection via IP-pinning) applied to all four IMAP/SMTP sink call-sites, plus store-time host validation in `createEmailAccount`.
+
+**Out of scope (per decision):** `tls.rejectUnauthorized: false` (a MITM/cert-trust weakness, not this SSRF advisory; its proper fix needs a per-account "allow self-signed" flag — schema + UI — deferred to a separate follow-up). The port allow-list and `classifyMailError` are already done on the parent branch and are reused, not re-implemented. Fixed-host sinks are out of scope: `lib/sendmail.ts` (env `EMAIL_HOST`), and the `fetch` calls to OpenAI / ECB / GitHub (hardcoded/env hosts, not IMAP/SMTP).
+
+## Non-goals
+
+- No generic `safe-fetch` HTTP wrapper. The current HTTP `fetch` sinks all use hardcoded/env hosts; a wrapper would harden nothing today and is preventative scope for later.
+- No change to the mail drivers, the email schema, or the sync job's structure.
+
+## Architecture
+
+### Why IP-pinning (the DNS-rebinding problem)
+
+The naive guard — resolve the hostname, check the IP is public, then hand the **hostname** to the driver — is defeated by DNS rebinding: the driver re-resolves at connect time (TOCTOU), and an attacker's DNS can return a public IP on the first lookup (passing the check) and `169.254.169.254` / `127.0.0.1` on the second (the actual connect). The fix is to **resolve once, validate every resolved address, then connect to the exact validated IP** — never the hostname. Both installed drivers support this: `imap` v0.8.19 and `nodemailer` v9.0.1 accept a pre-resolved IP as `host` plus the original hostname as `servername`/`tlsOptions.servername` for correct TLS SNI.
+
+### Components
+
+**`lib/net/ip-rules.ts`** — pure IP classification, the security crux, exhaustively unit-tested.
+
+```ts
+// Returns true if the address is NOT a public unicast address, i.e. must be
+// refused: loopback, private, link-local, unique-local, CGNAT, unspecified,
+// broadcast/multicast/reserved, and IPv4-mapped IPv6 wrapping any of the above.
+export function isDisallowedAddress(ip: string): boolean;
+```
+
+Implementation uses **`ipaddr.js`** (a small, zero-dependency, pure-JS, widely-vetted library; added as a direct dependency — no native build step, so no pnpm-builds friction). Classification via `ipaddr.parse(ip).range()`: allow only `"unicast"`; refuse `loopback`/`private`/`linkLocal`/`uniqueLocal`/`carrierGradeNat`/`unspecified`/`broadcast`/`multicast`/`reserved`. For an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`), unwrap to the embedded IPv4 and classify that. If `ipaddr.js` cannot be added cleanly, hand-roll the same ranges — the exhaustive test table is the safety net either way.
+
+**`lib/net/host-guard.ts`** — the async guard.
+
+```ts
+export class HostNotAllowedError extends Error {}
+
+// Resolve `host` and return a validated, pinned address to dial. If `host` is an
+// IP literal, validate it directly. Otherwise dns.lookup(host, { all: true }) and
+// validate EVERY resolved address; if any is disallowed, throw HostNotAllowedError.
+// Env escape hatch: MAIL_ALLOW_PRIVATE_HOSTS === "true" skips validation entirely
+// (default off) — for self-hosters whose mail server is on a private IP.
+export async function assertPublicHost(
+  host: string,
+): Promise<{ address: string; hostname: string }>;
+```
+
+- IP literal (`net.isIP(host) !== 0`): if `isDisallowedAddress(host)` → throw; else return `{ address: host, hostname: host }`.
+- Hostname: `await dns.lookup(host, { all: true, verbatim: true })`. Empty result → throw. If **any** returned address is disallowed → throw. Return `{ address: <first validated address>, hostname: host }` — the caller dials `address` (the pinned IP), keeping `hostname` for TLS SNI.
+- `MAIL_ALLOW_PRIVATE_HOSTS === "true"` → return `{ address: host, hostname: host }` without validation.
+
+### Sink integration
+
+Each sink calls `assertPublicHost` before connecting and dials the pinned IP with `servername` set to the original hostname.
+
+- **`testEmailConnection` / `listImapFolders`** (`accounts.ts`): after the existing `isAllowedImapPort` check, `const pinned = await assertPublicHost(input.imapHost)` inside a try/catch; on `HostNotAllowedError`, return `{ ok: false, error: classifyMailError(...) }` — the **same generic "could not connect"** a real failure yields, so a blocked internal host is indistinguishable from an unreachable one (no oracle). Then `new Imap({ host: pinned.address, port: input.imapPort, tls: input.imapSsl, tlsOptions: { servername: pinned.hostname, rejectUnauthorized: false }, ... })`.
+- **`createEmailAccount`** (`accounts.ts`): after the port checks, `await assertPublicHost(input.imapHost)` and `assertPublicHost(input.smtpHost)`; on failure, throw the existing validation-style error. Store-time defense-in-depth — a private host cannot be saved, so the stored-host sinks (`sendEmail`, `connectImap`) are protected at the source in addition to their own connect-time guard.
+- **`sendEmail`** (`messages.ts`): after resolving the `emailAccount` row, `const pinned = await assertPublicHost(account.smtpHost)` → `nodemailer.createTransport({ host: pinned.address, port: account.smtpPort, secure: account.smtpSsl, servername: account.smtpHost, auth: {...} })`.
+- **`connectImap`** (`imap-utils.ts`): `const pinned = await assertPublicHost(account.imapHost)` → `new Imap({ host: pinned.address, ..., tlsOptions: { servername: account.imapHost, rejectUnauthorized: false } })`. Background job; a `HostNotAllowedError` fails the sync for that account (recorded like any connect failure), not reflected to a caller.
+
+`servername` is set for TLS-SNI correctness now (so that when `rejectUnauthorized` is fixed later the SNI is already right); with `rejectUnauthorized: false` still in place it has no functional effect but is correct.
+
+## Data flow / error handling
+
+Guard runs first; a disallowed host means no TCP connection is ever attempted. Failures surface as: the same generic classified message for the non-blind accounts.ts sinks (no oracle), a stored-value rejection for `createEmailAccount`, and a normal sync failure for the background `connectImap`. `assertPublicHost` never returns a hostname as the dial target — always the validated IP.
+
+## Testing
+
+- **`ip-rules` unit tests** — a large allowed/disallowed table: disallow `127.0.0.1`, `10.0.0.1`, `172.16.0.1`, `192.168.1.1`, `169.254.169.254`, `100.64.0.1`, `0.0.0.0`, `255.255.255.255`, `::1`, `fe80::1`, `fc00::1`, `fd00::1`, `::`, `::ffff:127.0.0.1`, `::ffff:10.0.0.1`; allow `8.8.8.8`, `1.1.1.1`, `93.184.216.34`, a public IPv6 (`2606:4700:4700::1111`). Garbage input is treated as disallowed (fail closed).
+- **`host-guard` unit tests** (mock `node:dns/promises` `lookup`): a hostname resolving to a public IP returns that pinned IP; resolving to a private IP throws `HostNotAllowedError`; **mixed** results (one public + one private) throw (all must pass); an empty resolution throws; a public IP literal returns itself; a private IP literal throws; `MAIL_ALLOW_PRIVATE_HOSTS=true` bypasses. Fail-closed on lookup error.
+- **Sink tests** — for each sink: when `assertPublicHost` throws, the driver constructor (`new Imap` / `createTransport`) is **not** called and the sink returns/raises the expected non-leaking result; when it resolves, the driver receives `host: <pinned IP>` (not the hostname) and `servername: <hostname>`. The accounts.ts sinks additionally assert a blocked host yields the same classified message as an unreachable host.
+- **Every test must fail against the pre-guard code** — the acceptance bar.
+
+## Compatibility & rollout
+
+- One new dependency (`ipaddr.js`, pure JS) and two new files; no schema change, no migration.
+- **Behavioral change:** connecting to or storing a mail account on a loopback/private/link-local host now fails. Self-hosters with an internal mail server set `MAIL_ALLOW_PRIVATE_HOSTS=true` (documented). This is the intended, security-motivated change.
+- The advisory stays unpublished until this lands; on completion its affected range should be corrected (the reported Rossum path was removed in `6cd94a3a`, so "all versions" is wrong) and it can be published narrowed to the IMAP/SMTP surface.
+
+## Packaging
+
+One implementation plan, five tasks: (1) `lib/net/ip-rules.ts` + `ipaddr.js` dependency + exhaustive tests; (2) `lib/net/host-guard.ts` + tests (dns mocked); (3) the three `accounts.ts` sinks (test/discover/create); (4) `messages.ts` `sendEmail` + `imap-utils.ts` `connectImap`; (5) verification (full suite, tsc, build, and a sweep confirming no `new Imap(`/`createTransport(` with an attacker-controllable host remains unguarded). Executed via subagent-driven development where possible; inline fallback if the Agent classifier blocks the security content (as in workstreams A and B).

--- a/docs/superpowers/specs/2026-07-21-ssrf-host-guard-design.md
+++ b/docs/superpowers/specs/2026-07-21-ssrf-host-guard-design.md
@@ -1,8 +1,20 @@
 # Workstream C — SSRF Host-Guarding for IMAP/SMTP Sinks — Design
 
 **Date:** 2026-07-21
-**Status:** Approved (design), pending implementation
+**Status:** Implemented 2026-07-21 (branch `security/workstream-c-ssrf-hostguard`, forked from `security/quick-fixes-resend-imap`, unpushed; pending final review)
 **Advisory:** GHSA-f5r5-f2v5-74ww (critical) — "Server-Side Request Forgery (SSRF) in nextcrm-app"
+
+## Implementation notes (2026-07-21)
+
+Delivered across 5 commits: `lib/net/ip-rules.ts` (+ `ipaddr.js` 2.4.0), `lib/net/host-guard.ts` (`assertPublicHost`), and host-guarding on all four IMAP/SMTP sink call-sites. Gate green: 211 suites / 1159 tests, tsc clean, `pnpm build` succeeds. Coverage sweep: every `new Imap(`/`createTransport(` with an attacker-controllable host (`accounts.ts` test/discover, `messages.ts` send, `imap-utils.ts` connect) calls `assertPublicHost`; `lib/sendmail.ts` uses `process.env.EMAIL_HOST` (fixed) and is correctly unguarded.
+
+Executed inline (the Agent classifier blocked the security-content dispatches from task 1, as in workstreams A and B), with TDD (every guard test verified RED against pre-guard code) plus tsc/jest/build as the gate. A final whole-branch review is still owed.
+
+Two implementation notes:
+- **`203.0.113.9` (TEST-NET-3) is `reserved`, not public** — `ipaddr.js` correctly refuses RFC 5737 documentation ranges; the test table was corrected to reflect that the guard refuses reserved/documentation space too.
+- **nodemailer `servername`** is added via a typed spread (`...({ servername } as { servername: string })`) so the object literal keeps only well-known SMTP props and TS resolves the SMTP overload — a direct top-level `servername` tripped an excess-property/wrong-overload error that also broke `info.messageId`.
+
+`MAIL_ALLOW_PRIVATE_HOSTS=true` is the documented escape hatch for self-hosters whose mail server is on a private IP. TLS `rejectUnauthorized` deferred, as designed.
 
 ## Problem
 

--- a/inngest/lib/__tests__/imap-utils-ssrf.test.ts
+++ b/inngest/lib/__tests__/imap-utils-ssrf.test.ts
@@ -1,0 +1,47 @@
+// SSRF host-guard regression tests for connectImap (background IMAP sink).
+const mockImapInstances: any[] = [];
+jest.mock("imap", () => {
+  const ctor = jest.fn().mockImplementation((config: any) => {
+    const handlers: Record<string, (...a: any[]) => void> = {};
+    const inst = {
+      config,
+      once: (ev: string, cb: any) => { handlers[ev] = cb; return inst; },
+      removeAllListeners: () => {},
+      connect: () => { queueMicrotask(() => handlers["ready"]?.()); },
+      end: () => {},
+    };
+    mockImapInstances.push(inst);
+    return inst;
+  });
+  return { __esModule: true, default: ctor };
+});
+jest.mock("mailparser", () => ({ simpleParser: jest.fn() }));
+jest.mock("@/lib/net/host-guard", () => ({
+  assertPublicHost: jest.fn(),
+  HostNotAllowedError: class HostNotAllowedError extends Error {},
+}));
+
+import { assertPublicHost, HostNotAllowedError } from "@/lib/net/host-guard";
+import { connectImap } from "@/inngest/lib/imap-utils";
+
+const guard = assertPublicHost as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockImapInstances.length = 0;
+});
+
+it("a blocked host is not dialled", async () => {
+  guard.mockRejectedValue(new HostNotAllowedError());
+  await expect(
+    connectImap({ username: "u", password: "p", imapHost: "10.0.0.5", imapPort: 993, imapSsl: true })
+  ).rejects.toThrow();
+  expect(mockImapInstances.length).toBe(0);
+});
+
+it("an allowed host dials the PINNED IP with servername=hostname", async () => {
+  guard.mockResolvedValue({ address: "93.184.216.34", hostname: "imap.example.com" });
+  await connectImap({ username: "u", password: "p", imapHost: "imap.example.com", imapPort: 993, imapSsl: true });
+  expect(mockImapInstances[0].config.host).toBe("93.184.216.34");
+  expect(mockImapInstances[0].config.tlsOptions.servername).toBe("imap.example.com");
+});

--- a/inngest/lib/imap-utils.ts
+++ b/inngest/lib/imap-utils.ts
@@ -1,5 +1,6 @@
 import Imap from "imap";
 import { simpleParser } from "mailparser";
+import { assertPublicHost } from "@/lib/net/host-guard";
 
 export type ImapAccount = {
   username: string;
@@ -21,15 +22,18 @@ export type ParsedHeader = {
 };
 
 /** Open a connection and resolve when ready. Caller is responsible for imap.end(). */
-export function connectImap(account: ImapAccount): Promise<Imap> {
+export async function connectImap(account: ImapAccount): Promise<Imap> {
+  const pinned = await assertPublicHost(account.imapHost);
   return new Promise((resolve, reject) => {
     const imap = new Imap({
       user: account.username,
       password: account.password,
-      host: account.imapHost,
+      host: pinned.address,
       port: account.imapPort,
       tls: account.imapSsl,
-      tlsOptions: { rejectUnauthorized: false },
+      // Dial the validated IP; keep the hostname for TLS SNI. (rejectUnauthorized
+      // left as-is — TLS verification is a separate workstream.)
+      tlsOptions: { servername: account.imapHost, rejectUnauthorized: false },
       authTimeout: 15000,
       connTimeout: 15000,
     });

--- a/lib/authz/__tests__/scopes-crm-write.test.ts
+++ b/lib/authz/__tests__/scopes-crm-write.test.ts
@@ -1,0 +1,161 @@
+import { AuthorizationError } from "../errors";
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Leads: { findFirst: jest.fn() },
+    crm_Opportunities: { findFirst: jest.fn() },
+    crm_Contracts: { findFirst: jest.fn() },
+    crm_TargetLists: { findFirst: jest.fn() },
+    crm_Accounts_Tasks: { findFirst: jest.fn() },
+    crm_OpportunityLineItems: { findUnique: jest.fn() },
+    crm_ContractLineItems: { findUnique: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import {
+  assertCanWriteLead,
+  assertCanWriteOpportunity,
+  assertCanWriteContract,
+  assertCanWriteTargetList,
+  assertCanWriteCrmTask,
+  assertCanWriteOpportunityLineItem,
+  assertCanWriteContractLineItem,
+} from "../scopes/crm";
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("assertCanWriteLead / Opportunity / Contract (assigned_to+createdBy, deletedAt)", () => {
+  const cases = [
+    ["Leads", assertCanWriteLead, prismadb.crm_Leads.findFirst as jest.Mock],
+    ["Opportunities", assertCanWriteOpportunity, prismadb.crm_Opportunities.findFirst as jest.Mock],
+    ["Contracts", assertCanWriteContract, prismadb.crm_Contracts.findFirst as jest.Mock],
+  ] as const;
+
+  for (const [label, assertFn, find] of cases) {
+    it(`${label}: admin gets a bare id+deletedAt where`, async () => {
+      find.mockResolvedValue({ id: "r1" });
+      await assertFn({ id: "u", role: "admin" }, "r1");
+      expect(find).toHaveBeenCalledWith({
+        where: { id: "r1", deletedAt: null },
+        select: { id: true },
+      });
+    });
+
+    it(`${label}: user is scoped to assigned_to/createdBy`, async () => {
+      find.mockResolvedValue({ id: "r1" });
+      await assertFn({ id: "u3", role: "user" }, "r1");
+      const arg = find.mock.calls[0][0]!;
+      expect(arg.where).toMatchObject({
+        id: "r1",
+        deletedAt: null,
+        OR: [{ assigned_to: "u3" }, { createdBy: "u3" }],
+      });
+    });
+
+    it(`${label}: throws when not in scope`, async () => {
+      find.mockResolvedValue(null);
+      await expect(assertFn({ id: "u3", role: "user" }, "r1")).rejects.toBeInstanceOf(
+        AuthorizationError
+      );
+    });
+  }
+});
+
+describe("assertCanWriteTargetList (created_by only, no assigned_to)", () => {
+  const find = prismadb.crm_TargetLists.findFirst as jest.Mock;
+
+  it("admin: bare id+deletedAt", async () => {
+    find.mockResolvedValue({ id: "l1" });
+    await assertCanWriteTargetList({ id: "u", role: "admin" }, "l1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "l1", deletedAt: null },
+      select: { id: true },
+    });
+  });
+
+  it("user: scoped to created_by (no assigned_to clause)", async () => {
+    find.mockResolvedValue({ id: "l1" });
+    await assertCanWriteTargetList({ id: "u3", role: "user" }, "l1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "l1", deletedAt: null, created_by: "u3" },
+      select: { id: true },
+    });
+  });
+
+  it("throws when not in scope", async () => {
+    find.mockResolvedValue(null);
+    await expect(
+      assertCanWriteTargetList({ id: "u3", role: "user" }, "l1")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("assertCanWriteCrmTask (createdBy OR user assignee, no deletedAt)", () => {
+  const find = prismadb.crm_Accounts_Tasks.findFirst as jest.Mock;
+
+  it("admin: bare id where (no deletedAt column on this model)", async () => {
+    find.mockResolvedValue({ id: "t1" });
+    await assertCanWriteCrmTask({ id: "u", role: "manager" }, "t1");
+    expect(find).toHaveBeenCalledWith({ where: { id: "t1" }, select: { id: true } });
+  });
+
+  it("user: scoped to creator or assignee", async () => {
+    find.mockResolvedValue({ id: "t1" });
+    await assertCanWriteCrmTask({ id: "u3", role: "user" }, "t1");
+    expect(find).toHaveBeenCalledWith({
+      where: { id: "t1", OR: [{ createdBy: "u3" }, { user: "u3" }] },
+      select: { id: true },
+    });
+  });
+
+  it("throws when not creator/assignee", async () => {
+    find.mockResolvedValue(null);
+    await expect(
+      assertCanWriteCrmTask({ id: "u3", role: "user" }, "t1")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});
+
+describe("line-item wrappers delegate to the parent write assert", () => {
+  it("opportunity line-item: resolves parent then asserts opportunity write", async () => {
+    (prismadb.crm_OpportunityLineItems.findUnique as jest.Mock).mockResolvedValue({
+      opportunityId: "opp1",
+    });
+    (prismadb.crm_Opportunities.findFirst as jest.Mock).mockResolvedValue({ id: "opp1" });
+    await assertCanWriteOpportunityLineItem({ id: "u3", role: "user" }, "li1");
+    expect(prismadb.crm_OpportunityLineItems.findUnique).toHaveBeenCalledWith({
+      where: { id: "li1" },
+      select: { opportunityId: true },
+    });
+    // parent write assert ran against the resolved opportunityId
+    expect(prismadb.crm_Opportunities.findFirst).toHaveBeenCalled();
+  });
+
+  it("opportunity line-item: throws when the line item does not exist", async () => {
+    (prismadb.crm_OpportunityLineItems.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(
+      assertCanWriteOpportunityLineItem({ id: "u3", role: "user" }, "missing")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  it("contract line-item: resolves parent then asserts contract write", async () => {
+    (prismadb.crm_ContractLineItems.findUnique as jest.Mock).mockResolvedValue({
+      contractId: "ct1",
+    });
+    (prismadb.crm_Contracts.findFirst as jest.Mock).mockResolvedValue({ id: "ct1" });
+    await assertCanWriteContractLineItem({ id: "u3", role: "user" }, "cli1");
+    expect(prismadb.crm_ContractLineItems.findUnique).toHaveBeenCalledWith({
+      where: { id: "cli1" },
+      select: { contractId: true },
+    });
+    expect(prismadb.crm_Contracts.findFirst).toHaveBeenCalled();
+  });
+
+  it("contract line-item: throws when the line item does not exist", async () => {
+    (prismadb.crm_ContractLineItems.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(
+      assertCanWriteContractLineItem({ id: "u3", role: "user" }, "missing")
+    ).rejects.toBeInstanceOf(AuthorizationError);
+  });
+});

--- a/lib/authz/index.ts
+++ b/lib/authz/index.ts
@@ -54,6 +54,15 @@ export {
   targetListReadScopeWhere,
   assertCanReadTargetList,
 } from "./scopes/crm";
+export {
+  assertCanWriteLead,
+  assertCanWriteOpportunity,
+  assertCanWriteContract,
+  assertCanWriteTargetList,
+  assertCanWriteCrmTask,
+  assertCanWriteOpportunityLineItem,
+  assertCanWriteContractLineItem,
+} from "./scopes/crm";
 export { assertCanReadActivityForEntity, assertCanWriteActivity } from "./scopes/crm";
 export {
   campaignReadScopeWhere,

--- a/lib/authz/scopes/crm.ts
+++ b/lib/authz/scopes/crm.ts
@@ -391,6 +391,101 @@ export async function assertCanReadTargetList(
   if (!row) throw new AuthorizationError();
 }
 
+// ── Write-scope asserts (Workstream A — GHSA-qwhm-9fcm-p878) ─────────────────
+// Mirror assertCanWriteAccount: admin/manager unrestricted; user scoped to the
+// model's ownership columns. Exact columns differ per model — see each helper.
+
+export async function assertCanWriteLead(
+  user: AuthzUser,
+  leadId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: leadId, deletedAt: null }
+      : { id: leadId, deletedAt: null, OR: [{ assigned_to: user.id }, { createdBy: user.id }] };
+  const row = await prismadb.crm_Leads.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteOpportunity(
+  user: AuthzUser,
+  opportunityId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: opportunityId, deletedAt: null }
+      : { id: opportunityId, deletedAt: null, OR: [{ assigned_to: user.id }, { createdBy: user.id }] };
+  const row = await prismadb.crm_Opportunities.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+export async function assertCanWriteContract(
+  user: AuthzUser,
+  contractId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: contractId, deletedAt: null }
+      : { id: contractId, deletedAt: null, OR: [{ assigned_to: user.id }, { createdBy: user.id }] };
+  const row = await prismadb.crm_Contracts.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+// crm_TargetLists has NO assigned_to — ownership is created_by only.
+export async function assertCanWriteTargetList(
+  user: AuthzUser,
+  listId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: listId, deletedAt: null }
+      : { id: listId, deletedAt: null, created_by: user.id };
+  const row = await prismadb.crm_TargetLists.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+// crm_Accounts_Tasks has NO deletedAt (hard delete). Ownership = creator or assignee.
+// NOTE: this covers creator/assignee. Broadening to parent-account writers is a
+// deliberate, safe narrowing deferred here (it would only widen access).
+export async function assertCanWriteCrmTask(
+  user: AuthzUser,
+  taskId: string,
+): Promise<void> {
+  const where =
+    user.role === "admin" || user.role === "manager"
+      ? { id: taskId }
+      : { id: taskId, OR: [{ createdBy: user.id }, { user: user.id }] };
+  const row = await prismadb.crm_Accounts_Tasks.findFirst({ where, select: { id: true } });
+  if (!row) throw new AuthorizationError();
+}
+
+// Line items carry no ownership column; authority is the parent opportunity/contract
+// (correct because a line-item write recomputes the parent's totals). Resolve the
+// parent id from the line-item row, then delegate to the parent write assert.
+export async function assertCanWriteOpportunityLineItem(
+  user: AuthzUser,
+  lineItemId: string,
+): Promise<void> {
+  const row = await prismadb.crm_OpportunityLineItems.findUnique({
+    where: { id: lineItemId },
+    select: { opportunityId: true },
+  });
+  if (!row) throw new AuthorizationError();
+  await assertCanWriteOpportunity(user, row.opportunityId);
+}
+
+export async function assertCanWriteContractLineItem(
+  user: AuthzUser,
+  lineItemId: string,
+): Promise<void> {
+  const row = await prismadb.crm_ContractLineItems.findUnique({
+    where: { id: lineItemId },
+    select: { contractId: true },
+  });
+  if (!row) throw new AuthorizationError();
+  await assertCanWriteContract(user, row.contractId);
+}
+
 // ---------------------------------------------------------------------------
 // E3.T1: Document read/write scope helpers (linked-entity aware).
 // Documents have multi-faceted ownership: created_by_user, createdBy (legacy),

--- a/lib/email/imap-safety.ts
+++ b/lib/email/imap-safety.ts
@@ -1,0 +1,76 @@
+// Safety helpers for user-supplied IMAP/SMTP connection details.
+//
+// Motivation (GHSA-f5r5-f2v5-74ww follow-up): the email-account actions let any
+// authenticated user open a TCP connection to an arbitrary host:port and, on
+// failure, reflected the raw driver error back to the caller. That turned the
+// "test connection" / "discover folders" features into a non-blind internal
+// port scanner (Postgres 5432, MinIO 9000/9001, Inngest 8288, cloud metadata,
+// …) and a service-fingerprinting oracle via leaked protocol/banner text.
+//
+// This module provides two of the mitigations that need no network work:
+//   1. a port allow-list, so only real mail ports are ever dialled; and
+//   2. an error classifier, so we return a small fixed set of user-actionable
+//      messages instead of the raw driver error.
+//
+// NOTE: connect-time host validation (reject loopback/private/link-local
+// addresses, with DNS-rebinding protection) is the complete fix and is tracked
+// separately. With only the port allow-list in place, the residual oracle is
+// "does internal host X speak IMAP on 143/993" — far weaker than arbitrary
+// port probing, but not fully closed until host validation lands.
+
+export const ALLOWED_IMAP_PORTS: readonly number[] = [143, 993];
+export const ALLOWED_SMTP_PORTS: readonly number[] = [25, 465, 587, 2525];
+
+export function isAllowedImapPort(port: number): boolean {
+  return Number.isInteger(port) && ALLOWED_IMAP_PORTS.includes(port);
+}
+
+export function isAllowedSmtpPort(port: number): boolean {
+  return Number.isInteger(port) && ALLOWED_SMTP_PORTS.includes(port);
+}
+
+// Collapse a raw IMAP/SMTP driver error into a small, fixed set of
+// user-actionable messages. Never returns the original message, so protocol
+// text and service banners cannot leak to the caller. The detailed error
+// should be logged server-side by the caller for operators.
+export function classifyMailError(
+  err: { message?: string } | string | null | undefined
+): string {
+  const raw = typeof err === "string" ? err : err?.message ?? "";
+  const m = raw.toLowerCase();
+
+  if (
+    m.includes("auth") ||
+    m.includes("credential") ||
+    m.includes("login") ||
+    m.includes("password") ||
+    m.includes("invalid user")
+  ) {
+    return "Authentication failed. Check the username and password.";
+  }
+  if (m.includes("timed out") || m.includes("timeout") || m.includes("etimedout")) {
+    return "Connection timed out. Check the host and port.";
+  }
+  if (
+    m.includes("cert") ||
+    m.includes("tls") ||
+    m.includes("ssl") ||
+    m.includes("self-signed") ||
+    m.includes("self signed")
+  ) {
+    return "TLS error. Check the SSL setting for this port.";
+  }
+  if (
+    m.includes("econnrefused") ||
+    m.includes("refused") ||
+    m.includes("enotfound") ||
+    m.includes("ehostunreach") ||
+    m.includes("enetunreach") ||
+    m.includes("econnreset") ||
+    m.includes("network") ||
+    m.includes("getaddrinfo")
+  ) {
+    return "Could not connect to the mail server.";
+  }
+  return "Could not complete the connection to the mail server.";
+}

--- a/lib/mcp/__tests__/projects-boards-scope.test.ts
+++ b/lib/mcp/__tests__/projects-boards-scope.test.ts
@@ -1,0 +1,105 @@
+// Object-level authorization regression tests for MCP project BOARD tools
+// (GHSA-vq6p-3qj5-p666). @/lib/authz is mocked because its barrel pulls in
+// better-auth (ESM) which breaks ts-jest.
+
+// AuthorizationError MUST be the real class from the leaf errors module, so the
+// adapter's `instanceof AuthorizationError` (which imports the same real class)
+// matches instances thrown here. A fresh `class extends Error` would not match,
+// and denials would propagate instead of converting to NOT_FOUND.
+jest.mock("@/lib/authz", () => ({
+  assertCanWriteBoard: jest.fn(),
+  boardReadScopeWhere: jest.fn(() => ({ deletedAt: null, __scope: "read" })),
+  AuthorizationError: jest.requireActual("@/lib/authz/errors").AuthorizationError,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    boards: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { assertCanWriteBoard, AuthorizationError } from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { projectTools } from "@/lib/mcp/tools/projects";
+
+const USER = { id: "u1", role: "user" } as const;
+function call(name: string, args: any) {
+  const tool = projectTools.find((t) => t.name === name)!;
+  return (tool.handler as any)(args, USER.id, USER);
+}
+
+const assertWrite = assertCanWriteBoard as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("projects_update_board", () => {
+  it("denies a non-owner (NOT_FOUND) and does not update", async () => {
+    assertWrite.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_update_board", { id: "b-victim", title: "x" })).rejects.toThrow("NOT_FOUND");
+    expect(assertWrite).toHaveBeenCalledWith(USER, "b-victim");
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("updates for an owner", async () => {
+    assertWrite.mockResolvedValue(undefined);
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b-1" });
+    await call("projects_update_board", { id: "b-1", title: "x" });
+    expect(prismadb.boards.update).toHaveBeenCalled();
+  });
+});
+
+describe("projects_delete_board", () => {
+  it("denies a non-owner and does not soft-delete", async () => {
+    assertWrite.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_delete_board", { id: "b-victim" })).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.boards.update).not.toHaveBeenCalled();
+  });
+
+  it("soft-deletes for an owner", async () => {
+    assertWrite.mockResolvedValue(undefined);
+    (prismadb.boards.update as jest.Mock).mockResolvedValue({ id: "b-1", deletedAt: new Date() });
+    await call("projects_delete_board", { id: "b-1" });
+    expect(assertWrite).toHaveBeenCalledWith(USER, "b-1");
+    expect(prismadb.boards.update).toHaveBeenCalled();
+  });
+});
+
+describe("projects_list_boards", () => {
+  it("filters by boardReadScopeWhere", async () => {
+    (prismadb.boards.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.boards.count as jest.Mock).mockResolvedValue(0);
+    await call("projects_list_boards", { limit: 20, offset: 0 });
+    const arg = (prismadb.boards.findMany as jest.Mock).mock.calls[0][0];
+    expect(arg.where).toMatchObject({ __scope: "read" });
+  });
+});
+
+describe("projects_get_board", () => {
+  it("scopes the findFirst by boardReadScopeWhere", async () => {
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue({ id: "b-1" });
+    await call("projects_get_board", { id: "b-1" });
+    const arg = (prismadb.boards.findFirst as jest.Mock).mock.calls[0][0];
+    expect(arg.where).toMatchObject({ id: "b-1", __scope: "read" });
+  });
+
+  it("returns NOT_FOUND when the board is out of scope", async () => {
+    (prismadb.boards.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(call("projects_get_board", { id: "b-victim" })).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe("projects_create_board", () => {
+  it("stamps the caller as owner", async () => {
+    (prismadb.boards.create as jest.Mock).mockResolvedValue({ id: "b-new" });
+    await call("projects_create_board", { title: "T", description: "D" });
+    const data = (prismadb.boards.create as jest.Mock).mock.calls[0][0].data;
+    expect(data.user).toBe("u1");
+    expect(data.createdBy).toBe("u1");
+    expect(data.updatedBy).toBe("u1");
+  });
+});

--- a/lib/mcp/__tests__/projects-comments-docs-scope.test.ts
+++ b/lib/mcp/__tests__/projects-comments-docs-scope.test.ts
@@ -1,0 +1,94 @@
+// Object-level authorization regression tests for MCP project COMMENT and
+// DOCUMENT-LINK tools (GHSA-vq6p-3qj5-p666).
+
+jest.mock("@/lib/authz", () => ({
+  assertCanReadTask: jest.fn(),
+  assertCanWriteTask: jest.fn(),
+  assertCanReadDocument: jest.fn(),
+  AuthorizationError: jest.requireActual("@/lib/authz/errors").AuthorizationError,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    tasksComments: { findMany: jest.fn(), count: jest.fn(), create: jest.fn() },
+    documentsToTasks: { create: jest.fn() },
+  },
+}));
+
+import {
+  assertCanReadTask,
+  assertCanWriteTask,
+  assertCanReadDocument,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { projectTools } from "@/lib/mcp/tools/projects";
+
+const USER = { id: "u1", role: "user" } as const;
+function call(name: string, args: any) {
+  const tool = projectTools.find((t) => t.name === name)!;
+  return (tool.handler as any)(args, USER.id, USER);
+}
+const readTask = assertCanReadTask as jest.Mock;
+const writeTask = assertCanWriteTask as jest.Mock;
+const readDoc = assertCanReadDocument as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("projects_add_comment", () => {
+  it("denies write on the task and does not create", async () => {
+    writeTask.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_add_comment", { task: "t-victim", comment: "x" })).rejects.toThrow("NOT_FOUND");
+    expect(writeTask).toHaveBeenCalledWith(USER, "t-victim");
+    expect(prismadb.tasksComments.create).not.toHaveBeenCalled();
+  });
+  it("creates for an authorized caller", async () => {
+    writeTask.mockResolvedValue(undefined);
+    (prismadb.tasksComments.create as jest.Mock).mockResolvedValue({ id: "c-1" });
+    await call("projects_add_comment", { task: "t-1", comment: "x" });
+    expect(prismadb.tasksComments.create).toHaveBeenCalled();
+  });
+});
+
+describe("projects_list_comments", () => {
+  it("denies read on the task and does not list", async () => {
+    readTask.mockRejectedValue(new AuthorizationError());
+    await expect(
+      call("projects_list_comments", { task: "t-victim", limit: 20, offset: 0 })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.tasksComments.findMany).not.toHaveBeenCalled();
+  });
+  it("lists for an authorized reader", async () => {
+    readTask.mockResolvedValue(undefined);
+    (prismadb.tasksComments.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.tasksComments.count as jest.Mock).mockResolvedValue(0);
+    await call("projects_list_comments", { task: "t-1", limit: 20, offset: 0 });
+    expect(prismadb.tasksComments.findMany).toHaveBeenCalled();
+  });
+});
+
+describe("projects_assign_document", () => {
+  it("requires write on the task AND read on the document", async () => {
+    writeTask.mockResolvedValue(undefined);
+    readDoc.mockRejectedValue(new AuthorizationError());
+    await expect(
+      call("projects_assign_document", { task_id: "t-1", document_id: "d-victim" })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(writeTask).toHaveBeenCalledWith(USER, "t-1");
+    expect(readDoc).toHaveBeenCalledWith(USER, "d-victim");
+    expect(prismadb.documentsToTasks.create).not.toHaveBeenCalled();
+  });
+  it("denies at the task before touching the document", async () => {
+    writeTask.mockRejectedValue(new AuthorizationError());
+    await expect(
+      call("projects_assign_document", { task_id: "t-victim", document_id: "d-1" })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.documentsToTasks.create).not.toHaveBeenCalled();
+  });
+  it("links when both are authorized", async () => {
+    writeTask.mockResolvedValue(undefined);
+    readDoc.mockResolvedValue(undefined);
+    (prismadb.documentsToTasks.create as jest.Mock).mockResolvedValue({});
+    await call("projects_assign_document", { task_id: "t-1", document_id: "d-1" });
+    expect(prismadb.documentsToTasks.create).toHaveBeenCalled();
+  });
+});

--- a/lib/mcp/__tests__/projects-sections-scope.test.ts
+++ b/lib/mcp/__tests__/projects-sections-scope.test.ts
@@ -1,0 +1,93 @@
+// Object-level authorization regression tests for MCP project SECTION tools
+// (GHSA-vq6p-3qj5-p666). AuthorizationError must be the real class (see note).
+
+jest.mock("@/lib/authz", () => ({
+  assertCanWriteBoard: jest.fn(),
+  boardReadScopeWhere: jest.fn(() => ({ deletedAt: null, __scope: "read" })),
+  AuthorizationError: jest.requireActual("@/lib/authz/errors").AuthorizationError,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    sections: {
+      findUnique: jest.fn(),
+      aggregate: jest.fn().mockResolvedValue({ _max: { position: null } }),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+import { assertCanWriteBoard, AuthorizationError } from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { projectTools } from "@/lib/mcp/tools/projects";
+
+const USER = { id: "u1", role: "user" } as const;
+function call(name: string, args: any) {
+  const tool = projectTools.find((t) => t.name === name)!;
+  return (tool.handler as any)(args, USER.id, USER);
+}
+const assertWrite = assertCanWriteBoard as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (prismadb.sections.aggregate as jest.Mock).mockResolvedValue({ _max: { position: null } });
+});
+
+describe("projects_create_section", () => {
+  it("denies when the parent board is not writable", async () => {
+    assertWrite.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_create_section", { board: "b-victim", title: "S" })).rejects.toThrow("NOT_FOUND");
+    expect(assertWrite).toHaveBeenCalledWith(USER, "b-victim");
+    expect(prismadb.sections.create).not.toHaveBeenCalled();
+  });
+
+  it("creates for a writable parent board", async () => {
+    assertWrite.mockResolvedValue(undefined);
+    (prismadb.sections.create as jest.Mock).mockResolvedValue({ id: "s-1" });
+    await call("projects_create_section", { board: "b-1", title: "S" });
+    expect(prismadb.sections.create).toHaveBeenCalled();
+  });
+});
+
+describe("projects_update_section", () => {
+  it("resolves the parent board then denies write", async () => {
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1" });
+    assertWrite.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_update_section", { id: "s-1", title: "x" })).rejects.toThrow("NOT_FOUND");
+    expect(assertWrite).toHaveBeenCalledWith(USER, "b-1");
+    expect(prismadb.sections.update).not.toHaveBeenCalled();
+  });
+
+  it("NOT_FOUND when the section does not exist", async () => {
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(call("projects_update_section", { id: "missing" })).rejects.toThrow("NOT_FOUND");
+    expect(assertWrite).not.toHaveBeenCalled();
+  });
+
+  it("updates for a writable parent board", async () => {
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1" });
+    assertWrite.mockResolvedValue(undefined);
+    (prismadb.sections.update as jest.Mock).mockResolvedValue({ id: "s-1" });
+    await call("projects_update_section", { id: "s-1", title: "x" });
+    expect(prismadb.sections.update).toHaveBeenCalled();
+  });
+});
+
+describe("projects_delete_section", () => {
+  it("resolves the parent board then denies write", async () => {
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1", _count: { tasks: 0 } });
+    assertWrite.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_delete_section", { id: "s-1" })).rejects.toThrow("NOT_FOUND");
+    expect(assertWrite).toHaveBeenCalledWith(USER, "b-1");
+    expect(prismadb.sections.delete).not.toHaveBeenCalled();
+  });
+
+  it("deletes an empty section for a writable parent board", async () => {
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1", _count: { tasks: 0 } });
+    assertWrite.mockResolvedValue(undefined);
+    (prismadb.sections.delete as jest.Mock).mockResolvedValue({});
+    await call("projects_delete_section", { id: "s-1" });
+    expect(prismadb.sections.delete).toHaveBeenCalled();
+  });
+});

--- a/lib/mcp/__tests__/projects-tasks-scope.test.ts
+++ b/lib/mcp/__tests__/projects-tasks-scope.test.ts
@@ -1,0 +1,124 @@
+// Object-level authorization regression tests for MCP project TASK tools
+// (GHSA-vq6p-3qj5-p666). AuthorizationError must be the real class.
+
+jest.mock("@/lib/authz", () => ({
+  assertCanReadTask: jest.fn(),
+  assertCanWriteTask: jest.fn(),
+  assertCanWriteBoard: jest.fn(),
+  boardReadScopeWhere: jest.fn(() => ({ deletedAt: null, __scope: "read" })),
+  AuthorizationError: jest.requireActual("@/lib/authz/errors").AuthorizationError,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    tasks: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      aggregate: jest.fn().mockResolvedValue({ _max: { position: null } }),
+    },
+    sections: { findUnique: jest.fn() },
+  },
+}));
+
+import {
+  assertCanReadTask,
+  assertCanWriteTask,
+  assertCanWriteBoard,
+  AuthorizationError,
+} from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { projectTools } from "@/lib/mcp/tools/projects";
+
+const USER = { id: "u1", role: "user" } as const;
+function call(name: string, args: any) {
+  const tool = projectTools.find((t) => t.name === name)!;
+  return (tool.handler as any)(args, USER.id, USER);
+}
+const readTask = assertCanReadTask as jest.Mock;
+const writeTask = assertCanWriteTask as jest.Mock;
+const writeBoard = assertCanWriteBoard as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (prismadb.tasks.aggregate as jest.Mock).mockResolvedValue({ _max: { position: null } });
+});
+
+describe("projects_update_task", () => {
+  it("denies and does not update", async () => {
+    writeTask.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_update_task", { id: "t-victim", title: "x" })).rejects.toThrow("NOT_FOUND");
+    expect(writeTask).toHaveBeenCalledWith(USER, "t-victim");
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+  it("updates for an authorized caller", async () => {
+    writeTask.mockResolvedValue(undefined);
+    (prismadb.tasks.update as jest.Mock).mockResolvedValue({ id: "t-1" });
+    await call("projects_update_task", { id: "t-1", title: "x" });
+    expect(prismadb.tasks.update).toHaveBeenCalled();
+  });
+});
+
+describe("projects_delete_task", () => {
+  it("denies and does not update status", async () => {
+    writeTask.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_delete_task", { id: "t-victim" })).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects_get_task", () => {
+  it("denies read and does not fetch the task body", async () => {
+    readTask.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_get_task", { id: "t-victim" })).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.tasks.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects_create_task", () => {
+  it("requires write on the parent board (via the section)", async () => {
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-1", board: "b-1" });
+    writeBoard.mockRejectedValue(new AuthorizationError());
+    await expect(
+      call("projects_create_task", { title: "T", section: "s-1", priority: "Normal" })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(writeBoard).toHaveBeenCalledWith(USER, "b-1");
+    expect(prismadb.tasks.create).not.toHaveBeenCalled();
+  });
+  it("NOT_FOUND when the section does not exist", async () => {
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(
+      call("projects_create_task", { title: "T", section: "missing", priority: "Normal" })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(writeBoard).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects_move_task", () => {
+  it("requires write on BOTH the source task and the destination board", async () => {
+    writeTask.mockResolvedValue(undefined); // source ok
+    (prismadb.sections.findUnique as jest.Mock).mockResolvedValue({ id: "s-dest", board: "b-dest" });
+    writeBoard.mockRejectedValue(new AuthorizationError()); // dest denied
+    await expect(call("projects_move_task", { id: "t-1", section: "s-dest" })).rejects.toThrow("NOT_FOUND");
+    expect(writeTask).toHaveBeenCalledWith(USER, "t-1");
+    expect(writeBoard).toHaveBeenCalledWith(USER, "b-dest");
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+  it("denies at the source task before touching the destination", async () => {
+    writeTask.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_move_task", { id: "t-victim", section: "s-dest" })).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.tasks.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects_list_tasks", () => {
+  it("always constrains to boards the user can read, even when a board id is supplied", async () => {
+    (prismadb.tasks.findMany as jest.Mock).mockResolvedValue([]);
+    (prismadb.tasks.count as jest.Mock).mockResolvedValue(0);
+    await call("projects_list_tasks", { board: "b-any", limit: 20, offset: 0 });
+    const where = (prismadb.tasks.findMany as jest.Mock).mock.calls[0][0].where;
+    expect(where.assigned_section.board_relation).toMatchObject({ __scope: "read" });
+    expect(where.assigned_section.board).toBe("b-any");
+  });
+});

--- a/lib/mcp/__tests__/projects-watch-scope.test.ts
+++ b/lib/mcp/__tests__/projects-watch-scope.test.ts
@@ -1,0 +1,48 @@
+// Object-level authorization regression test for MCP projects_watch_board
+// (GHSA-vq6p-3qj5-p666). Watching an unreadable board self-grants read scope
+// (boardReadScopeWhere includes watchers) — an escalation primitive. Gate on read.
+
+jest.mock("@/lib/authz", () => ({
+  assertCanReadBoard: jest.fn(),
+  AuthorizationError: jest.requireActual("@/lib/authz/errors").AuthorizationError,
+}));
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    boardWatchers: { create: jest.fn(), delete: jest.fn() },
+  },
+}));
+
+import { assertCanReadBoard, AuthorizationError } from "@/lib/authz";
+import { prismadb } from "@/lib/prisma";
+import { projectTools } from "@/lib/mcp/tools/projects";
+
+const USER = { id: "u1", role: "user" } as const;
+function call(name: string, args: any) {
+  const tool = projectTools.find((t) => t.name === name)!;
+  return (tool.handler as any)(args, USER.id, USER);
+}
+const readBoard = assertCanReadBoard as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("projects_watch_board", () => {
+  it("denies read on the board and does not create a watcher (escalation guard)", async () => {
+    readBoard.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_watch_board", { board_id: "b-victim", watch: true })).rejects.toThrow("NOT_FOUND");
+    expect(readBoard).toHaveBeenCalledWith(USER, "b-victim");
+    expect(prismadb.boardWatchers.create).not.toHaveBeenCalled();
+  });
+
+  it("watches a readable board", async () => {
+    readBoard.mockResolvedValue(undefined);
+    (prismadb.boardWatchers.create as jest.Mock).mockResolvedValue({});
+    await call("projects_watch_board", { board_id: "b-1", watch: true });
+    expect(prismadb.boardWatchers.create).toHaveBeenCalled();
+  });
+
+  it("unwatch also requires read and is denied for an unreadable board", async () => {
+    readBoard.mockRejectedValue(new AuthorizationError());
+    await expect(call("projects_watch_board", { board_id: "b-victim", watch: false })).rejects.toThrow("NOT_FOUND");
+    expect(prismadb.boardWatchers.delete).not.toHaveBeenCalled();
+  });
+});

--- a/lib/mcp/__tests__/scope-adapter.test.ts
+++ b/lib/mcp/__tests__/scope-adapter.test.ts
@@ -1,0 +1,37 @@
+// lib/authz's barrel re-exports session helpers that import lib/auth-server
+// -> better-auth, which is ESM-only and fails under ts-jest's CJS transform.
+// Mock the barrel to expose the real AuthorizationError class (via
+// requireActual on the leaf errors module, which has no such chain) — same
+// pattern used by other tests that need real AuthorizationError semantics
+// without pulling in the auth-server import chain.
+jest.mock("@/lib/authz", () => {
+  const { AuthorizationError } = jest.requireActual("@/lib/authz/errors");
+  return { AuthorizationError };
+});
+
+import { assertScopeOrNotFound } from "../helpers";
+import { AuthorizationError } from "@/lib/authz";
+
+describe("assertScopeOrNotFound", () => {
+  it("converts an AuthorizationError into a NOT_FOUND error", async () => {
+    await expect(
+      assertScopeOrNotFound(async () => {
+        throw new AuthorizationError();
+      }, "Board")
+    ).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("passes through when the assert resolves", async () => {
+    await expect(
+      assertScopeOrNotFound(async () => {}, "Board")
+    ).resolves.toBeUndefined();
+  });
+
+  it("propagates non-authorization errors unchanged", async () => {
+    await expect(
+      assertScopeOrNotFound(async () => {
+        throw new Error("db down");
+      }, "Board")
+    ).rejects.toThrow("db down");
+  });
+});

--- a/lib/mcp/helpers.ts
+++ b/lib/mcp/helpers.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+// Import from the leaf errors module, not the @/lib/authz barrel: the barrel
+// re-exports session helpers that pull in better-auth (ESM-only), which breaks
+// any jest suite transitively importing this file. errors.ts has no imports.
+import { AuthorizationError } from "@/lib/authz/errors";
 
 // ── Pagination ──────────────────────────────────────────────────
 
@@ -57,4 +61,19 @@ export function validationError(msg: string): never {
 
 export function externalError(msg: string): never {
   throw new Error(`EXTERNAL_ERROR: ${msg}`);
+}
+
+// Run an object-level authorization assert (assertCanWriteBoard, etc.) and
+// convert a denial into NOT_FOUND so the caller cannot tell whether the id
+// exists (no existence oracle). Non-authorization errors propagate unchanged.
+export async function assertScopeOrNotFound(
+  assert: () => Promise<void>,
+  entity: string,
+): Promise<void> {
+  try {
+    await assert();
+  } catch (e) {
+    if (e instanceof AuthorizationError) notFound(entity);
+    throw e;
+  }
 }

--- a/lib/mcp/tools/projects.ts
+++ b/lib/mcp/tools/projects.ts
@@ -6,6 +6,7 @@ import {
   boardReadScopeWhere,
   assertCanReadTask,
   assertCanWriteTask,
+  assertCanReadDocument,
 } from "@/lib/authz";
 import {
   paginationSchema,
@@ -354,11 +355,10 @@ export const projectTools = [
       task: z.string().uuid(),
       comment: z.string().min(1),
     }),
-    async handler(args: { task: string; comment: string }, userId: string) {
-      const existing = await prismadb.tasks.findUnique({ where: { id: args.task } });
-      if (!existing) notFound("Task");
+    async handler(args: { task: string; comment: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.task), "Task");
       const tc = await prismadb.tasksComments.create({
-        data: { v: 0, task: args.task, comment: args.comment, user: userId },
+        data: { v: 0, task: args.task, comment: args.comment, user: user.id },
       });
       return itemResponse(tc);
     },
@@ -370,7 +370,8 @@ export const projectTools = [
       task: z.string().uuid(),
       ...paginationSchema,
     }),
-    async handler(args: { task: string; limit: number; offset: number }, _userId: string) {
+    async handler(args: { task: string; limit: number; offset: number }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanReadTask(user, args.task), "Task");
       const where = { task: args.task };
       const [data, total] = await Promise.all([
         prismadb.tasksComments.findMany({
@@ -393,7 +394,9 @@ export const projectTools = [
       task_id: z.string().uuid(),
       document_id: z.string().uuid(),
     }),
-    async handler(args: { task_id: string; document_id: string }, _userId: string) {
+    async handler(args: { task_id: string; document_id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.task_id), "Task");
+      await assertScopeOrNotFound(() => assertCanReadDocument(user, args.document_id), "Document");
       await prismadb.documentsToTasks.create({
         data: { task_id: args.task_id, document_id: args.document_id },
       });

--- a/lib/mcp/tools/projects.ts
+++ b/lib/mcp/tools/projects.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
 import type { AuthzUser } from "@/lib/authz";
 import {
+  assertCanReadBoard,
   assertCanWriteBoard,
   boardReadScopeWhere,
   assertCanReadTask,
@@ -412,14 +413,18 @@ export const projectTools = [
       board_id: z.string().uuid(),
       watch: z.boolean().default(true),
     }),
-    async handler(args: { board_id: string; watch: boolean }, userId: string) {
+    async handler(args: { board_id: string; watch: boolean }, _userId: string, user: AuthzUser) {
+      // Read gate: board watchers sit only in the read scope, so watching a
+      // readable board grants nothing new; deny self-granting read to a board
+      // the caller cannot see.
+      await assertScopeOrNotFound(() => assertCanReadBoard(user, args.board_id), "Board");
       if (args.watch) {
         await prismadb.boardWatchers.create({
-          data: { board_id: args.board_id, user_id: userId },
+          data: { board_id: args.board_id, user_id: user.id },
         }).catch(() => {}); // Already watching — ignore duplicate
       } else {
         await prismadb.boardWatchers.delete({
-          where: { board_id_user_id: { board_id: args.board_id, user_id: userId } },
+          where: { board_id_user_id: { board_id: args.board_id, user_id: user.id } },
         }).catch(() => {}); // Not watching — ignore
       }
       return itemResponse({ board_id: args.board_id, watching: args.watch });

--- a/lib/mcp/tools/projects.ts
+++ b/lib/mcp/tools/projects.ts
@@ -138,11 +138,8 @@ export const projectTools = [
       board: z.string().uuid(),
       title: z.string().min(1),
     }),
-    async handler(args: { board: string; title: string }, userId: string) {
-      const board = await prismadb.boards.findFirst({
-        where: { id: args.board, ...userBoardWhere(userId) },
-      });
-      if (!board) notFound("Board");
+    async handler(args: { board: string; title: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, args.board), "Board");
       const maxPos = await prismadb.sections.aggregate({
         where: { board: args.board },
         _max: { position: true },
@@ -166,9 +163,10 @@ export const projectTools = [
       title: z.string().min(1).optional(),
       position: z.number().int().optional(),
     }),
-    async handler(args: { id: string; title?: string; position?: number }, _userId: string) {
+    async handler(args: { id: string; title?: string; position?: number }, _userId: string, user: AuthzUser) {
       const existing = await prismadb.sections.findUnique({ where: { id: args.id } });
       if (!existing) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, existing.board), "Board");
       const { id, position, ...rest } = args;
       const section = await prismadb.sections.update({
         where: { id },
@@ -181,12 +179,13 @@ export const projectTools = [
     name: "projects_delete_section",
     description: "Delete a section (must be empty — no tasks)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const section = await prismadb.sections.findUnique({
         where: { id: args.id },
         include: { _count: { select: { tasks: true } } },
       });
       if (!section) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, section.board), "Board");
       if (section._count.tasks > 0) conflict("Cannot delete section with tasks. Move or delete tasks first.");
       await prismadb.sections.delete({ where: { id: args.id } });
       return itemResponse({ id: args.id, deleted: true });

--- a/lib/mcp/tools/projects.ts
+++ b/lib/mcp/tools/projects.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
 import type { AuthzUser } from "@/lib/authz";
-import { assertCanWriteBoard, boardReadScopeWhere } from "@/lib/authz";
+import {
+  assertCanWriteBoard,
+  boardReadScopeWhere,
+  assertCanReadTask,
+  assertCanWriteTask,
+} from "@/lib/authz";
 import {
   paginationSchema,
   paginationArgs,
@@ -12,16 +17,6 @@ import {
   softDeleteData,
   assertScopeOrNotFound,
 } from "../helpers";
-
-function userBoardWhere(userId: string) {
-  return {
-    deletedAt: null,
-    OR: [
-      { user: userId },
-      { sharedWith: { has: userId } },
-    ],
-  };
-}
 
 export const projectTools = [
   // ── Boards ────────────────────────────────────────────
@@ -205,20 +200,21 @@ export const projectTools = [
     }),
     async handler(
       args: { board?: string; section?: string; user?: string; status?: string; limit: number; offset: number },
-      userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
       const where: any = {
         ...(args.section && { section: args.section }),
         ...(args.user && { user: args.user }),
         ...(args.status && { taskStatus: args.status as any }),
+        // Always constrain to tasks whose parent board the caller can read, and
+        // AND any requested board on top. This is the fix: a supplied board id
+        // can no longer bypass scoping (previously it did).
+        assigned_section: {
+          board_relation: boardReadScopeWhere(user),
+          ...(args.board && { board: args.board }),
+        },
       };
-      if (args.board) {
-        where.assigned_section = { board: args.board };
-      }
-      if (!args.board && !args.section) {
-        // Default: tasks in user's boards
-        where.assigned_section = { board_relation: userBoardWhere(userId) };
-      }
       const [data, total] = await Promise.all([
         prismadb.tasks.findMany({
           where,
@@ -234,7 +230,8 @@ export const projectTools = [
     name: "projects_get_task",
     description: "Get a task by ID with comments and documents",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, _userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanReadTask(user, args.id), "Task");
       const task = await prismadb.tasks.findUnique({
         where: { id: args.id },
         include: {
@@ -259,10 +256,12 @@ export const projectTools = [
     }),
     async handler(
       args: { title: string; content?: string; section: string; priority: string; dueDateAt?: string },
-      userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
       const sec = await prismadb.sections.findUnique({ where: { id: args.section } });
       if (!sec) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, sec.board), "Board");
       const maxPos = await prismadb.tasks.aggregate({
         where: { section: args.section },
         _max: { position: true },
@@ -275,9 +274,9 @@ export const projectTools = [
           section: args.section,
           priority: args.priority,
           position: (maxPos._max.position ?? BigInt(0)) + BigInt(1000),
-          user: userId,
-          createdBy: userId,
-          updatedBy: userId,
+          user: user.id,
+          createdBy: user.id,
+          updatedBy: user.id,
           ...(args.dueDateAt && { dueDateAt: new Date(args.dueDateAt) }),
         },
       });
@@ -295,16 +294,15 @@ export const projectTools = [
       dueDateAt: z.string().datetime().optional(),
       taskStatus: z.enum(["ACTIVE", "PENDING", "COMPLETE"]).optional(),
     }),
-    async handler(args: Record<string, any>, userId: string) {
-      const existing = await prismadb.tasks.findUnique({ where: { id: args.id } });
-      if (!existing) notFound("Task");
+    async handler(args: Record<string, any>, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task");
       const { id, dueDateAt, ...rest } = args;
       const task = await prismadb.tasks.update({
         where: { id },
         data: {
           ...rest,
           ...(dueDateAt !== undefined && { dueDateAt: new Date(dueDateAt) }),
-          updatedBy: userId,
+          updatedBy: user.id,
         },
       });
       return itemResponse(task);
@@ -318,17 +316,17 @@ export const projectTools = [
       section: z.string().uuid(),
       position: z.number().int().optional(),
     }),
-    async handler(args: { id: string; section: string; position?: number }, userId: string) {
-      const existing = await prismadb.tasks.findUnique({ where: { id: args.id } });
-      if (!existing) notFound("Task");
+    async handler(args: { id: string; section: string; position?: number }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task");
       const sec = await prismadb.sections.findUnique({ where: { id: args.section } });
       if (!sec) notFound("Section");
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, sec.board), "Board");
       const task = await prismadb.tasks.update({
         where: { id: args.id },
         data: {
           section: args.section,
           ...(args.position !== undefined && { position: BigInt(args.position) }),
-          updatedBy: userId,
+          updatedBy: user.id,
         },
       });
       return itemResponse(task);
@@ -338,12 +336,11 @@ export const projectTools = [
     name: "projects_delete_task",
     description: "Soft-delete a task (sets status to COMPLETE)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
-      const existing = await prismadb.tasks.findUnique({ where: { id: args.id } });
-      if (!existing) notFound("Task");
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteTask(user, args.id), "Task");
       const task = await prismadb.tasks.update({
         where: { id: args.id },
-        data: { taskStatus: "COMPLETE", updatedBy: userId },
+        data: { taskStatus: "COMPLETE", updatedBy: user.id },
       });
       return itemResponse({ id: task.id, status: "COMPLETE" });
     },

--- a/lib/mcp/tools/projects.ts
+++ b/lib/mcp/tools/projects.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
+import type { AuthzUser } from "@/lib/authz";
+import { assertCanWriteBoard, boardReadScopeWhere } from "@/lib/authz";
 import {
   paginationSchema,
   paginationArgs,
@@ -8,6 +10,7 @@ import {
   notFound,
   conflict,
   softDeleteData,
+  assertScopeOrNotFound,
 } from "../helpers";
 
 function userBoardWhere(userId: string) {
@@ -26,8 +29,8 @@ export const projectTools = [
     name: "projects_list_boards",
     description: "List project boards the user owns or is shared with",
     schema: z.object({ ...paginationSchema }),
-    async handler(args: { limit: number; offset: number }, userId: string) {
-      const where = userBoardWhere(userId);
+    async handler(args: { limit: number; offset: number }, _userId: string, user: AuthzUser) {
+      const where = boardReadScopeWhere(user);
       const [data, total] = await Promise.all([
         prismadb.boards.findMany({
           where,
@@ -44,9 +47,9 @@ export const projectTools = [
     name: "projects_get_board",
     description: "Get a project board with its sections and tasks",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const board = await prismadb.boards.findFirst({
-        where: { id: args.id, ...userBoardWhere(userId) },
+        where: { id: args.id, ...boardReadScopeWhere(user) },
         include: {
           sections: {
             orderBy: { position: "asc" },
@@ -75,7 +78,8 @@ export const projectTools = [
     }),
     async handler(
       args: { title: string; description: string; icon?: string; visibility?: string },
-      userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
       const board = await prismadb.boards.create({
         data: {
@@ -84,9 +88,9 @@ export const projectTools = [
           description: args.description,
           icon: args.icon,
           visibility: args.visibility,
-          user: userId,
-          createdBy: userId,
-          updatedBy: userId,
+          user: user.id,
+          createdBy: user.id,
+          updatedBy: user.id,
         },
       });
       return itemResponse(board);
@@ -102,15 +106,12 @@ export const projectTools = [
       icon: z.string().optional(),
       visibility: z.string().optional(),
     }),
-    async handler(args: Record<string, any>, userId: string) {
-      const existing = await prismadb.boards.findFirst({
-        where: { id: args.id, ...userBoardWhere(userId) },
-      });
-      if (!existing) notFound("Board");
+    async handler(args: Record<string, any>, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, args.id), "Board");
       const { id, ...updateData } = args;
       const board = await prismadb.boards.update({
         where: { id },
-        data: { ...updateData, updatedBy: userId },
+        data: { ...updateData, updatedBy: user.id },
       });
       return itemResponse(board);
     },
@@ -119,14 +120,11 @@ export const projectTools = [
     name: "projects_delete_board",
     description: "Soft-delete a project board (sets deletedAt timestamp)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
-      const existing = await prismadb.boards.findFirst({
-        where: { id: args.id, ...userBoardWhere(userId) },
-      });
-      if (!existing) notFound("Board");
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteBoard(user, args.id), "Board");
       const board = await prismadb.boards.update({
         where: { id: args.id },
-        data: softDeleteData(userId),
+        data: softDeleteData(user.id),
       });
       return itemResponse({ id: board.id, deletedAt: board.deletedAt });
     },

--- a/lib/net/__tests__/host-guard.test.ts
+++ b/lib/net/__tests__/host-guard.test.ts
@@ -1,0 +1,58 @@
+jest.mock("node:dns/promises", () => ({ lookup: jest.fn() }));
+
+import { lookup } from "node:dns/promises";
+import { assertPublicHost, HostNotAllowedError } from "../host-guard";
+
+const mockLookup = lookup as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.MAIL_ALLOW_PRIVATE_HOSTS;
+});
+
+it("returns the pinned IP for a host resolving to a public address", async () => {
+  mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  const res = await assertPublicHost("mail.example.com");
+  expect(res).toEqual({ address: "93.184.216.34", hostname: "mail.example.com" });
+});
+
+it("throws when the host resolves to a private address", async () => {
+  mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+  await expect(assertPublicHost("evil.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("throws when ANY resolved address is disallowed (mixed results / rebinding)", async () => {
+  mockLookup.mockResolvedValue([
+    { address: "93.184.216.34", family: 4 },
+    { address: "169.254.169.254", family: 4 },
+  ]);
+  await expect(assertPublicHost("rebind.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("throws on empty resolution", async () => {
+  mockLookup.mockResolvedValue([]);
+  await expect(assertPublicHost("nx.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("throws when lookup rejects (fail closed)", async () => {
+  mockLookup.mockRejectedValue(new Error("ENOTFOUND"));
+  await expect(assertPublicHost("nx.example.com")).rejects.toBeInstanceOf(HostNotAllowedError);
+});
+
+it("validates a public IP literal without a lookup", async () => {
+  const res = await assertPublicHost("8.8.8.8");
+  expect(res).toEqual({ address: "8.8.8.8", hostname: "8.8.8.8" });
+  expect(mockLookup).not.toHaveBeenCalled();
+});
+
+it("throws for a private IP literal", async () => {
+  await expect(assertPublicHost("127.0.0.1")).rejects.toBeInstanceOf(HostNotAllowedError);
+  expect(mockLookup).not.toHaveBeenCalled();
+});
+
+it("bypasses validation when MAIL_ALLOW_PRIVATE_HOSTS=true", async () => {
+  process.env.MAIL_ALLOW_PRIVATE_HOSTS = "true";
+  const res = await assertPublicHost("mail.internal");
+  expect(res).toEqual({ address: "mail.internal", hostname: "mail.internal" });
+  expect(mockLookup).not.toHaveBeenCalled();
+});

--- a/lib/net/__tests__/ip-rules.test.ts
+++ b/lib/net/__tests__/ip-rules.test.ts
@@ -1,0 +1,25 @@
+import { isDisallowedAddress } from "../ip-rules";
+
+describe("isDisallowedAddress", () => {
+  const disallowed = [
+    "127.0.0.1", "127.1.2.3", "10.0.0.1", "172.16.0.1", "172.31.255.255",
+    "192.168.1.1", "169.254.169.254", "100.64.0.1", "0.0.0.0",
+    "255.255.255.255", "224.0.0.1",
+    "203.0.113.9", // TEST-NET-3 (RFC 5737 documentation/reserved) — correctly refused
+    "::1", "fe80::1", "fc00::1", "fd12:3456::1", "::",
+    "::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:192.168.0.1",
+    "not-an-ip", "", "999.999.999.999",
+  ];
+  const allowed = [
+    "8.8.8.8", "1.1.1.1", "93.184.216.34",
+    "2606:4700:4700::1111", "2001:4860:4860::8888",
+    "::ffff:8.8.8.8", // IPv4-mapped public → allowed
+  ];
+
+  it.each(disallowed)("refuses %s", (ip) => {
+    expect(isDisallowedAddress(ip)).toBe(true);
+  });
+  it.each(allowed)("allows %s", (ip) => {
+    expect(isDisallowedAddress(ip)).toBe(false);
+  });
+});

--- a/lib/net/host-guard.ts
+++ b/lib/net/host-guard.ts
@@ -1,0 +1,39 @@
+import { lookup } from "node:dns/promises";
+import net from "node:net";
+import { isDisallowedAddress } from "./ip-rules";
+
+export class HostNotAllowedError extends Error {
+  constructor(message = "Host is not allowed") {
+    super(message);
+    this.name = "HostNotAllowedError";
+  }
+}
+
+// Resolve `host` once and return a validated, pinned address to dial. If any
+// resolved address is non-public (or the host is unresolvable), throw. Callers
+// MUST dial the returned `address` (the pinned IP), keeping `hostname` for TLS
+// SNI — dialling the hostname would re-resolve and reopen the DNS-rebinding hole.
+export async function assertPublicHost(
+  host: string,
+): Promise<{ address: string; hostname: string }> {
+  if (process.env.MAIL_ALLOW_PRIVATE_HOSTS === "true") {
+    return { address: host, hostname: host };
+  }
+
+  if (net.isIP(host) !== 0) {
+    if (isDisallowedAddress(host)) throw new HostNotAllowedError();
+    return { address: host, hostname: host };
+  }
+
+  let results: { address: string; family: number }[];
+  try {
+    results = await lookup(host, { all: true, verbatim: true });
+  } catch {
+    throw new HostNotAllowedError();
+  }
+  if (!results || results.length === 0) throw new HostNotAllowedError();
+  for (const r of results) {
+    if (isDisallowedAddress(r.address)) throw new HostNotAllowedError();
+  }
+  return { address: results[0].address, hostname: host };
+}

--- a/lib/net/ip-rules.ts
+++ b/lib/net/ip-rules.ts
@@ -1,0 +1,22 @@
+import ipaddr from "ipaddr.js";
+
+// Refuse everything that is not a public unicast address: loopback, private,
+// link-local, unique-local, CGNAT, unspecified, broadcast/multicast/reserved,
+// and IPv4-mapped IPv6 wrapping any of the above. Unparseable input is refused
+// (fail closed). Used by the SSRF host guard before dialling any mail server.
+export function isDisallowedAddress(ip: string): boolean {
+  let addr: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    addr = ipaddr.parse(ip);
+  } catch {
+    return true; // fail closed on anything we cannot parse
+  }
+  // Unwrap IPv4-mapped IPv6 (::ffff:a.b.c.d) and classify the embedded IPv4.
+  if (addr.kind() === "ipv6" && (addr as ipaddr.IPv6).isIPv4MappedAddress()) {
+    addr = (addr as ipaddr.IPv6).toIPv4Address();
+  }
+  // ipaddr's range() returns "unicast" only for globally-routable unicast space;
+  // every other classification (loopback/private/linkLocal/uniqueLocal/
+  // carrierGradeNat/unspecified/broadcast/multicast/reserved/...) is refused.
+  return addr.range() !== "unicast";
+}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "imap": "^0.8.19",
     "inngest": "^4.0.2",
     "input-otp": "^1.4.2",
+    "ipaddr.js": "^2.4.0",
     "jotai": "^2.18.0",
     "lucide-react": "^0.574.0",
     "mailparser": "^3.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ipaddr.js:
+        specifier: ^2.4.0
+        version: 2.4.0
       jotai:
         specifier: ^2.18.0
         version: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(react@19.2.4)(types-react@19.0.0-rc.1)
@@ -426,7 +429,7 @@ importers:
         version: 7.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(types-react-dom@19.0.0-rc.1)(types-react@19.0.0-rc.1)(typescript@5.9.3)
       shadcn:
         specifier: ^3.8.5
-        version: 3.8.5(@types/node@25.5.0)(typescript@5.9.3)
+        version: 3.8.5(@types/node@25.5.0)(supports-color@5.5.0)(typescript@5.9.3)
       ts-jest:
         specifier: ^29.4.6
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
@@ -6295,6 +6298,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -15566,7 +15573,7 @@ snapshots:
   gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
@@ -15575,7 +15582,7 @@ snapshots:
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
@@ -15869,7 +15876,7 @@ snapshots:
       - supports-color
     optional: true
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
@@ -15998,6 +16005,8 @@ snapshots:
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.4.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -18164,7 +18173,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.8.5(@types/node@25.5.0)(typescript@5.9.3):
+  shadcn@3.8.5(@types/node@25.5.0)(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.29.0
@@ -18184,7 +18193,7 @@ snapshots:
       fast-glob: 3.3.3
       fs-extra: 11.3.3
       fuzzysort: 3.1.0
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       kleur: 4.1.5
       msw: 2.12.10(@types/node@25.5.0)(typescript@5.9.3)
       node-fetch: 3.3.2


### PR DESCRIPTION
Fixes four security advisories in one lineage. Every change is guard-only — no schema migrations, no behavior change for authorized users. Combined gate: **230 suites / 1297 tests, tsc clean, `pnpm build` green.**

## What's fixed

### GHSA-qwhm-9fcm-p878 (critical) — CRM server-action IDOR
~40 CRM server actions authorized on session-existence alone and mutated by client-supplied id (any user could take over or destroy any account/contact/lead/opportunity/contract/line-item/target/task). They now enforce the **same object-level scope the read surface already ships** — a `user` writes only what they own or are assigned; admin/manager unrestricted — via new `assertCanWrite*` helpers in `lib/authz`. The advisory's privilege-escalation half was already fixed; this closes the IDOR half. A coverage sweep also caught two mutating actions outside the enumerated dirs (`convert-target.ts`, `set-inactive.ts`).

### GHSA-vq6p-3qj5-p666 (high) — MCP project-tools RBAC bypass
15 of 18 tools in `lib/mcp/tools/projects.ts` were exploitable — most **cross-tenant with no authorization at all** (any API-token holder could mutate any board's tasks/sections/comments). All 18 now call the same board/task asserts the web uses, through a small `assertScopeOrNotFound` adapter (denials surface as `NOT_FOUND`, no existence oracle). `watch_board` is read-gated to stop a self-service read-escalation; the misused `userBoardWhere` predicate is deleted.

### GHSA-f5r5-f2v5-74ww (critical) — SSRF via IMAP/SMTP sinks
An authenticated user controlled the host/port of server-side mail connections (internal port scanner against Postgres/MinIO/Inngest/metadata). New `lib/net/` host-guard resolves once, validates **every** resolved address (`ipaddr.js`), and returns a **pinned IP** the sinks dial (hostname kept as TLS `servername`) — closing DNS rebinding. Applied to `testEmailConnection`/`listImapFolders`/`createEmailAccount`, `sendEmail`, and the background `connectImap`. Blocked hosts return the same generic error as unreachable ones (no oracle). `MAIL_ALLOW_PRIVATE_HOSTS=true` is the escape hatch for self-hosters.

### Bundled quick-fixes (part of the SSRF lineage)
- IMAP/SMTP **port allow-list** + error classification (narrows the SSRF oracle; defense-in-depth under the host-guard).
- **Admin Resend-key action** (`setSMTP`) had zero authorization (a layout guard doesn't gate Server Action invocation) — now behind `requireRole(["admin"])`.

## Deferred (documented follow-ups, not in this PR)
TLS `rejectUnauthorized: false` on IMAP/SMTP (needs a per-account self-signed flag: schema + UI); relink-on-update parent-write consistency; `assertCanWriteCrmTask` parent-write breadth; publish the advisories with corrected affected ranges (the SSRF "all versions" is wrong — the reported Rossum path was removed earlier).

## Review note
Every workstream here was implemented **and** reviewed by the same automated process — the isolated per-task reviewer kept getting permission-classifier-blocked, so there was no independent second set of eyes. Given this is security-critical, please give it a real human review before it reaches `main`.

Specs and plans for each workstream are under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)