### PR TITLE
fix(mcp): role-aware read scoping, FK linking, and user lookup for CRM tools

### DIFF
--- a/__tests__/mcp/crm-account-linking.test.ts
+++ b/__tests__/mcp/crm-account-linking.test.ts
@@ -1,0 +1,149 @@
+// crm_update_opportunity / crm_update_contact used to whitelist only scalar
+// fields, so an `account` (or `contact`) FK passed by an API client was stripped
+// by schema validation and silently dropped — the call returned 200 with the
+// column still null. These tests pin the link/unlink contract.
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Opportunities: { findFirst: jest.fn(), update: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn(), update: jest.fn() },
+    crm_Contacts: { findFirst: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { crmOpportunityTools } from "@/lib/mcp/tools/crm-opportunities";
+import { crmContactTools } from "@/lib/mcp/tools/crm-contacts";
+
+type Role = "user" | "manager" | "admin";
+const ADMIN = { id: "a1", role: "admin" as Role };
+
+const allTools = [...crmOpportunityTools, ...crmContactTools];
+const run = (name: string, args: any, user: { id: string; role: Role } = ADMIN) => {
+  const t = allTools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool not found: ${name}`);
+  return (t.handler as any)(args, user.id, user);
+};
+
+const opps = prismadb.crm_Opportunities as any;
+const accounts = prismadb.crm_Accounts as any;
+const contacts = prismadb.crm_Contacts as any;
+
+// Every lookup resolves by default; individual tests override what they exercise.
+beforeEach(() => {
+  jest.clearAllMocks();
+  opps.findFirst.mockResolvedValue({ id: "o1" });
+  opps.update.mockResolvedValue({ id: "o1" });
+  accounts.findFirst.mockResolvedValue({ id: "acc1" });
+  contacts.findFirst.mockResolvedValue({ id: "c1" });
+  contacts.update.mockResolvedValue({ id: "c1" });
+});
+
+describe("crm_update_opportunity account/contact linking", () => {
+  it("accepts the schema fields at all (they used to be stripped)", () => {
+    const schema = crmOpportunityTools.find((t) => t.name === "crm_update_opportunity")!
+      .schema as any;
+    const parsed = schema.parse({
+      id: "11111111-1111-4111-8111-111111111111",
+      account: "22222222-2222-4222-8222-222222222222",
+      contact: "33333333-3333-4333-8333-333333333333",
+    });
+    expect(parsed.account).toBe("22222222-2222-4222-8222-222222222222");
+    expect(parsed.contact).toBe("33333333-3333-4333-8333-333333333333");
+  });
+
+  it("persists the account FK", async () => {
+    await run("crm_update_opportunity", { id: "o1", account: "acc1" });
+    expect(opps.update.mock.calls[0][0].data.account).toBe("acc1");
+  });
+
+  it("persists the contact FK", async () => {
+    await run("crm_update_opportunity", { id: "o1", contact: "c1" });
+    expect(opps.update.mock.calls[0][0].data.contact).toBe("c1");
+  });
+
+  it("re-links to a different account", async () => {
+    await run("crm_update_opportunity", { id: "o1", account: "acc1" });
+    await run("crm_update_opportunity", { id: "o1", account: "acc2" });
+    expect(opps.update.mock.calls[0][0].data.account).toBe("acc1");
+    expect(opps.update.mock.calls[1][0].data.account).toBe("acc2");
+  });
+
+  it("explicit null unlinks without validating a non-existent parent", async () => {
+    await run("crm_update_opportunity", { id: "o1", account: null, contact: null });
+    const data = opps.update.mock.calls[0][0].data;
+    expect(data.account).toBeNull();
+    expect(data.contact).toBeNull();
+    expect(accounts.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("omitting the fields leaves the existing links untouched", async () => {
+    await run("crm_update_opportunity", { id: "o1", name: "renamed" });
+    const data = opps.update.mock.calls[0][0].data;
+    expect(data).not.toHaveProperty("account");
+    expect(data).not.toHaveProperty("contact");
+  });
+
+  it("rejects an unknown account instead of writing a dangling FK", async () => {
+    accounts.findFirst.mockResolvedValue(null);
+    await expect(
+      run("crm_update_opportunity", { id: "o1", account: "ghost" })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(opps.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a soft-deleted account", async () => {
+    accounts.findFirst.mockResolvedValue(null);
+    await expect(
+      run("crm_update_opportunity", { id: "o1", account: "acc1" })
+    ).rejects.toThrow("NOT_FOUND");
+    // The existence check must exclude soft-deleted rows.
+    expect(accounts.findFirst.mock.calls[0][0].where.deletedAt).toBeNull();
+    expect(opps.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown contact instead of writing a dangling FK", async () => {
+    contacts.findFirst.mockResolvedValue(null);
+    await expect(
+      run("crm_update_opportunity", { id: "o1", contact: "ghost" })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(opps.update).not.toHaveBeenCalled();
+  });
+
+  it("checks the opportunity is writable before touching the parent", async () => {
+    opps.findFirst.mockResolvedValue(null);
+    await expect(
+      run("crm_update_opportunity", { id: "victim", account: "acc1" })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(accounts.findFirst).not.toHaveBeenCalled();
+    expect(opps.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("crm_update_contact account linking", () => {
+  it("writes the relation FK (accountsIDs), not the legacy `account` column", async () => {
+    await run("crm_update_contact", { id: "c1", account: "acc1" });
+    const data = contacts.update.mock.calls[0][0].data;
+    expect(data.accountsIDs).toBe("acc1");
+    expect(data).not.toHaveProperty("account");
+  });
+
+  it("explicit null unlinks", async () => {
+    await run("crm_update_contact", { id: "c1", account: null });
+    expect(contacts.update.mock.calls[0][0].data.accountsIDs).toBeNull();
+    expect(accounts.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("omitting account leaves the link untouched", async () => {
+    await run("crm_update_contact", { id: "c1", last_name: "Novak" });
+    expect(contacts.update.mock.calls[0][0].data).not.toHaveProperty("accountsIDs");
+  });
+
+  it("rejects an unknown account instead of writing a dangling FK", async () => {
+    accounts.findFirst.mockResolvedValue(null);
+    await expect(run("crm_update_contact", { id: "c1", account: "ghost" })).rejects.toThrow(
+      "NOT_FOUND"
+    );
+    expect(contacts.update).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/mcp/crm-read-scope.test.ts
+++ b/__tests__/mcp/crm-read-scope.test.ts
@@ -1,0 +1,157 @@
+// The MCP CRM read handlers used to hardcode `assigned_to: userId`, which is
+// stricter than the web UI: an admin/manager token only ever saw its own rows.
+// They now share the role-aware scope helpers in lib/authz/scopes/crm.ts.
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    crm_Opportunities: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
+    crm_Accounts: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
+    crm_Contacts: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
+  },
+}));
+
+import { prismadb } from "@/lib/prisma";
+import { crmOpportunityTools } from "@/lib/mcp/tools/crm-opportunities";
+import { crmAccountTools } from "@/lib/mcp/tools/crm-accounts";
+import { crmContactTools } from "@/lib/mcp/tools/crm-contacts";
+
+type Role = "user" | "manager" | "admin";
+const MEMBER = { id: "u1", role: "user" as Role };
+const MANAGER = { id: "m1", role: "manager" as Role };
+const ADMIN = { id: "a1", role: "admin" as Role };
+
+const allTools = [...crmOpportunityTools, ...crmAccountTools, ...crmContactTools];
+// Handlers receive (args, userId, user)
+const run = (name: string, args: any, user: { id: string; role: Role }) => {
+  const t = allTools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool not found: ${name}`);
+  return (t.handler as any)(args, user.id, user);
+};
+
+// Flatten a scope `OR` into the list of ownership columns it constrains.
+const ownershipKeys = (where: any) =>
+  (where.OR ?? []).flatMap((clause: any) => Object.keys(clause));
+
+const listMocks = {
+  crm_list_opportunities: prismadb.crm_Opportunities,
+  crm_list_accounts: prismadb.crm_Accounts,
+  crm_list_contacts: prismadb.crm_Contacts,
+} as const;
+
+const searchMocks = {
+  crm_search_opportunities: prismadb.crm_Opportunities,
+  crm_search_accounts: prismadb.crm_Accounts,
+  crm_search_contacts: prismadb.crm_Contacts,
+} as const;
+
+const getMocks = {
+  crm_get_opportunity: prismadb.crm_Opportunities,
+  crm_get_account: prismadb.crm_Accounts,
+  crm_get_contact: prismadb.crm_Contacts,
+} as const;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe.each(Object.entries(listMocks))("%s read scope", (toolName, model) => {
+  const m = model as any;
+
+  it.each([
+    ["admin", ADMIN],
+    ["manager", MANAGER],
+  ])("%s sees every non-deleted row (no ownership filter)", async (_label, user) => {
+    m.findMany.mockResolvedValue([]);
+    m.count.mockResolvedValue(0);
+    await run(toolName, { limit: 20, offset: 0 }, user);
+    const where = m.findMany.mock.calls[0][0].where;
+    expect(where).toEqual({ deletedAt: null });
+    expect(where.assigned_to).toBeUndefined();
+  });
+
+  it("member stays restricted to rows they own or are linked to", async () => {
+    m.findMany.mockResolvedValue([]);
+    m.count.mockResolvedValue(0);
+    await run(toolName, { limit: 20, offset: 0 }, MEMBER);
+    const where = m.findMany.mock.calls[0][0].where;
+    expect(where.deletedAt).toBeNull();
+    expect(ownershipKeys(where)).toContain("assigned_to");
+    // The scope must never widen to every row for a plain member.
+    expect(where.OR.length).toBeGreaterThan(0);
+  });
+
+  it("member and admin do not receive the same where clause", async () => {
+    m.findMany.mockResolvedValue([]);
+    m.count.mockResolvedValue(0);
+    await run(toolName, { limit: 20, offset: 0 }, MEMBER);
+    await run(toolName, { limit: 20, offset: 0 }, ADMIN);
+    const memberWhere = m.findMany.mock.calls[0][0].where;
+    const adminWhere = m.findMany.mock.calls[1][0].where;
+    expect(memberWhere).not.toEqual(adminWhere);
+  });
+
+  it("count uses the same where clause as findMany", async () => {
+    m.findMany.mockResolvedValue([]);
+    m.count.mockResolvedValue(0);
+    await run(toolName, { limit: 20, offset: 0 }, MEMBER);
+    expect(m.count.mock.calls[0][0].where).toEqual(m.findMany.mock.calls[0][0].where);
+  });
+});
+
+describe.each(Object.entries(getMocks))("%s read scope", (toolName, model) => {
+  const m = model as any;
+
+  it("admin lookup is not filtered by assigned_to", async () => {
+    m.findFirst.mockResolvedValue({ id: "x1" });
+    await run(toolName, { id: "x1" }, ADMIN);
+    const where = m.findFirst.mock.calls[0][0].where;
+    expect(where).toEqual({ id: "x1", deletedAt: null });
+  });
+
+  it("member lookup keeps the ownership OR", async () => {
+    m.findFirst.mockResolvedValue({ id: "x1" });
+    await run(toolName, { id: "x1" }, MEMBER);
+    const where = m.findFirst.mock.calls[0][0].where;
+    expect(where.id).toBe("x1");
+    expect(ownershipKeys(where)).toContain("assigned_to");
+  });
+
+  it("out-of-scope row still surfaces NOT_FOUND", async () => {
+    m.findFirst.mockResolvedValue(null);
+    await expect(run(toolName, { id: "victim" }, MEMBER)).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe.each(Object.entries(searchMocks))("%s read scope", (toolName, model) => {
+  const m = model as any;
+
+  it("admin search is not filtered by assigned_to", async () => {
+    m.findMany.mockResolvedValue([]);
+    m.count.mockResolvedValue(0);
+    await run(toolName, { query: "acme", limit: 20, offset: 0 }, ADMIN);
+    const where = m.findMany.mock.calls[0][0].where;
+    expect(where.deletedAt).toBeNull();
+    expect(where.assigned_to).toBeUndefined();
+    // With no scope OR to preserve, the search terms are the only AND branch.
+    expect(where.AND[0].OR.length).toBeGreaterThan(0);
+  });
+
+  // Regression: the scope helper returns its own `OR`. Spreading the search
+  // terms as a sibling `OR` would overwrite it and expose every row matching
+  // the query to a plain member.
+  it("member search intersects the scope instead of replacing it", async () => {
+    m.findMany.mockResolvedValue([]);
+    m.count.mockResolvedValue(0);
+    await run(toolName, { query: "acme", limit: 20, offset: 0 }, MEMBER);
+    const where = m.findMany.mock.calls[0][0].where;
+
+    // Scope survives...
+    expect(ownershipKeys(where)).toContain("assigned_to");
+    // ...and the query terms live under AND, not as a competing top-level OR.
+    const searchOr = where.AND[0].OR;
+    expect(searchOr.length).toBeGreaterThan(0);
+    for (const clause of searchOr) {
+      const field = Object.keys(clause)[0];
+      expect(clause[field]).toEqual({ contains: "acme", mode: "insensitive" });
+    }
+    expect(where.OR).not.toEqual(searchOr);
+  });
+});

--- a/__tests__/mcp/crm-users.test.ts
+++ b/__tests__/mcp/crm-users.test.ts
@@ -1,0 +1,184 @@
+// crm_list_users exists so an agent can resolve a person to the user ID that
+// assigned_to needs. Field exposure mirrors the web UI: actions/user/search-users.ts
+// hands every authenticated user id/name/avatar for ACTIVE users, while email,
+// role and status stay admin-module territory.
+
+jest.mock("@/lib/prisma", () => ({
+  prismadb: {
+    users: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
+    crm_Opportunities: { findFirst: jest.fn(), update: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn() },
+    crm_Contacts: { findFirst: jest.fn() },
+  },
+}));
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { prismadb } from "@/lib/prisma";
+import { crmUserTools } from "@/lib/mcp/tools/crm-users";
+import { crmOpportunityTools } from "@/lib/mcp/tools/crm-opportunities";
+
+type Role = "user" | "manager" | "admin";
+const MEMBER = { id: "u1", role: "user" as Role };
+const MANAGER = { id: "m1", role: "manager" as Role };
+const ADMIN = { id: "a1", role: "admin" as Role };
+
+const tools = [...crmUserTools, ...crmOpportunityTools];
+const run = (name: string, args: any, user: { id: string; role: Role }) => {
+  const t = tools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool not found: ${name}`);
+  return (t.handler as any)(args, user.id, user);
+};
+
+const users = prismadb.users as any;
+const opps = prismadb.crm_Opportunities as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  users.findMany.mockResolvedValue([]);
+  users.count.mockResolvedValue(0);
+  users.findFirst.mockResolvedValue({ id: "u2" });
+  opps.findFirst.mockResolvedValue({ id: "o1" });
+  opps.update.mockResolvedValue({ id: "o1" });
+});
+
+// The registry can't be imported here: lib/mcp/tools/index.ts pulls in
+// projects.ts, which imports the @/lib/authz barrel and therefore ESM-only
+// better-auth (see the note atop lib/mcp/helpers.ts). Assert on the source so
+// a tool that is written but never wired up still fails the suite.
+describe("crm_list_users registration", () => {
+  const registry = readFileSync(
+    join(process.cwd(), "lib/mcp/tools/index.ts"),
+    "utf8"
+  );
+
+  it("is spread into allTools", () => {
+    expect(registry).toMatch(/\.\.\.crmUserTools,/);
+  });
+
+  it("is imported by the registry", () => {
+    expect(registry).toMatch(/import \{ crmUserTools \} from "\.\/crm-users";/);
+  });
+
+  it("exposes exactly one tool, named crm_list_users", () => {
+    expect(crmUserTools.map((t) => t.name)).toEqual(["crm_list_users"]);
+  });
+});
+
+describe("crm_list_users field exposure", () => {
+  it("members get only id/name/avatar, matching the web UI picker", async () => {
+    await run("crm_list_users", { limit: 20, offset: 0 }, MEMBER);
+    const select = users.findMany.mock.calls[0][0].select;
+    expect(select).toEqual({ id: true, name: true, avatar: true });
+    expect(select.email).toBeUndefined();
+    expect(select.role).toBeUndefined();
+  });
+
+  it.each([
+    ["manager", MANAGER],
+    ["admin", ADMIN],
+  ])("%s additionally gets email, role and status", async (_label, user) => {
+    await run("crm_list_users", { limit: 20, offset: 0 }, user);
+    const select = users.findMany.mock.calls[0][0].select;
+    expect(select.email).toBe(true);
+    expect(select.role).toBe(true);
+    expect(select.userStatus).toBe(true);
+    expect(select.id).toBe(true);
+  });
+
+  it("never selects the password column for anyone", async () => {
+    for (const user of [MEMBER, MANAGER, ADMIN]) {
+      await run("crm_list_users", { limit: 20, offset: 0 }, user);
+    }
+    for (const call of users.findMany.mock.calls) {
+      expect(call[0].select).not.toHaveProperty("password");
+    }
+  });
+});
+
+describe("crm_list_users status filtering", () => {
+  it("defaults to active users only", async () => {
+    await run("crm_list_users", { limit: 20, offset: 0 }, MEMBER);
+    expect(users.findMany.mock.calls[0][0].where.userStatus).toBe("ACTIVE");
+  });
+
+  it("a member cannot widen the status filter", async () => {
+    await run("crm_list_users", { status: "ALL", limit: 20, offset: 0 }, MEMBER);
+    expect(users.findMany.mock.calls[0][0].where.userStatus).toBe("ACTIVE");
+  });
+
+  it("a member cannot enumerate pending accounts", async () => {
+    await run("crm_list_users", { status: "PENDING", limit: 20, offset: 0 }, MEMBER);
+    expect(users.findMany.mock.calls[0][0].where.userStatus).toBe("ACTIVE");
+  });
+
+  it("an admin may request all statuses", async () => {
+    await run("crm_list_users", { status: "ALL", limit: 20, offset: 0 }, ADMIN);
+    expect(users.findMany.mock.calls[0][0].where).not.toHaveProperty("userStatus");
+  });
+
+  it("an admin may filter to inactive users", async () => {
+    await run("crm_list_users", { status: "INACTIVE", limit: 20, offset: 0 }, ADMIN);
+    expect(users.findMany.mock.calls[0][0].where.userStatus).toBe("INACTIVE");
+  });
+});
+
+describe("crm_list_users search", () => {
+  it("matches names case-insensitively", async () => {
+    await run("crm_list_users", { query: "pav", limit: 20, offset: 0 }, MEMBER);
+    expect(users.findMany.mock.calls[0][0].where.name).toEqual({
+      contains: "pav",
+      mode: "insensitive",
+    });
+  });
+
+  it("count uses the same where clause as findMany", async () => {
+    await run("crm_list_users", { query: "pav", limit: 20, offset: 0 }, MEMBER);
+    expect(users.count.mock.calls[0][0].where).toEqual(
+      users.findMany.mock.calls[0][0].where
+    );
+  });
+});
+
+describe("crm_update_opportunity reassignment", () => {
+  it("persists assigned_to", async () => {
+    await run("crm_update_opportunity", { id: "o1", assigned_to: "u2" }, ADMIN);
+    expect(opps.update.mock.calls[0][0].data.assigned_to).toBe("u2");
+  });
+
+  it("rejects an unknown assignee instead of writing a dangling FK", async () => {
+    users.findFirst.mockResolvedValue(null);
+    await expect(
+      run("crm_update_opportunity", { id: "o1", assigned_to: "ghost" }, ADMIN)
+    ).rejects.toThrow("NOT_FOUND");
+    expect(opps.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses to park work on a non-active account", async () => {
+    users.findFirst.mockResolvedValue(null);
+    await expect(
+      run("crm_update_opportunity", { id: "o1", assigned_to: "u2" }, ADMIN)
+    ).rejects.toThrow("NOT_FOUND");
+    expect(users.findFirst.mock.calls[0][0].where.userStatus).toBe("ACTIVE");
+  });
+
+  it("explicit null unassigns without validating a user", async () => {
+    await run("crm_update_opportunity", { id: "o1", assigned_to: null }, ADMIN);
+    expect(opps.update.mock.calls[0][0].data.assigned_to).toBeNull();
+    expect(users.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("omitting assigned_to leaves the owner untouched", async () => {
+    await run("crm_update_opportunity", { id: "o1", name: "renamed" }, ADMIN);
+    expect(opps.update.mock.calls[0][0].data).not.toHaveProperty("assigned_to");
+  });
+
+  it("checks the opportunity is writable before validating the assignee", async () => {
+    opps.findFirst.mockResolvedValue(null);
+    await expect(
+      run("crm_update_opportunity", { id: "victim", assigned_to: "u2" }, MEMBER)
+    ).rejects.toThrow("NOT_FOUND");
+    expect(users.findFirst).not.toHaveBeenCalled();
+    expect(opps.update).not.toHaveBeenCalled();
+  });
+});

--- a/lib/mcp/tools/crm-accounts.ts
+++ b/lib/mcp/tools/crm-accounts.ts
@@ -1,25 +1,45 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
+import type { AuthzUser } from "@/lib/authz";
+import {
+  accountReadScopeWhere,
+  assertCanWriteAccount,
+} from "@/lib/authz/scopes/crm";
 import {
   paginationSchema,
   paginationArgs,
   listResponse,
   itemResponse,
   ilike,
-  isNotDeleted,
   notFound,
   softDeleteData,
+  assertScopeOrNotFound,
 } from "../helpers";
+
+// assertCanWriteAccount intentionally ignores deletedAt (the server actions
+// guard it separately), so the MCP write path keeps its own soft-delete check.
+async function assertWritableAccount(user: AuthzUser, accountId: string) {
+  const row = await prismadb.crm_Accounts.findFirst({
+    where: { id: accountId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!row) notFound("Account");
+  await assertScopeOrNotFound(() => assertCanWriteAccount(user, accountId), "Account");
+}
 
 export const crmAccountTools = [
   {
     name: "crm_list_accounts",
-    description: "List CRM accounts assigned to the authenticated user",
+    description: "List CRM accounts visible to the authenticated user",
     schema: z.object({
       ...paginationSchema,
     }),
-    async handler(args: { limit: number; offset: number }, userId: string) {
-      const where = { assigned_to: userId, ...isNotDeleted() };
+    async handler(
+      args: { limit: number; offset: number },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const where = accountReadScopeWhere(user);
       const [data, total] = await Promise.all([
         prismadb.crm_Accounts.findMany({
           where,
@@ -33,11 +53,11 @@ export const crmAccountTools = [
   },
   {
     name: "crm_get_account",
-    description: "Get a single CRM account by ID",
+    description: "Get a single CRM account by ID (visible to the authenticated user)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const account = await prismadb.crm_Accounts.findFirst({
-        where: { id: args.id, assigned_to: userId, ...isNotDeleted() },
+        where: { id: args.id, ...accountReadScopeWhere(user) },
       });
       if (!account) notFound("Account");
       return itemResponse(account);
@@ -45,19 +65,22 @@ export const crmAccountTools = [
   },
   {
     name: "crm_search_accounts",
-    description: "Search accounts by name or website (substring match)",
+    description:
+      "Search accounts visible to the authenticated user by name or website (substring match)",
     schema: z.object({
       query: z.string().min(1),
       ...paginationSchema,
     }),
     async handler(
       args: { query: string; limit: number; offset: number },
-      userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
+      // The read scope itself may carry an `OR`; nest the search terms under
+      // `AND` so they intersect the scope instead of replacing it.
       const where = {
-        assigned_to: userId,
-        ...isNotDeleted(),
-        OR: [ilike("name", args.query), ilike("website", args.query)],
+        ...accountReadScopeWhere(user),
+        AND: [{ OR: [ilike("name", args.query), ilike("website", args.query)] }],
       };
       const [data, total] = await Promise.all([
         prismadb.crm_Accounts.findMany({
@@ -125,12 +148,10 @@ export const crmAccountTools = [
         office_phone?: string;
         website?: string;
       },
-      userId: string
+      userId: string,
+      user: AuthzUser
     ) {
-      const existing = await prismadb.crm_Accounts.findFirst({
-        where: { id: args.id, assigned_to: userId, ...isNotDeleted() },
-      });
-      if (!existing) notFound("Account");
+      await assertWritableAccount(user, args.id);
       const { id, ...updateData } = args;
       const account = await prismadb.crm_Accounts.update({
         where: { id },
@@ -143,11 +164,8 @@ export const crmAccountTools = [
     name: "crm_delete_account",
     description: "Soft-delete a CRM account by ID (sets deletedAt timestamp)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
-      const existing = await prismadb.crm_Accounts.findFirst({
-        where: { id: args.id, assigned_to: userId, ...isNotDeleted() },
-      });
-      if (!existing) notFound("Account");
+    async handler(args: { id: string }, userId: string, user: AuthzUser) {
+      await assertWritableAccount(user, args.id);
       const account = await prismadb.crm_Accounts.update({
         where: { id: args.id },
         data: softDeleteData(userId),

--- a/lib/mcp/tools/crm-contacts.ts
+++ b/lib/mcp/tools/crm-contacts.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
+import type { AuthzUser } from "@/lib/authz";
+import {
+  contactReadScopeWhere,
+  assertCanWriteContact,
+  assertCanWriteAccount,
+} from "@/lib/authz/scopes/crm";
 import {
   paginationSchema,
   paginationArgs,
@@ -8,15 +14,41 @@ import {
   ilike,
   notFound,
   softDeleteData,
+  assertScopeOrNotFound,
 } from "../helpers";
+
+// assertCanWriteContact intentionally ignores deletedAt (the server actions
+// guard it separately), so the MCP write path keeps its own soft-delete check.
+async function assertWritableContact(user: AuthzUser, contactId: string) {
+  const row = await prismadb.crm_Contacts.findFirst({
+    where: { id: contactId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!row) notFound("Contact");
+  await assertScopeOrNotFound(() => assertCanWriteContact(user, contactId), "Contact");
+}
+
+// Relinking a contact to an account is a parent write — mirrors update-contact.ts.
+async function assertLinkableAccount(user: AuthzUser, accountId: string) {
+  const row = await prismadb.crm_Accounts.findFirst({
+    where: { id: accountId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!row) notFound("Account");
+  await assertScopeOrNotFound(() => assertCanWriteAccount(user, accountId), "Account");
+}
 
 export const crmContactTools = [
   {
     name: "crm_list_contacts",
-    description: "List CRM contacts assigned to the authenticated user",
+    description: "List CRM contacts visible to the authenticated user",
     schema: z.object({ ...paginationSchema }),
-    async handler(args: { limit: number; offset: number }, userId: string) {
-      const where = { assigned_to: userId, deletedAt: null };
+    async handler(
+      args: { limit: number; offset: number },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const where = contactReadScopeWhere(user);
       const [data, total] = await Promise.all([
         prismadb.crm_Contacts.findMany({
           where,
@@ -30,11 +62,11 @@ export const crmContactTools = [
   },
   {
     name: "crm_get_contact",
-    description: "Get a single CRM contact by ID",
+    description: "Get a single CRM contact by ID (visible to the authenticated user)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const contact = await prismadb.crm_Contacts.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
+        where: { id: args.id, ...contactReadScopeWhere(user) },
       });
       if (!contact) notFound("Contact");
       return itemResponse(contact);
@@ -42,21 +74,28 @@ export const crmContactTools = [
   },
   {
     name: "crm_search_contacts",
-    description: "Search contacts by name, email, or phone (substring match)",
+    description:
+      "Search contacts visible to the authenticated user by name, email, or phone (substring match)",
     schema: z.object({ query: z.string().min(1), ...paginationSchema }),
     async handler(
       args: { query: string; limit: number; offset: number },
-      userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
+      // The read scope itself may carry an `OR`; nest the search terms under
+      // `AND` so they intersect the scope instead of replacing it.
       const where = {
-        assigned_to: userId,
-        deletedAt: null,
-        OR: [
-          ilike("first_name", args.query),
-          ilike("last_name", args.query),
-          ilike("email", args.query),
-          ilike("office_phone", args.query),
-          ilike("mobile_phone", args.query),
+        ...contactReadScopeWhere(user),
+        AND: [
+          {
+            OR: [
+              ilike("first_name", args.query),
+              ilike("last_name", args.query),
+              ilike("email", args.query),
+              ilike("office_phone", args.query),
+              ilike("mobile_phone", args.query),
+            ],
+          },
         ],
       };
       const [data, total] = await Promise.all([
@@ -117,6 +156,8 @@ export const crmContactTools = [
       office_phone: z.string().optional(),
       mobile_phone: z.string().optional(),
       position: z.string().optional(),
+      // Pass an account id to link, explicit null to unlink. Omit to leave unchanged.
+      account: z.string().uuid().nullable().optional(),
     }),
     async handler(
       args: {
@@ -127,17 +168,23 @@ export const crmContactTools = [
         office_phone?: string;
         mobile_phone?: string;
         position?: string;
+        account?: string | null;
       },
-      userId: string
+      userId: string,
+      user: AuthzUser
     ) {
-      const existing = await prismadb.crm_Contacts.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
-      });
-      if (!existing) notFound("Contact");
-      const { id, ...updateData } = args;
+      await assertWritableContact(user, args.id);
+      if (args.account) await assertLinkableAccount(user, args.account);
+      const { id, account, ...updateData } = args;
       const contact = await prismadb.crm_Contacts.update({
         where: { id },
-        data: { ...updateData, updatedBy: userId },
+        data: {
+          ...updateData,
+          // `accountsIDs` is the real relation FK (crm_Contacts.assigned_accounts);
+          // the legacy `account` column carries no relation, so the UI ignores it too.
+          ...(account !== undefined && { accountsIDs: account }),
+          updatedBy: userId,
+        },
       });
       return itemResponse(contact);
     },
@@ -146,11 +193,8 @@ export const crmContactTools = [
     name: "crm_delete_contact",
     description: "Soft-delete a CRM contact by ID (sets deletedAt timestamp)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
-      const existing = await prismadb.crm_Contacts.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
-      });
-      if (!existing) notFound("Contact");
+    async handler(args: { id: string }, userId: string, user: AuthzUser) {
+      await assertWritableContact(user, args.id);
       const contact = await prismadb.crm_Contacts.update({
         where: { id: args.id },
         data: softDeleteData(userId),

--- a/lib/mcp/tools/crm-opportunities.ts
+++ b/lib/mcp/tools/crm-opportunities.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
+import type { AuthzUser } from "@/lib/authz";
+import {
+  opportunityReadScopeWhere,
+  assertCanWriteOpportunity,
+  assertCanWriteAccount,
+  assertCanWriteContact,
+} from "@/lib/authz/scopes/crm";
 import {
   paginationSchema,
   paginationArgs,
@@ -8,15 +15,41 @@ import {
   ilike,
   notFound,
   softDeleteData,
+  assertScopeOrNotFound,
 } from "../helpers";
+
+// Relinking an opportunity to an account/contact is a parent write: the row must
+// exist, must not be soft-deleted, and the caller must be allowed to write it.
+// Mirrors create-opportunity.ts / update-contact.ts, which assert the same way.
+async function assertLinkableAccount(user: AuthzUser, accountId: string) {
+  const row = await prismadb.crm_Accounts.findFirst({
+    where: { id: accountId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!row) notFound("Account");
+  await assertScopeOrNotFound(() => assertCanWriteAccount(user, accountId), "Account");
+}
+
+async function assertLinkableContact(user: AuthzUser, contactId: string) {
+  const row = await prismadb.crm_Contacts.findFirst({
+    where: { id: contactId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!row) notFound("Contact");
+  await assertScopeOrNotFound(() => assertCanWriteContact(user, contactId), "Contact");
+}
 
 export const crmOpportunityTools = [
   {
     name: "crm_list_opportunities",
-    description: "List CRM opportunities assigned to the authenticated user",
+    description: "List CRM opportunities visible to the authenticated user",
     schema: z.object({ ...paginationSchema }),
-    async handler(args: { limit: number; offset: number }, userId: string) {
-      const where = { assigned_to: userId, deletedAt: null };
+    async handler(
+      args: { limit: number; offset: number },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const where = opportunityReadScopeWhere(user);
       const [data, total] = await Promise.all([
         prismadb.crm_Opportunities.findMany({
           where,
@@ -30,11 +63,11 @@ export const crmOpportunityTools = [
   },
   {
     name: "crm_get_opportunity",
-    description: "Get a single CRM opportunity by ID",
+    description: "Get a single CRM opportunity by ID (visible to the authenticated user)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const opp = await prismadb.crm_Opportunities.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
+        where: { id: args.id, ...opportunityReadScopeWhere(user) },
       });
       if (!opp) notFound("Opportunity");
       return itemResponse(opp);
@@ -42,16 +75,19 @@ export const crmOpportunityTools = [
   },
   {
     name: "crm_search_opportunities",
-    description: "Search opportunities by name or description (substring match)",
+    description:
+      "Search opportunities visible to the authenticated user by name or description (substring match)",
     schema: z.object({ query: z.string().min(1), ...paginationSchema }),
     async handler(
       args: { query: string; limit: number; offset: number },
-      userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
+      // The read scope itself may carry an `OR`; nest the search terms under
+      // `AND` so they intersect the scope instead of replacing it.
       const where = {
-        assigned_to: userId,
-        deletedAt: null,
-        OR: [ilike("name", args.query), ilike("description", args.query)],
+        ...opportunityReadScopeWhere(user),
+        AND: [{ OR: [ilike("name", args.query), ilike("description", args.query)] }],
       };
       const [data, total] = await Promise.all([
         prismadb.crm_Opportunities.findMany({
@@ -117,6 +153,9 @@ export const crmOpportunityTools = [
       expected_revenue: z.number().int().min(0).optional(),
       currency: z.string().optional(),
       next_step: z.string().optional(),
+      // Pass an id to link, explicit null to unlink. Omit to leave unchanged.
+      account: z.string().uuid().nullable().optional(),
+      contact: z.string().uuid().nullable().optional(),
     }),
     async handler(
       args: {
@@ -128,14 +167,20 @@ export const crmOpportunityTools = [
         expected_revenue?: number;
         currency?: string;
         next_step?: string;
+        account?: string | null;
+        contact?: string | null;
       },
-      userId: string
+      userId: string,
+      user: AuthzUser
     ) {
-      const existing = await prismadb.crm_Opportunities.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
-      });
-      if (!existing) notFound("Opportunity");
-      const { id, budget, expected_revenue, close_date, currency, ...rest } = args;
+      await assertScopeOrNotFound(
+        () => assertCanWriteOpportunity(user, args.id),
+        "Opportunity"
+      );
+      if (args.account) await assertLinkableAccount(user, args.account);
+      if (args.contact) await assertLinkableContact(user, args.contact);
+      const { id, budget, expected_revenue, close_date, currency, account, contact, ...rest } =
+        args;
       const opp = await prismadb.crm_Opportunities.update({
         where: { id },
         data: {
@@ -144,6 +189,8 @@ export const crmOpportunityTools = [
           ...(budget !== undefined && { budget }),
           ...(expected_revenue !== undefined && { expected_revenue }),
           ...(close_date !== undefined && { close_date: new Date(close_date) }),
+          ...(account !== undefined && { account }),
+          ...(contact !== undefined && { contact }),
           updatedBy: userId,
         },
       });
@@ -154,11 +201,11 @@ export const crmOpportunityTools = [
     name: "crm_delete_opportunity",
     description: "Soft-delete a CRM opportunity by ID",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
-      const existing = await prismadb.crm_Opportunities.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
-      });
-      if (!existing) notFound("Opportunity");
+    async handler(args: { id: string }, userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(
+        () => assertCanWriteOpportunity(user, args.id),
+        "Opportunity"
+      );
       const opp = await prismadb.crm_Opportunities.update({
         where: { id: args.id },
         data: softDeleteData(userId),

--- a/lib/mcp/tools/crm-opportunities.ts
+++ b/lib/mcp/tools/crm-opportunities.ts
@@ -30,6 +30,17 @@ async function assertLinkableAccount(user: AuthzUser, accountId: string) {
   await assertScopeOrNotFound(() => assertCanWriteAccount(user, accountId), "Account");
 }
 
+// Reassignment targets must be a real, active user. The server action relies on
+// the FK constraint alone; checking here keeps the failure a clean NOT_FOUND
+// instead of a Prisma error, and stops work being parked on a disabled account.
+async function assertAssignableUser(assigneeId: string) {
+  const row = await prismadb.users.findFirst({
+    where: { id: assigneeId, userStatus: "ACTIVE" },
+    select: { id: true },
+  });
+  if (!row) notFound("User");
+}
+
 async function assertLinkableContact(user: AuthzUser, contactId: string) {
   const row = await prismadb.crm_Contacts.findFirst({
     where: { id: contactId, deletedAt: null },
@@ -156,6 +167,8 @@ export const crmOpportunityTools = [
       // Pass an id to link, explicit null to unlink. Omit to leave unchanged.
       account: z.string().uuid().nullable().optional(),
       contact: z.string().uuid().nullable().optional(),
+      // Reassign the owner. Use crm_list_users to resolve a person to their ID.
+      assigned_to: z.string().uuid().nullable().optional(),
     }),
     async handler(
       args: {
@@ -169,6 +182,7 @@ export const crmOpportunityTools = [
         next_step?: string;
         account?: string | null;
         contact?: string | null;
+        assigned_to?: string | null;
       },
       userId: string,
       user: AuthzUser
@@ -179,8 +193,18 @@ export const crmOpportunityTools = [
       );
       if (args.account) await assertLinkableAccount(user, args.account);
       if (args.contact) await assertLinkableContact(user, args.contact);
-      const { id, budget, expected_revenue, close_date, currency, account, contact, ...rest } =
-        args;
+      if (args.assigned_to) await assertAssignableUser(args.assigned_to);
+      const {
+        id,
+        budget,
+        expected_revenue,
+        close_date,
+        currency,
+        account,
+        contact,
+        assigned_to,
+        ...rest
+      } = args;
       const opp = await prismadb.crm_Opportunities.update({
         where: { id },
         data: {
@@ -191,6 +215,7 @@ export const crmOpportunityTools = [
           ...(close_date !== undefined && { close_date: new Date(close_date) }),
           ...(account !== undefined && { account }),
           ...(contact !== undefined && { contact }),
+          ...(assigned_to !== undefined && { assigned_to }),
           updatedBy: userId,
         },
       });

--- a/lib/mcp/tools/crm-users.ts
+++ b/lib/mcp/tools/crm-users.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { prismadb } from "@/lib/prisma";
+import type { AuthzUser } from "@/lib/authz";
+import {
+  paginationSchema,
+  paginationArgs,
+  listResponse,
+} from "../helpers";
+
+// Field exposure mirrors the web UI:
+//   - actions/user/search-users.ts gives every authenticated user id/name/avatar
+//     for ACTIVE users (this is the assignee picker), so members get the same.
+//   - The wider set (email, role, status) is admin-module territory, so it is
+//     gated to manager/admin here.
+const BASE_SELECT = { id: true, name: true, avatar: true } as const;
+const PRIVILEGED_SELECT = {
+  ...BASE_SELECT,
+  email: true,
+  role: true,
+  userStatus: true,
+  lastLoginAt: true,
+} as const;
+
+export const crmUserTools = [
+  {
+    name: "crm_list_users",
+    description:
+      "List NextCRM users, to resolve a person to the user ID needed by assigned_to. " +
+      "Returns active users by default. Managers and admins additionally see email, " +
+      "role, status and last login.",
+    schema: z.object({
+      // Substring match on name, same as the web UI's assignee picker.
+      query: z.string().min(1).optional(),
+      // Manager/admin only: inactive and pending users are hidden otherwise.
+      status: z.enum(["ACTIVE", "INACTIVE", "PENDING", "ALL"]).optional(),
+      ...paginationSchema,
+    }),
+    async handler(
+      args: { query?: string; status?: string; limit: number; offset: number },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const privileged = user.role === "admin" || user.role === "manager";
+
+      // Members never see anything but active users, whatever they ask for.
+      const status = privileged ? (args.status ?? "ACTIVE") : "ACTIVE";
+
+      const where = {
+        ...(status !== "ALL" && { userStatus: status as "ACTIVE" | "INACTIVE" | "PENDING" }),
+        ...(args.query && {
+          name: { contains: args.query, mode: "insensitive" as const },
+        }),
+      };
+
+      const [data, total] = await Promise.all([
+        prismadb.users.findMany({
+          where,
+          select: privileged ? PRIVILEGED_SELECT : BASE_SELECT,
+          ...paginationArgs(args),
+          orderBy: { name: "asc" },
+        }),
+        prismadb.users.count({ where }),
+      ]);
+      return listResponse(data, total, args.offset);
+    },
+  },
+];

--- a/lib/mcp/tools/index.ts
+++ b/lib/mcp/tools/index.ts
@@ -4,6 +4,7 @@ export { crmLeadTools } from "./crm-leads";
 export { crmOpportunityTools } from "./crm-opportunities";
 export { crmTargetTools } from "./crm-targets";
 export { crmProductTools } from "./crm-products";
+export { crmUserTools } from "./crm-users";
 export { crmContractTools } from "./crm-contracts";
 export { crmActivityTools } from "./crm-activities";
 export { crmDocumentTools } from "./crm-documents";
@@ -20,6 +21,7 @@ import { crmLeadTools } from "./crm-leads";
 import { crmOpportunityTools } from "./crm-opportunities";
 import { crmTargetTools } from "./crm-targets";
 import { crmProductTools } from "./crm-products";
+import { crmUserTools } from "./crm-users";
 import { crmContractTools } from "./crm-contracts";
 import { crmActivityTools } from "./crm-activities";
 import { crmDocumentTools } from "./crm-documents";
@@ -37,6 +39,7 @@ export const allTools = [
   ...crmOpportunityTools,
   ...crmTargetTools,
   ...crmProductTools,
+  ...crmUserTools,
   ...crmContractTools,
   ...crmActivityTools,
   ...crmDocumentTools,


### PR DESCRIPTION
Three related gaps in the MCP CRM tool layer, all closed by aligning the tools with what the web UI already does.

## 1. Role-aware read scoping

The opportunity, account, and contact read handlers hardcoded `assigned_to: userId`, which is stricter than the web UI: an admin or manager token only ever saw its own records. They now use the shared helpers in `lib/authz/scopes/crm.ts`, so admin/manager tokens see all non-deleted rows while members keep the same restricted visibility as the UI.

This is what weekly-pack's sync hit — `crm_list_opportunities` on an admin `nxtc__` token was returning only that admin's assigned opportunities.

The search handlers nest their query terms under `AND`. The scope helpers return their own `OR`, so a sibling `OR` would have silently replaced the scope and exposed every matching row to a plain member.

## 2. Account/contact FK linking

`crm_update_opportunity` now accepts `account` and `contact`; `crm_update_contact` accepts `account`. These were absent from the Zod schemas, so a client passing them got a `200` back with the column still `null` — a silent failure where the success code was not evidence the field persisted.

Each is `uuid().nullable().optional()`: an id links, an explicit `null` unlinks, omitting it leaves the link untouched. Parents are validated (exists, not soft-deleted, caller may write it) before the FK is written, so no dangling references.

On contacts this writes `accountsIDs` — the relation FK the UI writes and the read scopes traverse — not the relationless legacy `account` column, which nothing reads.

## 3. `crm_list_users`

Nothing on the MCP surface resolved a person to a user ID. `reports_run`'s `users` category returns aggregated chart points, not identities, and the only place an id/name pair appeared was `projects_list_comments`.

Field exposure mirrors the web UI rather than introducing a new policy:

- **Members** get `id`/`name`/`avatar`, matching `actions/user/search-users.ts`, which backs the assignee picker for any authenticated user.
- **Manager/admin** additionally get `email`, `role`, `userStatus`, `lastLoginAt` — admin-module territory in the UI.

Members are pinned to `ACTIVE` regardless of the `status` argument, so a member token cannot enumerate pending or deactivated accounts. No select includes `password`.

`crm_update_opportunity` also gains `assigned_to`, without which the lookup leads nowhere — an agent could resolve a user ID and still have no way to apply it. The assignee must be an existing ACTIVE user, keeping the failure a clean `NOT_FOUND` rather than a Prisma FK error, and stopping deals being parked on a deactivated account.

## Authorization

Write handlers now mirror the server actions' `assertCanWrite*` helpers. This is required for the linking fix to be usable: the Odoo migration's relinking pass runs on an admin token against records that admin does not own.

- Denials still surface as `NOT_FOUND`, not `FORBIDDEN`, preserving the existing no-existence-oracle contract.
- `assertCanWriteAccount` and `assertCanWriteContact` do not filter `deletedAt` (unlike the opportunity one), so the MCP write path keeps its own soft-delete check rather than silently dropping that guard.
- Reassignment rights are unchanged: `assertCanWriteOpportunity` gates it as before.

## Testing

`tsc --noEmit` clean. Full jest suite **1361/1361** across 233 suites.

64 new tests in `__tests__/mcp/`. Stashing the source changes fails 28 of the read-scope and linking tests, so they are not vacuous.

One compromise worth flagging: the `crm_list_users` registration test asserts on `lib/mcp/tools/index.ts` as source text rather than importing `allTools`. Importing the registry pulls in `projects.ts` and therefore the `@/lib/authz` barrel and ESM-only `better-auth`, which jest cannot load (documented atop `lib/mcp/helpers.ts`). It still catches a tool that is written but never wired up.

## Follow-ups, not in this PR

- Accounts, contacts, and leads also carry `assigned_to` and remain non-reassignable over MCP.
- weekly-pack: the stale doc comments in `lib/nextcrm/client.ts` (lines 6-7 and 121) describe the old token-owner-only behavior and are now wrong.
- Re-run the linking pass at `~/odoo-migration/hygiene.py` to convert the `[account=X]` description tags into real foreign keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
