### PR TITLE
fix(crm): blank-UUID + create-in-context UX; ci(e2e): pin inngest-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,17 +175,25 @@ jobs:
       - run: pnpm exec prisma migrate deploy
       - name: Seed test data (admin user for auth.setup)
         run: pnpm exec prisma db seed
+      # Pinned, not @latest: an unpinned CLI is refetched each run and a new
+      # upstream release can break CI with no warning. Pre-fetching here also
+      # keeps the registry download out of the readiness budget below — that
+      # download racing the poll was the cause of intermittent startup failures.
+      - name: Install Inngest CLI
+        run: npm install -g inngest-cli@1.38.1
       - name: Start Inngest dev server
         # Campaign submit paths await inngest.send(); without a reachable
         # event API at INNGEST_BASE_URL the server action throws and the
         # wizard never redirects.
         run: |
-          nohup npx --yes inngest-cli@latest dev --no-discovery -u http://localhost:3000/api/inngest > inngest-dev.log 2>&1 &
-          for i in $(seq 1 30); do
+          nohup inngest dev --no-discovery -u http://localhost:3000/api/inngest > inngest-dev.log 2>&1 &
+          # 60 × 2s = 120s. The binary is already installed, so this budget is
+          # purely the server's own boot time, not a network fetch.
+          for i in $(seq 1 60); do
             curl -sf http://localhost:8288 > /dev/null && exit 0
             sleep 2
           done
-          echo "inngest-cli dev failed to become ready" >&2
+          echo "inngest-cli dev failed to become ready after 120s" >&2
           cat inngest-dev.log >&2
           exit 1
       - name: Run Playwright (chromium; setup project runs as its dependency)

--- a/actions/crm/accounts/create-account.ts
+++ b/actions/crm/accounts/create-account.ts
@@ -50,6 +50,8 @@ export const createAccount = async (data: {
         createdBy: user.id,
         updatedBy: user.id,
         ...data,
+        assigned_to: data.assigned_to || user.id,
+        industry: data.industry || undefined,
         status: "Active",
       },
     });

--- a/actions/crm/contacts/create-contact.ts
+++ b/actions/crm/contacts/create-contact.ts
@@ -67,9 +67,9 @@ export const createContact = async (data: {
         v: 0,
         createdBy: userId,
         updatedBy: userId,
-        accountsIDs: assigned_account ?? undefined,
-        assigned_to: assigned_to ?? undefined,
-        contact_type_id: contact_type_id ?? undefined,
+        accountsIDs: assigned_account || undefined,
+        assigned_to: assigned_to || undefined,
+        contact_type_id: contact_type_id || undefined,
         birthday:
           birthday_day && birthday_month && birthday_year
             ? birthday_day + "/" + birthday_month + "/" + birthday_year

--- a/app/[locale]/(routes)/crm/accounts/[accountId]/page.tsx
+++ b/app/[locale]/(routes)/crm/accounts/[accountId]/page.tsx
@@ -134,7 +134,7 @@ const AccountDetailPage = async (props: AccountDetailPageProps) => {
               crmData={crmData}
               accountId={accountId}
             />
-            <LeadsView data={leads} crmData={crmData} />
+            <LeadsView data={leads} crmData={crmData} accountId={accountId} />
             <AccountProductsView
               data={accountProducts}
               accountId={accountId}

--- a/app/[locale]/(routes)/crm/accounts/components/NewAccountForm.tsx
+++ b/app/[locale]/(routes)/crm/accounts/components/NewAccountForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { z } from "zod";
+import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
@@ -27,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { UserSearchCombobox } from "@/components/ui/user-search-combobox";
 import { createAccount } from "@/actions/crm/accounts/create-account";
+import { useSession } from "@/lib/auth-client";
 
 type Props = {
   industries: any[];
@@ -36,6 +38,7 @@ type Props = {
 export function NewAccountForm({ industries, onFinish }: Props) {
   const t = useTranslations("CrmAccountForm");
   const c = useTranslations("Common");
+  const { data: session } = useSession();
 
   const formSchema = z.object({
     name: z.string().min(1, t("nameRequired")).max(100),
@@ -69,6 +72,11 @@ export function NewAccountForm({ industries, onFinish }: Props) {
     resolver: zodResolver(formSchema),
     mode: "onBlur",
   });
+
+  useEffect(() => {
+    const uid = session?.user?.id;
+    if (uid && !form.getValues("assigned_to")) form.setValue("assigned_to", uid);
+  }, [session, form]);
 
   const onSubmit = async (data: NewAccountFormValues) => {
     const result = await createAccount(data);

--- a/app/[locale]/(routes)/crm/components/ContactsView.tsx
+++ b/app/[locale]/(routes)/crm/components/ContactsView.tsx
@@ -35,7 +35,7 @@ interface ContactsViewProps {
   accountId?: string;
 }
 
-const ContactsView = ({ data, crmData }: ContactsViewProps) => {
+const ContactsView = ({ data, crmData, accountId }: ContactsViewProps) => {
   const [open, setOpen] = useState(false);
   const t = useTranslations("CrmPage");
 
@@ -67,6 +67,7 @@ const ContactsView = ({ data, crmData }: ContactsViewProps) => {
                 <div className="mt-6 space-y-4">
                   <NewContactForm
                     accounts={accounts}
+                    accountId={accountId}
                     onFinish={() => setOpen(false)}
                   />
                 </div>

--- a/app/[locale]/(routes)/crm/components/LeadsView.tsx
+++ b/app/[locale]/(routes)/crm/components/LeadsView.tsx
@@ -31,9 +31,10 @@ type CrmData = Awaited<ReturnType<typeof getAllCrmData>>;
 interface LeadsViewProps {
   data: any[];
   crmData: CrmData;
+  accountId?: string;
 }
 
-const LeadsView = ({ data, crmData }: LeadsViewProps) => {
+const LeadsView = ({ data, crmData, accountId }: LeadsViewProps) => {
   const { accounts, leadSources, leadStatuses, leadTypes } = crmData;
   const [open, setOpen] = useState(false);
   const t = useTranslations("CrmPage");
@@ -65,6 +66,7 @@ const LeadsView = ({ data, crmData }: LeadsViewProps) => {
                     leadSources={leadSources}
                     leadStatuses={leadStatuses}
                     leadTypes={leadTypes}
+                    accountId={accountId}
                     onFinish={() => setOpen(false)}
                   />
                 </div>

--- a/app/[locale]/(routes)/crm/contacts/components/NewContactForm.tsx
+++ b/app/[locale]/(routes)/crm/contacts/components/NewContactForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { z } from "zod";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
@@ -27,6 +28,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { UserSearchCombobox } from "@/components/ui/user-search-combobox";
 import { createContact } from "@/actions/crm/contacts/create-contact";
+import { useSession } from "@/lib/auth-client";
 
 type AccountOption = {
   id: string;
@@ -35,15 +37,18 @@ type AccountOption = {
 
 type NewContactFormProps = {
   accounts: AccountOption[];
+  accountId?: string;
   onFinish: () => void;
 };
 
 export function NewContactForm({
   accounts,
+  accountId,
   onFinish,
 }: NewContactFormProps) {
   const t = useTranslations("CrmContactForm");
   const c = useTranslations("Common");
+  const { data: session } = useSession();
 
   const formSchema = z.object({
     birthday_year: z.string().optional(),
@@ -88,7 +93,7 @@ export function NewContactForm({
       status: false,
       type: "",
       assigned_to: "",
-      assigned_account: "",
+      assigned_account: accountId ?? "",
       social_twitter: "",
       social_facebook: "",
       social_linkedin: "",
@@ -101,6 +106,11 @@ export function NewContactForm({
     },
   });
 
+  useEffect(() => {
+    const uid = session?.user?.id;
+    if (uid && !form.getValues("assigned_to")) form.setValue("assigned_to", uid);
+  }, [session, form]);
+
   const contactType = [
     { name: t("customer"), id: "Customer" },
     { name: t("partner"), id: "Partner" },
@@ -108,8 +118,13 @@ export function NewContactForm({
   ];
 
   const onSubmit = async (data: NewAccountFormValues) => {
-    const { type, ...rest } = data;
-    const result = await createContact({ ...rest, contact_type_id: type || undefined });
+    const { type, assigned_to, assigned_account, ...rest } = data;
+    const result = await createContact({
+      ...rest,
+      assigned_to: assigned_to || undefined,
+      assigned_account: assigned_account || undefined,
+      contact_type_id: type || undefined,
+    });
     if (result?.error) {
       form.setError("root.serverError", { message: result.error });
     } else {
@@ -370,6 +385,7 @@ export function NewContactForm({
                       <Select
                         onValueChange={field.onChange}
                         defaultValue={field.value}
+                        disabled={!!accountId}
                       >
                         <FormControl>
                           <SelectTrigger>

--- a/app/[locale]/(routes)/crm/contracts/_forms/create-contract.tsx
+++ b/app/[locale]/(routes)/crm/contracts/_forms/create-contract.tsx
@@ -2,7 +2,7 @@
 
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
-import { ElementRef, useRef, useState } from "react";
+import { ElementRef, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 
@@ -19,6 +19,7 @@ import { FormSubmit } from "@/components/form/form-submit";
 import { FormDatePicker } from "@/components/form/form-datepicker";
 import { FormTextarea } from "@/components/form/form-textarea";
 import { FormSelect } from "@/components/form/from-select";
+import { useSession } from "@/lib/auth-client";
 
 const CreateContractForm = ({
   accounts,
@@ -32,8 +33,14 @@ const CreateContractForm = ({
   const router = useRouter();
   const closeRef = useRef<ElementRef<"button">>(null);
   const [assignedTo, setAssignedTo] = useState<string>("");
+  const { data: session } = useSession();
   const t = useTranslations("CrmContractForm");
   const c = useTranslations("Common");
+
+  useEffect(() => {
+    const uid = session?.user?.id;
+    if (uid) setAssignedTo((prev) => prev || uid);
+  }, [session]);
 
   //console.log(accountId, "accountId");
 
@@ -143,6 +150,7 @@ const CreateContractForm = ({
           data={accounts}
           errors={fieldErrors}
           defaultValue={accountId}
+          disabled={!!accountId}
         />
         <div className="space-y-1">
           <label className="text-sm font-medium">{c("assignedTo")}</label>

--- a/app/[locale]/(routes)/crm/leads/components/NewLeadForm.tsx
+++ b/app/[locale]/(routes)/crm/leads/components/NewLeadForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { z } from "zod";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
@@ -26,6 +27,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { UserSearchCombobox } from "@/components/ui/user-search-combobox";
 import { createLead } from "@/actions/crm/leads/create-lead";
+import { useSession } from "@/lib/auth-client";
 
 //TODO: fix all the types
 type ConfigItem = { id: string; name: string };
@@ -35,12 +37,14 @@ type NewTaskFormProps = {
   leadSources: ConfigItem[];
   leadStatuses: ConfigItem[];
   leadTypes: ConfigItem[];
+  accountId?: string;
   onFinish?: () => void;
 };
 
-export function NewLeadForm({ accounts, leadSources, leadStatuses, leadTypes, onFinish }: NewTaskFormProps) {
+export function NewLeadForm({ accounts, leadSources, leadStatuses, leadTypes, accountId, onFinish }: NewTaskFormProps) {
   const t = useTranslations("CrmLeadForm");
   const c = useTranslations("Common");
+  const { data: session } = useSession();
 
   const formSchema = z.object({
     first_name: z.string().optional(),
@@ -78,9 +82,14 @@ export function NewLeadForm({ accounts, leadSources, leadStatuses, leadTypes, on
       refered_by: "",
       campaign: "",
       assigned_to: "",
-      accountIDs: "",
+      accountIDs: accountId ?? "",
     },
   });
+
+  useEffect(() => {
+    const uid = session?.user?.id;
+    if (uid && !form.getValues("assigned_to")) form.setValue("assigned_to", uid);
+  }, [session, form]);
 
   const onSubmit = async (data: NewLeadFormValues) => {
     const result = await createLead(data);
@@ -346,6 +355,7 @@ export function NewLeadForm({ accounts, leadSources, leadStatuses, leadTypes, on
                   <Select
                     onValueChange={field.onChange}
                     defaultValue={field.value}
+                    disabled={!!accountId}
                   >
                     <FormControl>
                       <SelectTrigger>

--- a/app/[locale]/(routes)/crm/opportunities/components/NewOpportunityForm.tsx
+++ b/app/[locale]/(routes)/crm/opportunities/components/NewOpportunityForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { z } from "zod";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { format } from "date-fns";
 import { useForm } from "react-hook-form";
 import { CalendarIcon } from "lucide-react";
@@ -44,6 +44,7 @@ import {
   crm_campaigns,
 } from "@prisma/client";
 import { createOpportunity } from "@/actions/crm/opportunities/create-opportunity";
+import { useSession } from "@/lib/auth-client";
 
 //TODO: fix all the types
 type NewTaskFormProps = {
@@ -71,6 +72,7 @@ export function NewOpportunityForm({
 }: NewTaskFormProps) {
   const t = useTranslations("CrmOpportunityForm");
   const c = useTranslations("Common");
+  const { data: session } = useSession();
 
   const [searchAccountValue, setSearchAccountValue] = useState<string>("");
   const [searchContactValue, setSearchContactValue] = useState<string>("");
@@ -137,6 +139,11 @@ export function NewOpportunityForm({
       name: "",
     },
   });
+
+  useEffect(() => {
+    const uid = session?.user?.id;
+    if (uid && !form.getValues("assigned_to")) form.setValue("assigned_to", uid);
+  }, [session, form]);
 
   const onSubmit = async (data: NewAccountFormValues) => {
     const result = await createOpportunity(data);
@@ -445,11 +452,12 @@ export function NewOpportunityForm({
                   control={form.control}
                   name="account"
                   render={({ field }) => (
-                    <FormItem hidden={accountId ? true : false}>
+                    <FormItem>
                       <FormLabel>{t("assignedAccount")}</FormLabel>
                       <Select
                         onValueChange={field.onChange}
                         defaultValue={field.value}
+                        disabled={!!accountId}
                       >
                         <FormControl>
                           <SelectTrigger>

--- a/components/form/from-select.tsx
+++ b/components/form/from-select.tsx
@@ -83,6 +83,7 @@ export const FormSelect = forwardRef<HTMLInputElement, FormInputProps>(
           <Select
             onValueChange={(value: any) => setValue(value)}
             value={value}
+            disabled={pending || disabled}
           >
             <SelectTrigger className="w-full">
               <SelectValue placeholder={placeholder} />


### PR DESCRIPTION
Bundles two independent changes on `dev`.

---

## 1. fix(crm): normalize blank UUID inputs and auto-fill account/assignee on create

Fixes a Prisma `P2007` error when creating a contact and improves the "create from within an account" UX across the CRM.

### Bug fix
Creating a contact failed with `invalid input syntax for type uuid: ""` — optional select fields (`assigned_to`, `assigned_account`, `contact_type_id`) submitted empty strings straight into UUID columns. The `?? undefined` guard didn't catch `""`. Now normalized to `undefined` (stored as `null`) at both the server action and the create form.

### UX improvements
- **Account auto-select + lock:** When creating from an account page, the account is now pre-selected and shown locked (visible, disabled) instead of forcing a manual pick. Applied to **contacts, opportunities, contracts, and leads**. Leads were newly wired through `LeadsView` → `NewLeadForm` (the `accountId` was previously dropped).
- **Assignee default:** `assigned_to` now defaults to the creating user (still editable, so delegation works) across the **five create forms** — contacts, opportunities, leads, accounts, contracts — via the client session.
- **Shared component:** `FormSelect` now forwards `disabled` to its visible `<Select>` (previously only disabled the hidden input), enabling the contract account lock.

### Out of scope (flagged, not changed)
- Invoices create flow.
- Latent same-pattern `""`→UUID normalization gap in `update-lead.ts`.

---

## 2. ci(e2e): pin inngest-cli and widen the startup readiness budget

The e2e job started Inngest with `npx --yes inngest-cli@latest`, refetching the CLI on every run inside the 60s readiness poll. A slow fetch blew the budget and killed the job before Playwright ran (with no diagnostic; a re-run of the same SHA passed). `@latest` also risked a breaking upstream release landing in CI unannounced.

Pin to `inngest-cli@1.38.1` in a dedicated install step so the download no longer races the poll. The readiness budget is now purely the server's boot time, widened to 120s (60 × 2s).

---

## Testing
- `tsc --noEmit` passes with no new errors.
- Remaining IDE diagnostics on touched CRM files (zod `.email()`/`.url()` deprecations, `onFinish` serializable-prop warnings) are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)