### PR TITLE
fix(security): resolve all open Dependabot and CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 # Inert dummy env shared by every job. Module-level code (OpenAI client in
 # /api/inngest, better-auth, minio, …) reads these at import, so typecheck,
 # tests and next build all need them present. Nothing here is a real

--- a/app/api/crm/contacts/create-from-remote/route.ts
+++ b/app/api/crm/contacts/create-from-remote/route.ts
@@ -18,8 +18,6 @@ export async function POST(req: Request) {
 
   const body = await req.json();
 
-  console.log(body, "body");
-
   const { name, surname, email, phone, company, message, tag } = body;
   if (!name || !surname || !email || !phone || !company || !message || !tag) {
     return NextResponse.json(

--- a/app/api/crm/contacts/enrich/route.ts
+++ b/app/api/crm/contacts/enrich/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  const sessionId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+  const sessionId = crypto.randomUUID();
   const abortController = new AbortController();
   activeSessions.set(sessionId, { controller: abortController, enrichmentId: enrichmentRecord.id });
 

--- a/app/api/crm/targets/enrich/route.ts
+++ b/app/api/crm/targets/enrich/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  const sessionId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+  const sessionId = crypto.randomUUID();
   const abortController = new AbortController();
   activeSessions.set(sessionId, { controller: abortController, enrichmentId: enrichmentRecord.id });
 

--- a/lib/enrichment/agent-architecture/orchestrator.ts
+++ b/lib/enrichment/agent-architecture/orchestrator.ts
@@ -1359,9 +1359,14 @@ export class AgentOrchestrator {
         if (enrichment.sourceContext && Array.isArray(enrichment.sourceContext)) {
           enrichment.sourceContext = enrichment.sourceContext.filter(ctx => {
             if (!ctx.url) return false;
-            
+
+            let ctxHost = '';
+            try {
+              ctxHost = new URL(ctx.url.includes('://') ? ctx.url : `https://${ctx.url}`).hostname;
+            } catch { /* not a parseable URL */ }
+
             // If it claims to be a GitHub URL, verify it was in our search results
-            if (ctx.url.includes('github.com')) {
+            if (ctxHost === 'github.com' || ctxHost.endsWith('.github.com')) {
               const isValidGithub = githubResults.some(r => r.url === ctx.url);
               if (!isValidGithub) {
                 console.log(`[AGENT-TECH-STACK] Removing hallucinated GitHub URL: ${ctx.url}`);
@@ -1781,9 +1786,14 @@ export class AgentOrchestrator {
       if (src.includes('webflow')) technologies.add('Webflow');
       if (src.includes('stripe')) technologies.add('Stripe');
       if (src.includes('cloudflare')) technologies.add('Cloudflare');
-      if (src.includes('cdn.jsdelivr.net')) technologies.add('jsDelivr CDN');
-      if (src.includes('unpkg.com')) technologies.add('unpkg CDN');
-      if (src.includes('cdnjs.cloudflare.com')) technologies.add('cdnjs');
+      let srcHost = '';
+      try {
+        // Base handles relative and scheme-relative srcs; those resolve to the placeholder host
+        srcHost = new URL(src, 'https://placeholder.invalid').hostname;
+      } catch { /* malformed src */ }
+      if (srcHost === 'cdn.jsdelivr.net') technologies.add('jsDelivr CDN');
+      if (srcHost === 'unpkg.com') technologies.add('unpkg CDN');
+      if (srcHost === 'cdnjs.cloudflare.com') technologies.add('cdnjs');
     }
     
     // Check for CSS frameworks in link tags

--- a/lib/enrichment/services/openai.ts
+++ b/lib/enrichment/services/openai.ts
@@ -203,10 +203,9 @@ If looking for "Example Corp" but finding "Microsoft has 200,000 employees":
 
 **CRITICAL**: Use domain names and context to verify if it's the same company. Be smart about name variations.
 
-**TARGET ENTITY - IMPORTANT**: You are ONLY extracting information about:
-${contextInfo}
+**TARGET ENTITY - IMPORTANT**: You are ONLY extracting information about the TARGET ENTITY described under "TARGET ENTITY:" at the start of the user message.
 
-**CRITICAL**: 
+**CRITICAL**:
 - Only extract information about the TARGET ENTITY listed above
 - Company name variations are OK (e.g., "Seek AI" vs "Seek", "OpenAI" vs "Open AI")
 - Look for domain matches (e.g., if searching for "Seek AI" and you see content from seek.ai, that's likely the same company)
@@ -218,8 +217,7 @@ ${contextInfo}
 - Always capitalize industry names properly (e.g., "Technology", "Healthcare", "E-commerce", "Finance")
 - If you find information about CLEARLY DIFFERENT companies, IGNORE IT
 
-Fields to extract for the TARGET ENTITY ONLY:
-${fieldDescriptions}
+Extract only the fields listed under "FIELDS TO EXTRACT:" in the user message, for the TARGET ENTITY ONLY.
 
 ADDITIONAL GUIDELINES:
 1. Employee Count: Must be explicitly stated. Look for phrases like "X employees", "team of X", "X people". If not found, return null.
@@ -246,7 +244,7 @@ DOMAIN PARKING/SALE PAGES:
           },
           {
             role: 'user',
-            content: trimmedContent,
+            content: `TARGET ENTITY:\n${contextInfo}\n\nFIELDS TO EXTRACT:\n${fieldDescriptions}\n\nCONTENT:\n${trimmedContent}`,
           },
         ],
         response_format: zodResponseFormat(schema, 'enrichment_data'),
@@ -431,13 +429,9 @@ DOMAIN PARKING/SALE PAGES:
   - WRONG: "Contact Us | Acme Corp" (this is just a page title)
   - RIGHT: "Our headquarters is located in San Francisco, CA"
 
-**CRITICAL**: Do NOT use page titles, headers, or navigation text as exact_text. The exact_text must be from the actual content that contains the value.${customInstructions}
+**CRITICAL**: Do NOT use page titles, headers, or navigation text as exact_text. The exact_text must be from the actual content that contains the value.
 
-Context about the entity:
-${contextInfo}
-
-Fields to extract:
-${fieldDescriptions}
+Context about the entity is provided under "TARGET ENTITY:" and the fields to extract under "FIELDS TO EXTRACT:" at the start of the user message.
 
 Example of what the content looks like:
 """
@@ -488,7 +482,7 @@ REMEMBER: Extract exact_text from the "=== ACTUAL CONTENT BELOW ===" section, NO
           },
           {
             role: 'user',
-            content: trimmedContent,
+            content: `TARGET ENTITY:\n${contextInfo}\n\nFIELDS TO EXTRACT:\n${fieldDescriptions}${customInstructions}\n\nCONTENT:\n${trimmedContent}`,
           },
         ],
         response_format: zodResponseFormat(schema, 'corroborated_data'),
@@ -576,7 +570,7 @@ REMEMBER: Extract exact_text from the "=== ACTUAL CONTENT BELOW ===" section, NO
             );
             
             if (looksLikeTitle) {
-              console.log(`[VALIDATION] Filtering out title-like evidence for ${field.name}:`, e.exact_text);
+              console.log('[VALIDATION] Filtering out title-like evidence for field:', field.name, e.exact_text);
               return false;
             }
             
@@ -606,14 +600,14 @@ REMEMBER: Extract exact_text from the "=== ACTUAL CONTENT BELOW ===" section, NO
             
             const looksLikeHallucination = hallucationPatterns.some(pattern => pattern.test(e.exact_text));
             if (looksLikeHallucination) {
-              console.log(`[VALIDATION] Detected potential hallucination pattern in ${field.name}:`, e.exact_text);
+              console.log('[VALIDATION] Detected potential hallucination pattern in field:', field.name, e.exact_text);
               return false;
             }
             
             // Validate that the snippet actually contains the value
             const isValid = validateSnippetContainsValue(e.exact_text, e.value as string | number | boolean | string[]);
             if (!isValid) {
-              console.log(`[VALIDATION] Filtering out evidence for ${field.name} - snippet doesn't contain value:`, {
+              console.log("[VALIDATION] Filtering out evidence - snippet doesn't contain value:", field.name, {
                 value: e.value,
                 snippet: e.exact_text.substring(0, 100) + '...'
               });
@@ -647,7 +641,7 @@ REMEMBER: Extract exact_text from the "=== ACTUAL CONTENT BELOW ===" section, NO
             
             // Debug log what we're keeping
             if (validSourceContext.length > 0) {
-              console.log(`[SOURCE-CONTEXT] For ${field.name}, keeping ${validSourceContext.length} sources:`,
+              console.log('[SOURCE-CONTEXT] Keeping sources for field:', field.name, validSourceContext.length,
                 validSourceContext.map((sc: { url: string; snippet: string }) => ({ url: sc.url, snippet: sc.snippet.substring(0, 50) + '...' }))
               );
 
@@ -702,7 +696,11 @@ REMEMBER: Extract exact_text from the "=== ACTUAL CONTENT BELOW ===" section, NO
               // Validate GitHub URLs in evidence
               if (enrichmentResult.corroboration) {
                 enrichmentResult.corroboration.evidence = enrichmentResult.corroboration.evidence.filter((e) => {
-                if (e.source_url && e.source_url.includes('github.com')) {
+                let sourceHost = '';
+                try {
+                  sourceHost = new URL(e.source_url && e.source_url.includes('://') ? e.source_url : `https://${e.source_url}`).hostname;
+                } catch { /* not a parseable URL */ }
+                if (e.source_url && (sourceHost === 'github.com' || sourceHost.endsWith('.github.com'))) {
                   // Check if this GitHub URL was provided in the context
                   const validGithubUrls = Array.isArray(context.validGithubUrls) ? context.validGithubUrls as string[] : [];
                   const isValid = validGithubUrls.includes(e.source_url);

--- a/lib/enrichment/strategies/enrichment-strategy.ts
+++ b/lib/enrichment/strategies/enrichment-strategy.ts
@@ -9,6 +9,15 @@ export interface EnrichmentStrategyOptions {
   openaiApiKey: string;
 }
 
+const PERSONAL_EMAIL_DOMAINS = ['gmail.com', 'aol.com', 'icloud.com', 'protonmail.com'];
+// Providers matched by first domain label so country TLDs count too (yahoo.co.uk, …)
+const PERSONAL_EMAIL_PROVIDERS = ['yahoo', 'hotmail', 'outlook'];
+
+function isPersonalEmailDomain(domain: string): boolean {
+  const d = domain.toLowerCase();
+  return PERSONAL_EMAIL_DOMAINS.includes(d) || PERSONAL_EMAIL_PROVIDERS.includes(d.split('.')[0]);
+}
+
 export class EnrichmentStrategy {
   private firecrawl: FirecrawlService;
   private openai: OpenAIService;
@@ -43,15 +52,7 @@ export class EnrichmentStrategy {
         console.log(`[EnrichmentStrategy] Parsed domain: ${emailDomain}, Generated ${searchQueries.length} search queries`);
         
         // Check if it's a personal email domain
-        isPersonalEmail = !!(emailDomain && (
-          emailDomain.includes('gmail.com') || 
-          emailDomain.includes('yahoo.') || 
-          emailDomain.includes('hotmail.') || 
-          emailDomain.includes('outlook.') ||
-          emailDomain.includes('aol.com') ||
-          emailDomain.includes('icloud.com') ||
-          emailDomain.includes('protonmail.com')
-        ));
+        isPersonalEmail = !!(emailDomain && isPersonalEmailDomain(emailDomain));
         
         // Add parsed info to context
         if (parsedEmail.companyName) {
@@ -68,7 +69,7 @@ export class EnrichmentStrategy {
           f.name === 'company_website'
         );
         
-        if (websiteField && emailDomain && !emailDomain.includes('gmail.com') && !emailDomain.includes('yahoo.') && !emailDomain.includes('hotmail.') && !emailDomain.includes('outlook.')) {
+        if (websiteField && emailDomain && !isPersonalEmail) {
           results[websiteField.name] = {
             field: websiteField.name,
             value: `https://${emailDomain}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,10 @@ overrides:
   axios@>=1.15.2 <1.18.0: ^1.18.0
   axios@>=1.7.0 <1.18.0: ^1.18.0
   body-parser@>=2.0.0 <2.3.0: ^2.3.0
-  brace-expansion@<1.1.16: ^1.1.16
-  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
+  brace-expansion@<1.1.17: ^1.1.17
+  brace-expansion@>=2.0.0 <2.1.3: ^2.1.3
+  brace-expansion@>=3.0.0 <5.0.8: ^5.0.8
+  valibot@<=1.4.1: ^1.4.2
   esbuild@>=0.27.3 <0.28.1: ^0.28.1
   fast-uri@>=3.0.0 <3.1.3: ^3.1.3
   fast-uri@>=3.0.0 <=3.1.3: ^3.1.4
@@ -4945,15 +4947,15 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8998,8 +9000,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -12137,7 +12139,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -14535,16 +14537,16 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.2
 
@@ -17189,19 +17191,19 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -19164,7 +19166,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,8 +55,10 @@ overrides:
   axios@>=1.15.2 <1.18.0: ^1.18.0
   axios@>=1.7.0 <1.18.0: ^1.18.0
   body-parser@>=2.0.0 <2.3.0: ^2.3.0
-  brace-expansion@<1.1.16: ^1.1.16
-  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
+  brace-expansion@<1.1.17: ^1.1.17
+  brace-expansion@>=2.0.0 <2.1.3: ^2.1.3
+  brace-expansion@>=3.0.0 <5.0.8: ^5.0.8
+  valibot@<=1.4.1: ^1.4.2
   esbuild@>=0.27.3 <0.28.1: ^0.28.1
   fast-uri@>=3.0.0 <3.1.3: ^3.1.3
   fast-uri@>=3.0.0 <=3.1.3: ^3.1.4
@@ -119,7 +121,6 @@ minimumReleaseAgeExclude:
   - ws@7.5.11 || 8.21.0
   - '@babel/core@7.29.1'
   - axios@1.18.0
-  - brace-expansion@1.1.16 || 5.0.7
   - body-parser@2.3.0
   - '@hono/node-server@2.0.5'
   - '@opentelemetry/propagator-jaeger@2.9.0'


### PR DESCRIPTION
Closes all 27 open GitHub Security alerts (4 Dependabot, 23 CodeQL).

## Dependabot (4 alerts)
- `brace-expansion` bumped to 1.1.18 / 2.1.4 / 5.0.9 across all major lines via `pnpm-workspace.yaml` overrides (GHSA-mh99-v99m-4gvg, DoS)
- `valibot` bumped to 1.4.2 (GHSA-5qjj-4xww-7phc)

## CodeQL (23 alerts)
- **js/system-prompt-injection (2)** — `lib/enrichment/services/openai.ts`: data-derived `contextInfo`/`fieldDescriptions`/`customInstructions` moved out of the system prompts into labeled sections of the user message; system prompts are now fully static.
- **js/incomplete-url-substring-sanitization (10)** — replaced `includes('host')` substring checks with parsed-hostname comparisons: personal-email-domain classification in `enrichment-strategy.ts` (shared helper), GitHub source-URL validation in `openai.ts` and `orchestrator.ts`, CDN detection in `orchestrator.ts`.
- **js/tainted-format-string (5)** — constant `console.log` format strings with tainted values passed as arguments; removed the raw request-body log in `create-from-remote` (also logged PII).
- **js/insecure-randomness (2)** — enrichment session IDs now use `crypto.randomUUID()` instead of `Date.now()`+`Math.random()`.
- **actions/missing-workflow-permissions (4)** — top-level `permissions: contents: read` in `ci.yml` (no job uses the token for writes).

Verified locally: `tsc --noEmit` clean, full jest suite 1409/1409 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)