### PR TITLE
docs(mcp): sync SKILL.md with role-aware scoping and reassignment tools

### DIFF
--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -64,7 +64,7 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 - **crm_get_account** — Get a single CRM account by ID
 - **crm_search_accounts** — Search accounts by name or website (substring match)
 - **crm_create_account** — Create a new CRM account
-- **crm_update_account** — Update an existing CRM account by ID
+- **crm_update_account** — Update an existing CRM account by ID (accepts `assigned_to` to reassign the owner)
 - **crm_delete_account** — Soft-delete a CRM account by ID (sets deletedAt timestamp)
 
 ### Contacts (6 tools)
@@ -73,7 +73,7 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 - **crm_get_contact** — Get a single CRM contact by ID
 - **crm_search_contacts** — Search contacts by name, email, or phone (substring match)
 - **crm_create_contact** — Create a new CRM contact
-- **crm_update_contact** — Update an existing CRM contact by ID
+- **crm_update_contact** — Update an existing CRM contact by ID (accepts `assigned_to` to reassign, `account` to link/unlink a parent account)
 - **crm_delete_contact** — Soft-delete a CRM contact by ID (sets deletedAt timestamp)
 
 ### Leads (6 tools)
@@ -82,7 +82,7 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 - **crm_get_lead** — Get a single CRM lead by ID
 - **crm_search_leads** — Search leads by name, company, or email (substring match)
 - **crm_create_lead** — Create a new CRM lead
-- **crm_update_lead** — Update an existing CRM lead by ID
+- **crm_update_lead** — Update an existing CRM lead by ID (accepts `assigned_to` to reassign the owner)
 - **crm_delete_lead** — Soft-delete a CRM lead by ID (sets deletedAt timestamp)
 
 ### Opportunities (6 tools)
@@ -91,7 +91,7 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 - **crm_get_opportunity** — Get a single CRM opportunity by ID
 - **crm_search_opportunities** — Search opportunities by name or description (substring match)
 - **crm_create_opportunity** — Create a new CRM opportunity
-- **crm_update_opportunity** — Update an existing CRM opportunity by ID
+- **crm_update_opportunity** — Update an existing CRM opportunity by ID (accepts `assigned_to` to reassign, `account`/`contact` to link/unlink)
 - **crm_delete_opportunity** — Soft-delete a CRM opportunity by ID
 
 ### Targets (6 tools)
@@ -104,6 +104,8 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 - **crm_delete_target** — Soft-delete a CRM target by ID (sets deletedAt timestamp)
 
 ### Products (5 tools)
+
+Writes (create/update/delete) require a manager or admin role; reads are open to all roles.
 
 - **crm_list_products** — List CRM products (org-wide catalog)
 - **crm_get_product** — Get a single CRM product by ID
@@ -159,7 +161,11 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 
 - **crm_list_email_accounts** — List the authenticated user's connected email accounts
 
-### Campaigns (18 tools)
+### Users (1 tool)
+
+- **crm_list_users** — List NextCRM users to resolve a person to the user ID that `assigned_to` needs. Returns active users by default; managers and admins additionally see email, role, status, and last login
+
+### Campaigns (19 tools)
 
 - **campaigns_list** — List campaigns (org-wide)
 - **campaigns_get** — Get a campaign by ID with steps and stats summary
@@ -237,6 +243,13 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 2. `crm_enrich_target_bulk` — enrich up to 100 targets at once
 3. `crm_get_target` — check enrichment results
 
+### Reassign records to another user
+1. `crm_list_users` — resolve the person's name to a user ID (`query` does a substring match on name)
+2. `crm_update_account` / `crm_update_contact` / `crm_update_lead` / `crm_update_opportunity` — set `assigned_to` to that ID
+3. Pass `assigned_to: null` instead to unassign; omit it entirely to leave the current owner alone
+
+A member token can only reassign records it already owns, and the target must be an ACTIVE user — otherwise the update returns `NOT_FOUND`.
+
 ### Project management
 1. `projects_create_board` — create a project board
 2. `projects_create_section` — add columns (To Do, In Progress, Done)
@@ -249,5 +262,7 @@ All tools require a valid Bearer token. Tokens are generated from the Developer 
 - All list operations support pagination (cursor-based)
 - Search operations use substring matching
 - Delete operations are soft-deletes (set `deletedAt`, recoverable via admin audit log)
-- Data is scoped to the authenticated user where applicable
+- Reads are scoped by the token owner's role, matching the web UI: admin and manager tokens see all non-deleted records, member tokens see only their own
+- Writes are gated per-record. A denied write returns `NOT_FOUND` rather than `FORBIDDEN`, so a failure never confirms a record exists
+- `assigned_to` accepts an active user ID (reassign) or explicit `null` (unassign); omitting it leaves the owner untouched. Use `crm_list_users` to resolve the ID
 - Enrichment tools require API keys (OpenAI + Firecrawl) configured at system or user level


### PR DESCRIPTION
`public/SKILL.md` had not been touched since the MCP server landed (`b3a57b87`, plus a basePath fix). Three PRs since — #258, #272, #274 — changed both the tool list and the scoping contract, so the skill was describing a surface that no longer exists.

## What was wrong

| Issue | Detail |
|---|---|
| Missing tool | `crm_list_users` (#272) was undocumented — it is the only way to resolve a person to the ID `assigned_to` needs, so the reassignment feature was undiscoverable from the docs alone |
| Wrong scoping claim | "Data is scoped to the authenticated user where applicable" described the exact behavior #272 fixed **as a bug**: admin and manager tokens were seeing only their own records |
| Missing capability | `assigned_to` reassignment on account/contact/lead/opportunity updates (#272, #274) |
| Missing capability | FK linking — `account`/`contact` on `crm_update_opportunity`, `account` on `crm_update_contact` (#272) |
| Undocumented RBAC | Product writes are manager/admin only (GHSA-wv63-cq38-qg58, #258) |
| Wrong count | Campaigns header said 18; the list beneath it had 19 |

The scoping line was the one worth catching. An agent reading it would conclude an admin token could not see org-wide data and would work around a restriction that is not there.

## What changed

Documentation only — no source, no schema, no behavior. Every claim was checked against the tool names registered in `lib/mcp/tools/` rather than against the PR descriptions.

Also added a **Reassign records to another user** recipe to Common Workflows: the `crm_list_users` → `assigned_to` sequence, the three-way semantics (ID reassigns / explicit `null` unassigns / omitted leaves the owner alone), and the two failure modes that both surface as `NOT_FOUND` — a member reassigning a record it does not own, and naming a non-ACTIVE user.

## Verified unchanged

Transport and auth setup, the `nxtc__` token prefix, and every other tool name and section count still match `lib/mcp/tools/` exactly.

## Follow-up, not in this PR

Both #272 and #274 flag it and it is still open: `weekly-pack`'s `lib/nextcrm/client.ts` lines 6-7 and 121 document the old token-owner-only behavior and are now wrong. Different repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)