### PR TITLE
feat(mcp): reassignment on accounts, contacts and leads; scope CRM lead tools

### DIFF
--- a/__tests__/mcp/crm-read-scope.test.ts
+++ b/__tests__/mcp/crm-read-scope.test.ts
@@ -7,6 +7,7 @@ jest.mock("@/lib/prisma", () => ({
     crm_Opportunities: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
     crm_Accounts: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
     crm_Contacts: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
+    crm_Leads: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
   },
 }));
 
@@ -14,13 +15,19 @@ import { prismadb } from "@/lib/prisma";
 import { crmOpportunityTools } from "@/lib/mcp/tools/crm-opportunities";
 import { crmAccountTools } from "@/lib/mcp/tools/crm-accounts";
 import { crmContactTools } from "@/lib/mcp/tools/crm-contacts";
+import { crmLeadTools } from "@/lib/mcp/tools/crm-leads";
 
 type Role = "user" | "manager" | "admin";
 const MEMBER = { id: "u1", role: "user" as Role };
 const MANAGER = { id: "m1", role: "manager" as Role };
 const ADMIN = { id: "a1", role: "admin" as Role };
 
-const allTools = [...crmOpportunityTools, ...crmAccountTools, ...crmContactTools];
+const allTools = [
+  ...crmOpportunityTools,
+  ...crmAccountTools,
+  ...crmContactTools,
+  ...crmLeadTools,
+];
 // Handlers receive (args, userId, user)
 const run = (name: string, args: any, user: { id: string; role: Role }) => {
   const t = allTools.find((x) => x.name === name);
@@ -36,18 +43,21 @@ const listMocks = {
   crm_list_opportunities: prismadb.crm_Opportunities,
   crm_list_accounts: prismadb.crm_Accounts,
   crm_list_contacts: prismadb.crm_Contacts,
+  crm_list_leads: prismadb.crm_Leads,
 } as const;
 
 const searchMocks = {
   crm_search_opportunities: prismadb.crm_Opportunities,
   crm_search_accounts: prismadb.crm_Accounts,
   crm_search_contacts: prismadb.crm_Contacts,
+  crm_search_leads: prismadb.crm_Leads,
 } as const;
 
 const getMocks = {
   crm_get_opportunity: prismadb.crm_Opportunities,
   crm_get_account: prismadb.crm_Accounts,
   crm_get_contact: prismadb.crm_Contacts,
+  crm_get_lead: prismadb.crm_Leads,
 } as const;
 
 beforeEach(() => jest.clearAllMocks());

--- a/__tests__/mcp/crm-users.test.ts
+++ b/__tests__/mcp/crm-users.test.ts
@@ -7,8 +7,9 @@ jest.mock("@/lib/prisma", () => ({
   prismadb: {
     users: { findMany: jest.fn(), count: jest.fn(), findFirst: jest.fn() },
     crm_Opportunities: { findFirst: jest.fn(), update: jest.fn() },
-    crm_Accounts: { findFirst: jest.fn() },
-    crm_Contacts: { findFirst: jest.fn() },
+    crm_Accounts: { findFirst: jest.fn(), update: jest.fn() },
+    crm_Contacts: { findFirst: jest.fn(), update: jest.fn() },
+    crm_Leads: { findFirst: jest.fn(), update: jest.fn() },
   },
 }));
 
@@ -17,13 +18,22 @@ import { join } from "node:path";
 import { prismadb } from "@/lib/prisma";
 import { crmUserTools } from "@/lib/mcp/tools/crm-users";
 import { crmOpportunityTools } from "@/lib/mcp/tools/crm-opportunities";
+import { crmAccountTools } from "@/lib/mcp/tools/crm-accounts";
+import { crmContactTools } from "@/lib/mcp/tools/crm-contacts";
+import { crmLeadTools } from "@/lib/mcp/tools/crm-leads";
 
 type Role = "user" | "manager" | "admin";
 const MEMBER = { id: "u1", role: "user" as Role };
 const MANAGER = { id: "m1", role: "manager" as Role };
 const ADMIN = { id: "a1", role: "admin" as Role };
 
-const tools = [...crmUserTools, ...crmOpportunityTools];
+const tools = [
+  ...crmUserTools,
+  ...crmOpportunityTools,
+  ...crmAccountTools,
+  ...crmContactTools,
+  ...crmLeadTools,
+];
 const run = (name: string, args: any, user: { id: string; role: Role }) => {
   const t = tools.find((x) => x.name === name);
   if (!t) throw new Error(`tool not found: ${name}`);
@@ -31,15 +41,24 @@ const run = (name: string, args: any, user: { id: string; role: Role }) => {
 };
 
 const users = prismadb.users as any;
-const opps = prismadb.crm_Opportunities as any;
+
+// Every entity that carries assigned_to and can be reassigned over MCP.
+const REASSIGNABLE = [
+  { tool: "crm_update_opportunity", model: prismadb.crm_Opportunities },
+  { tool: "crm_update_account", model: prismadb.crm_Accounts },
+  { tool: "crm_update_contact", model: prismadb.crm_Contacts },
+  { tool: "crm_update_lead", model: prismadb.crm_Leads },
+] as const;
 
 beforeEach(() => {
   jest.clearAllMocks();
   users.findMany.mockResolvedValue([]);
   users.count.mockResolvedValue(0);
   users.findFirst.mockResolvedValue({ id: "u2" });
-  opps.findFirst.mockResolvedValue({ id: "o1" });
-  opps.update.mockResolvedValue({ id: "o1" });
+  for (const { model } of REASSIGNABLE) {
+    (model as any).findFirst.mockResolvedValue({ id: "x1" });
+    (model as any).update.mockResolvedValue({ id: "x1" });
+  }
 });
 
 // The registry can't be imported here: lib/mcp/tools/index.ts pulls in
@@ -140,45 +159,67 @@ describe("crm_list_users search", () => {
   });
 });
 
-describe("crm_update_opportunity reassignment", () => {
+describe.each(REASSIGNABLE)("$tool reassignment", ({ tool, model }) => {
+  const m = model as any;
+  const UUID = "11111111-1111-4111-8111-111111111111";
+  const ASSIGNEE = "22222222-2222-4222-8222-222222222222";
+
+  // The handler tests below call handlers directly, which bypasses validation.
+  // The route validates through tool.schema, and a zod object strips keys it
+  // does not declare — so without this, a missing schema field would look fine.
+  it("declares assigned_to on the schema so the route does not strip it", () => {
+    const schema = tools.find((t) => t.name === tool)!.schema as any;
+    expect(schema.parse({ id: UUID, assigned_to: ASSIGNEE }).assigned_to).toBe(ASSIGNEE);
+  });
+
+  it("accepts an explicit null through the schema", () => {
+    const schema = tools.find((t) => t.name === tool)!.schema as any;
+    expect(schema.parse({ id: UUID, assigned_to: null }).assigned_to).toBeNull();
+  });
+
+  it("rejects a non-uuid assignee at the schema", () => {
+    const schema = tools.find((t) => t.name === tool)!.schema as any;
+    expect(() => schema.parse({ id: UUID, assigned_to: "not-a-uuid" })).toThrow();
+  });
+
   it("persists assigned_to", async () => {
-    await run("crm_update_opportunity", { id: "o1", assigned_to: "u2" }, ADMIN);
-    expect(opps.update.mock.calls[0][0].data.assigned_to).toBe("u2");
+    await run(tool, { id: "x1", assigned_to: "u2" }, ADMIN);
+    expect(m.update.mock.calls[0][0].data.assigned_to).toBe("u2");
   });
 
   it("rejects an unknown assignee instead of writing a dangling FK", async () => {
     users.findFirst.mockResolvedValue(null);
-    await expect(
-      run("crm_update_opportunity", { id: "o1", assigned_to: "ghost" }, ADMIN)
-    ).rejects.toThrow("NOT_FOUND");
-    expect(opps.update).not.toHaveBeenCalled();
+    await expect(run(tool, { id: "x1", assigned_to: "ghost" }, ADMIN)).rejects.toThrow(
+      "NOT_FOUND"
+    );
+    expect(m.update).not.toHaveBeenCalled();
   });
 
   it("refuses to park work on a non-active account", async () => {
     users.findFirst.mockResolvedValue(null);
-    await expect(
-      run("crm_update_opportunity", { id: "o1", assigned_to: "u2" }, ADMIN)
-    ).rejects.toThrow("NOT_FOUND");
+    await expect(run(tool, { id: "x1", assigned_to: "u2" }, ADMIN)).rejects.toThrow(
+      "NOT_FOUND"
+    );
     expect(users.findFirst.mock.calls[0][0].where.userStatus).toBe("ACTIVE");
   });
 
   it("explicit null unassigns without validating a user", async () => {
-    await run("crm_update_opportunity", { id: "o1", assigned_to: null }, ADMIN);
-    expect(opps.update.mock.calls[0][0].data.assigned_to).toBeNull();
+    await run(tool, { id: "x1", assigned_to: null }, ADMIN);
+    expect(m.update.mock.calls[0][0].data.assigned_to).toBeNull();
     expect(users.findFirst).not.toHaveBeenCalled();
   });
 
   it("omitting assigned_to leaves the owner untouched", async () => {
-    await run("crm_update_opportunity", { id: "o1", name: "renamed" }, ADMIN);
-    expect(opps.update.mock.calls[0][0].data).not.toHaveProperty("assigned_to");
+    await run(tool, { id: "x1" }, ADMIN);
+    expect(m.update.mock.calls[0][0].data).not.toHaveProperty("assigned_to");
   });
 
-  it("checks the opportunity is writable before validating the assignee", async () => {
-    opps.findFirst.mockResolvedValue(null);
-    await expect(
-      run("crm_update_opportunity", { id: "victim", assigned_to: "u2" }, MEMBER)
-    ).rejects.toThrow("NOT_FOUND");
+  it("checks the record is writable before validating the assignee", async () => {
+    m.findFirst.mockResolvedValue(null);
+    await expect(run(tool, { id: "victim", assigned_to: "u2" }, MEMBER)).rejects.toThrow(
+      "NOT_FOUND"
+    );
     expect(users.findFirst).not.toHaveBeenCalled();
-    expect(opps.update).not.toHaveBeenCalled();
+    expect(m.update).not.toHaveBeenCalled();
   });
 });

--- a/lib/mcp/helpers.ts
+++ b/lib/mcp/helpers.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 // re-exports session helpers that pull in better-auth (ESM-only), which breaks
 // any jest suite transitively importing this file. errors.ts has no imports.
 import { AuthorizationError } from "@/lib/authz/errors";
+import { prismadb } from "@/lib/prisma";
 
 // ── Pagination ──────────────────────────────────────────────────
 
@@ -61,6 +62,17 @@ export function validationError(msg: string): never {
 
 export function externalError(msg: string): never {
   throw new Error(`EXTERNAL_ERROR: ${msg}`);
+}
+
+// Reassignment targets must be a real, active user. The server actions rely on
+// the FK constraint alone; checking here keeps the failure a clean NOT_FOUND
+// instead of a Prisma error, and stops work being parked on a disabled account.
+export async function assertAssignableUser(assigneeId: string): Promise<void> {
+  const row = await prismadb.users.findFirst({
+    where: { id: assigneeId, userStatus: "ACTIVE" },
+    select: { id: true },
+  });
+  if (!row) notFound("User");
 }
 
 // Run an object-level authorization assert (assertCanWriteBoard, etc.) and

--- a/lib/mcp/tools/crm-accounts.ts
+++ b/lib/mcp/tools/crm-accounts.ts
@@ -14,6 +14,7 @@ import {
   notFound,
   softDeleteData,
   assertScopeOrNotFound,
+  assertAssignableUser,
 } from "../helpers";
 
 // assertCanWriteAccount intentionally ignores deletedAt (the server actions
@@ -138,6 +139,8 @@ export const crmAccountTools = [
       description: z.string().optional(),
       office_phone: z.string().optional(),
       website: z.string().optional(),
+      // Reassign the owner. Use crm_list_users to resolve a person to their ID.
+      assigned_to: z.string().uuid().nullable().optional(),
     }),
     async handler(
       args: {
@@ -147,15 +150,21 @@ export const crmAccountTools = [
         description?: string;
         office_phone?: string;
         website?: string;
+        assigned_to?: string | null;
       },
       userId: string,
       user: AuthzUser
     ) {
       await assertWritableAccount(user, args.id);
-      const { id, ...updateData } = args;
+      if (args.assigned_to) await assertAssignableUser(args.assigned_to);
+      const { id, assigned_to, ...updateData } = args;
       const account = await prismadb.crm_Accounts.update({
         where: { id },
-        data: { ...updateData, updatedBy: userId },
+        data: {
+          ...updateData,
+          ...(assigned_to !== undefined && { assigned_to }),
+          updatedBy: userId,
+        },
       });
       return itemResponse(account);
     },

--- a/lib/mcp/tools/crm-contacts.ts
+++ b/lib/mcp/tools/crm-contacts.ts
@@ -15,6 +15,7 @@ import {
   notFound,
   softDeleteData,
   assertScopeOrNotFound,
+  assertAssignableUser,
 } from "../helpers";
 
 // assertCanWriteContact intentionally ignores deletedAt (the server actions
@@ -158,6 +159,8 @@ export const crmContactTools = [
       position: z.string().optional(),
       // Pass an account id to link, explicit null to unlink. Omit to leave unchanged.
       account: z.string().uuid().nullable().optional(),
+      // Reassign the owner. Use crm_list_users to resolve a person to their ID.
+      assigned_to: z.string().uuid().nullable().optional(),
     }),
     async handler(
       args: {
@@ -169,13 +172,15 @@ export const crmContactTools = [
         mobile_phone?: string;
         position?: string;
         account?: string | null;
+        assigned_to?: string | null;
       },
       userId: string,
       user: AuthzUser
     ) {
       await assertWritableContact(user, args.id);
       if (args.account) await assertLinkableAccount(user, args.account);
-      const { id, account, ...updateData } = args;
+      if (args.assigned_to) await assertAssignableUser(args.assigned_to);
+      const { id, account, assigned_to, ...updateData } = args;
       const contact = await prismadb.crm_Contacts.update({
         where: { id },
         data: {
@@ -183,6 +188,7 @@ export const crmContactTools = [
           // `accountsIDs` is the real relation FK (crm_Contacts.assigned_accounts);
           // the legacy `account` column carries no relation, so the UI ignores it too.
           ...(account !== undefined && { accountsIDs: account }),
+          ...(assigned_to !== undefined && { assigned_to }),
           updatedBy: userId,
         },
       });

--- a/lib/mcp/tools/crm-leads.ts
+++ b/lib/mcp/tools/crm-leads.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import { prismadb } from "@/lib/prisma";
+import type { AuthzUser } from "@/lib/authz";
+import { leadReadScopeWhere, assertCanWriteLead } from "@/lib/authz/scopes/crm";
 import {
   paginationSchema,
   paginationArgs,
@@ -8,15 +10,21 @@ import {
   ilike,
   notFound,
   softDeleteData,
+  assertScopeOrNotFound,
+  assertAssignableUser,
 } from "../helpers";
 
 export const crmLeadTools = [
   {
     name: "crm_list_leads",
-    description: "List CRM leads assigned to the authenticated user",
+    description: "List CRM leads visible to the authenticated user",
     schema: z.object({ ...paginationSchema }),
-    async handler(args: { limit: number; offset: number }, userId: string) {
-      const where = { assigned_to: userId, deletedAt: null };
+    async handler(
+      args: { limit: number; offset: number },
+      _userId: string,
+      user: AuthzUser
+    ) {
+      const where = leadReadScopeWhere(user);
       const [data, total] = await Promise.all([
         prismadb.crm_Leads.findMany({
           where,
@@ -30,11 +38,11 @@ export const crmLeadTools = [
   },
   {
     name: "crm_get_lead",
-    description: "Get a single CRM lead by ID",
+    description: "Get a single CRM lead by ID (visible to the authenticated user)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
+    async handler(args: { id: string }, _userId: string, user: AuthzUser) {
       const lead = await prismadb.crm_Leads.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
+        where: { id: args.id, ...leadReadScopeWhere(user) },
       });
       if (!lead) notFound("Lead");
       return itemResponse(lead);
@@ -42,20 +50,27 @@ export const crmLeadTools = [
   },
   {
     name: "crm_search_leads",
-    description: "Search leads by name, company, or email (substring match)",
+    description:
+      "Search leads visible to the authenticated user by name, company, or email (substring match)",
     schema: z.object({ query: z.string().min(1), ...paginationSchema }),
     async handler(
       args: { query: string; limit: number; offset: number },
-      userId: string
+      _userId: string,
+      user: AuthzUser
     ) {
+      // The read scope itself may carry an `OR`; nest the search terms under
+      // `AND` so they intersect the scope instead of replacing it.
       const where = {
-        assigned_to: userId,
-        deletedAt: null,
-        OR: [
-          ilike("firstName", args.query),
-          ilike("lastName", args.query),
-          ilike("email", args.query),
-          ilike("company", args.query),
+        ...leadReadScopeWhere(user),
+        AND: [
+          {
+            OR: [
+              ilike("firstName", args.query),
+              ilike("lastName", args.query),
+              ilike("email", args.query),
+              ilike("company", args.query),
+            ],
+          },
         ],
       };
       const [data, total] = await Promise.all([
@@ -109,6 +124,8 @@ export const crmLeadTools = [
       company: z.string().optional(),
       phone: z.string().optional(),
       jobTitle: z.string().optional(),
+      // Reassign the owner. Use crm_list_users to resolve a person to their ID.
+      assigned_to: z.string().uuid().nullable().optional(),
     }),
     async handler(
       args: {
@@ -119,17 +136,21 @@ export const crmLeadTools = [
         company?: string;
         phone?: string;
         jobTitle?: string;
+        assigned_to?: string | null;
       },
-      userId: string
+      userId: string,
+      user: AuthzUser
     ) {
-      const existing = await prismadb.crm_Leads.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
-      });
-      if (!existing) notFound("Lead");
-      const { id, ...updateData } = args;
+      await assertScopeOrNotFound(() => assertCanWriteLead(user, args.id), "Lead");
+      if (args.assigned_to) await assertAssignableUser(args.assigned_to);
+      const { id, assigned_to, ...updateData } = args;
       const lead = await prismadb.crm_Leads.update({
         where: { id },
-        data: { ...updateData, updatedBy: userId },
+        data: {
+          ...updateData,
+          ...(assigned_to !== undefined && { assigned_to }),
+          updatedBy: userId,
+        },
       });
       return itemResponse(lead);
     },
@@ -138,11 +159,8 @@ export const crmLeadTools = [
     name: "crm_delete_lead",
     description: "Soft-delete a CRM lead by ID (sets deletedAt timestamp)",
     schema: z.object({ id: z.string().uuid() }),
-    async handler(args: { id: string }, userId: string) {
-      const existing = await prismadb.crm_Leads.findFirst({
-        where: { id: args.id, assigned_to: userId, deletedAt: null },
-      });
-      if (!existing) notFound("Lead");
+    async handler(args: { id: string }, userId: string, user: AuthzUser) {
+      await assertScopeOrNotFound(() => assertCanWriteLead(user, args.id), "Lead");
       const lead = await prismadb.crm_Leads.update({
         where: { id: args.id },
         data: softDeleteData(userId),

--- a/lib/mcp/tools/crm-opportunities.ts
+++ b/lib/mcp/tools/crm-opportunities.ts
@@ -16,6 +16,7 @@ import {
   notFound,
   softDeleteData,
   assertScopeOrNotFound,
+  assertAssignableUser,
 } from "../helpers";
 
 // Relinking an opportunity to an account/contact is a parent write: the row must
@@ -28,17 +29,6 @@ async function assertLinkableAccount(user: AuthzUser, accountId: string) {
   });
   if (!row) notFound("Account");
   await assertScopeOrNotFound(() => assertCanWriteAccount(user, accountId), "Account");
-}
-
-// Reassignment targets must be a real, active user. The server action relies on
-// the FK constraint alone; checking here keeps the failure a clean NOT_FOUND
-// instead of a Prisma error, and stops work being parked on a disabled account.
-async function assertAssignableUser(assigneeId: string) {
-  const row = await prismadb.users.findFirst({
-    where: { id: assigneeId, userStatus: "ACTIVE" },
-    select: { id: true },
-  });
-  if (!row) notFound("User");
 }
 
 async function assertLinkableContact(user: AuthzUser, contactId: string) {


### PR DESCRIPTION
Follow-up to #272, closing the last of its listed gaps: accounts, contacts and leads all carry `assigned_to` but were not reassignable over MCP.

## Reassignment

`crm_update_account`, `crm_update_contact` and `crm_update_lead` gain `assigned_to`, matching `crm_update_opportunity`:

- an id reassigns, an explicit `null` unassigns, omitting it leaves the owner alone
- the assignee must be an existing **ACTIVE** user, which keeps the failure a clean `NOT_FOUND` instead of a Prisma FK error, and stops work being parked on a deactivated account
- `assertCanWrite*` still gates the write, so reassignment rights are unchanged

`assertAssignableUser` moves from `crm-opportunities.ts` into `lib/mcp/helpers.ts` rather than being copied into all four tool modules.

Pair with `crm_list_users` (#272) to resolve a person to the ID this field needs.

## Leads were never scoped

`crm-leads.ts` was missed by #272, which covered opportunities, accounts and contacts. It still hardcoded `assigned_to: userId` on both reads and writes.

Adding `assigned_to` alone would have reproduced the exact broken combination #272 fixed — an admin could name a new owner but could not write the lead in the first place. So leads get the same treatment:

- `leadReadScopeWhere` on `crm_list_leads`, `crm_get_lead`, `crm_search_leads`
- search terms nested under `AND`, because the scope helper returns its own `OR` that a sibling `OR` would silently replace
- `assertCanWriteLead` on update/delete

This is scope beyond the stated task, but the feature does not function without it.

## Testing

`tsc --noEmit` clean. Full jest suite **1401/1401** across 233 suites.

Reassignment is covered per entity, and the read-scope suite now includes leads.

Worth flagging: the reassignment tests assert at the **schema** level as well as the handler level. Handler tests call handlers directly, which bypasses validation, and the old handlers spread unrecognised args straight into the Prisma `data` — so `assigned_to` appeared to persist even where the schema never declared it. The route validates through `tool.schema`, and a zod object strips undeclared keys, so those calls would have failed in production while the tests stayed green. Stashing the source now fails 22 tests rather than 13.

That is the same class of silent failure as the original bug in #272: a success response that did not persist the field.

## Remaining follow-up

weekly-pack `lib/nextcrm/client.ts` lines 6-7 and 121 still document the old token-owner-only behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
